### PR TITLE
Fault handling and recovery improved

### DIFF
--- a/core/mbed/uvisor-lib/secure_access.h
+++ b/core/mbed/uvisor-lib/secure_access.h
@@ -17,6 +17,8 @@
 #ifndef __SECURE_ACCESS_H__
 #define __SECURE_ACCESS_H__
 
+#include "uvisor-lib/vmpu_exports.h"
+
 /* the switch statement will be optimised away since the compiler already knows
  * the sizeof(type) */
 #define ADDRESS_WRITE(type, addr, val) \
@@ -58,6 +60,7 @@ static inline __attribute__((always_inline)) void uvisor_write32(uint32_t volati
     register uint32_t r1 __asm__("r1") = val;
     __asm__ volatile(
         "str %[v], [%[a]]\n"
+        UVISOR_NOP_GROUP
         :: [a] "r" (r0),
            [v] "r" (r1)
     );
@@ -69,6 +72,7 @@ static inline __attribute__((always_inline)) void uvisor_write16(uint16_t volati
     register uint16_t r1 __asm__("r1") = val;
     __asm__ volatile(
         "strh %[v], [%[a]]\n"
+        UVISOR_NOP_GROUP
         :: [a] "r" (r0),
            [v] "r" (r1)
     );
@@ -80,6 +84,7 @@ static inline __attribute__((always_inline)) void uvisor_write8(uint8_t volatile
     register uint8_t  r1 __asm__("r1") = val;
     __asm__ volatile(
         "strb %[v], [%[a]]\n"
+        UVISOR_NOP_GROUP
         :: [a] "r" (r0),
            [v] "r" (r1)
     );

--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -80,7 +80,7 @@ extern void vmpu_switch(uint8_t src_box, uint8_t dst_box);
 extern void vmpu_load_box(uint8_t box_id);
 extern void vmpu_add_peripheral_map(uint8_t box_id, uint32_t addr, uint32_t length, uint8_t shared);
 
-extern int vmpu_unpriv_access(uint32_t pc, uint32_t sp);
+extern int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp);
 
 extern void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size);
 extern uint32_t vmpu_acl_static_region(uint8_t region, void* base, uint32_t size, UvisorBoxAcl acl);

--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -106,6 +106,14 @@
 #define UVISOR_BOX_STACK_SIZE UVISOR_MIN_STACK_SIZE
 #endif/*UVISOR_BOX_STACK*/
 
+/* NOPs added for write buffering synchronization (2 are for dsb. 16bits) */
+#define UVISOR_NOP_CNT   (2 + 3)
+#define UVISOR_NOP_GROUP \
+   "dsb\n" \
+   "nop\n" \
+   "nop\n" \
+   "nop\n"
+
 typedef uint32_t UvisorBoxAcl;
 
 typedef struct

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -209,7 +209,7 @@ static void vmpu_load_boxes(void)
 }
 
 /* FIXME: perform ACL checks to close security hole */
-int vmpu_unpriv_access(uint32_t pc, uint32_t sp)
+int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp)
 {
     uint16_t opcode;
     uint32_t r0, r1;
@@ -220,7 +220,7 @@ int vmpu_unpriv_access(uint32_t pc, uint32_t sp)
     if(!VMPU_FLASH_ADDR(pc))
        HALT_ERROR(NOT_ALLOWED, "This is not the PC (0x%08X) your were searching for", pc);
 
-    /* if the bus fault is imprecise seek back for ldrX/strX opcode */
+    /* if the bus fault is imprecise we will seek back for ldrX/strX opcode */
     if(SCB->CFSR & (1 << 10))
         cnt_max = UVISOR_NOP_CNT;
     else
@@ -314,7 +314,7 @@ int vmpu_unpriv_access(uint32_t pc, uint32_t sp)
         return -1;
 
     /* otherwise execution continues from the instruction following the fault */
-    /* note: we assume the instruction is 16 bits wide and skip the NOPs */
+    /* note: we assume the instruction is 16 bits wide and skip possible NOPs */
     vmpu_unpriv_uint32_write(sp + (6 << 2), pc + ((UVISOR_NOP_CNT + 2 - cnt) << 1));
 
     /* success */

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -78,9 +78,16 @@ TMpuBox g_mpu_box[UVISOR_MAX_BOXES];
 
 static uint32_t g_vmpu_aligment_mask;
 
+/* TODO/FIXME: implement recovery from MemManage fault */
+static int vmpu_fault_recovery_mpu(uint32_t pc, uint32_t sp)
+{
+    /* FIXME: currently we deny every access */
+    /* TODO: implement actual recovery */
+    return -1;
+}
+
 void vmpu_sys_mux_handler(uint32_t lr)
 {
-    int res;
     uint32_t sp, pc;
 
     /* the IPSR enumerates interrupt numbers from 0 up, while *_IRQn numbers are
@@ -91,22 +98,25 @@ void vmpu_sys_mux_handler(uint32_t lr)
     switch(ipsr)
     {
         case MemoryManagement_IRQn:
-            /* only support unprivileged exceptions */
+            /* currently we only support recovery from unprivileged mode */
             if(lr & 0x4)
             {
+                /* pc and sp at fault */
                 sp = __get_PSP();
                 pc = vmpu_unpriv_uint32_read(sp + (6 * 4));
 
-                if(vmpu_unpriv_access(pc, sp))
-                {
-                    DEBUG_FAULT(FAULT_MEMMANAGE, lr);
-                    HALT_ERROR(PERMISSION_DENIED, "Access to restricted resource denied");
-                }
+                /* check if the fault is an MPU fault */
+                if((SCB->CFSR & (1 << 7)) && !vmpu_fault_recovery_mpu(pc, sp))
+                    return;
+
+                /* if recovery was not successful, throw an error and halt */
+                DEBUG_FAULT(FAULT_MEMMANAGE, lr);
+                HALT_ERROR(PERMISSION_DENIED, "Access to restricted resource denied");
             }
             else
             {
                 DEBUG_FAULT(FAULT_MEMMANAGE, lr);
-                halt_led(FAULT_MEMMANAGE);
+                HALT_ERROR(FAULT_MEMMANAGE, "Cannot recover from privileged MemManage fault");
             }
 
         case BusFault_IRQn:


### PR DESCRIPTION
This PR suggests improvements for the fault handling and recovery in uVisor.

**The Problem**
Fault handling is hardware specific when it comes to memory accesses, since faults on devices with the ARM MPU result in MemManage Faults, which are generally easy to recover, while the Freescale MPU triggers bus faults, which can be of different classes.

**The Solution**
- Different cases for bus faults introduced for K64F:
    - `vmpu_fault_recovery_mpu(pc, sp)` for Freescale MPU faults (hw-specific)
    - `vmpu_fault_recovery_bus(pc, sp)` for special registers that cannot be given unprivileged access in any other way (observed on MK64F, even if not documented)
- Bus/MemManage faults re-structured to systematically test all cases and halt on failure
- *Special* bus fault recovery now supports imprecise bus faults

**Additional Notes**
The `vmpu_fault_recovery_bus(pc, sp)` function allows to recover from precise and imprecise bus faults if they occurred in a format that follows a very precise pattern:
```asm
str r1, [r0]
dsb
nop
nop
nop
```
where the `str` instruction can be replaced by `strb`, `strh`, `ldr`, `ldrb`, `ldrh` and the `nop`s are only used if imprecise bus faults are enabled. The code is written in a way that little or no overhead is added wrt to the precise-fault-only implementation.

`FIXME`: ACL checks to be added to the `vmpu_fault_recovery_bus` function
`TODO`: `vmpu_fault_recovery_mpu(pc, sp)` to be implemented for both targets