### PR TITLE
core: eliminate duplicated macro UVISOR_ARRAY_COUNT

### DIFF
--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -81,7 +81,6 @@
 
 #define UVISOR_TO_STR(x)            #x
 #define UVISOR_TO_STRING(x)         UVISOR_TO_STR(x)
-#define UVISOR_ARRAY_COUNT(x)       (sizeof(x)/sizeof(x[0]))
 #define UVISOR_PAD32(x)             (32 - (sizeof(x) & ~0x1FUL))
 #define UVISOR_BOX_MAGIC            0x42CFB66FUL
 #define UVISOR_BOX_VERSION          100


### PR DESCRIPTION
Defer to the one defined in header "uvisor_exports.h"