### PR TITLE
core: avoid bashisms like '<<<'

### DIFF
--- a/core/Makefile.rules
+++ b/core/Makefile.rules
@@ -93,8 +93,8 @@ DEBUG_HOST:=localhost:2331
 OPT:=-Os -DNDEBUG
 DEBUG:=-g3
 WARNING:=-Wall -Werror
-CPU_LOWER:=$(shell tr '[:upper:]' '[:lower:]' <<< $(CPU))
-ARCH_LOWER:=$(shell tr '[:upper:]' '[:lower:]' <<< $(ARCH))
+CPU_LOWER:=$(shell echo $(CPU) | tr '[:upper:]' '[:lower:]')
+ARCH_LOWER:=$(shell echo $(ARCH) | tr '[:upper:]' '[:lower:]')
 FLASH_OFFSET:=0
 
 # determine repository version


### PR DESCRIPTION
When building with GNU make, it uses sh as the shell, which is dash
in Ubuntu. It is quite likely to be bash in other versions of GNU/Linux.
As a result, we should avoid bashisms (like <<<) and only use strict
POSIX syntax.