### PR TITLE
mpu: use clz to find highest bit

### DIFF
--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -150,14 +150,7 @@ typedef struct
 
 static inline int vmpu_bits(uint32_t size)
 {
-    int bits=0;
-    /* find highest bit */
-    while(size)
-    {
-        size>>=1;
-        bits++;
-    }
-    return bits;
+    return (size == 0) ? 0 : (32 - __builtin_clz(size));
 }
 
 #endif/*__VMPU_EXPORTS_H__*/


### PR DESCRIPTION
For ARMv7-M, GCC's __builtin_clz generates efficient clz instruction
without loops.