### PR TITLE
Improved generality and portability of SVCall macros

### DIFF
--- a/core/mbed/uvisor-lib/secure_gateway.h
+++ b/core/mbed/uvisor-lib/secure_gateway.h
@@ -17,51 +17,6 @@
 #ifndef __SECURE_GATEWAY_H__
 #define __SECURE_GATEWAY_H__
 
-/* this macro selects an overloaded macro (variable number of arguments) */
-#define SELECT_MACRO(_0, _1, _2, _3, _4, NAME, ...) NAME
-
-/* used to count macro arguments */
-#define NARGS(...)                                                             \
-     SELECT_MACRO(_0, ##__VA_ARGS__, 4, 3, 2, 1, 0)
-
-/* used to declare register values to hold the variable number of arguments */
-#define SELECT_ARGS(...)                                                       \
-     SELECT_MACRO(_0, ##__VA_ARGS__, SELECT_ARGS4,                             \
-                                     SELECT_ARGS3,                             \
-                                     SELECT_ARGS2,                             \
-                                     SELECT_ARGS1,                             \
-                                     SELECT_ARGS0)(__VA_ARGS__)                \
-
-#define SELECT_ARGS0()
-#define SELECT_ARGS1(a0)                                                       \
-        register uint32_t r0 asm("r0") = (uint32_t) a0;
-#define SELECT_ARGS2(a0, a1)                                                   \
-        register uint32_t r0 asm("r0") = (uint32_t) a0;                        \
-        register uint32_t r1 asm("r1") = (uint32_t) a1;
-#define SELECT_ARGS3(a0, a1, a2)                                               \
-        register uint32_t r0 asm("r0") = (uint32_t) a0;                        \
-        register uint32_t r1 asm("r1") = (uint32_t) a1;                        \
-        register uint32_t r2 asm("r2") = (uint32_t) a2;
-#define SELECT_ARGS4(a0, a1, a2, a3)                                           \
-        register uint32_t r0 asm("r0") = (uint32_t) a0;                        \
-        register uint32_t r1 asm("r1") = (uint32_t) a1;                        \
-        register uint32_t r2 asm("r2") = (uint32_t) a2;                        \
-        register uint32_t r3 asm("r3") = (uint32_t) a3;
-
-/* used to declare registers in the asm volatile to avoid compiler opt */
-#define SELECT_REGS(...) \
-     SELECT_MACRO(_0, ##__VA_ARGS__, SELECT_REGS4,                             \
-                                     SELECT_REGS3,                             \
-                                     SELECT_REGS2,                             \
-                                     SELECT_REGS1,                             \
-                                     SELECT_REGS0)(__VA_ARGS__)                \
-
-#define SELECT_REGS0()
-#define SELECT_REGS1(a0)             , "r" (r0)
-#define SELECT_REGS2(a0, a1)         , "r" (r0), "r" (r1)
-#define SELECT_REGS3(a0, a1, a2)     , "r" (r0), "r" (r1), "r" (r2)
-#define SELECT_REGS4(a0, a1, a2, a3) , "r" (r0), "r" (r1), "r" (r2), "r" (r3)
-
 /* the actual secure gateway */
 #define secure_gateway(dst_box, dst_fn, ...)                                   \
     ({                                                                         \

--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -79,8 +79,6 @@
                                      UVISOR_TACL_SREAD          |\
                                      UVISOR_TACL_SWRITE)
 
-#define UVISOR_TO_STR(x)            #x
-#define UVISOR_TO_STRING(x)         UVISOR_TO_STR(x)
 #define UVISOR_PAD32(x)             (32 - (sizeof(x) & ~0x1FUL))
 #define UVISOR_BOX_MAGIC            0x42CFB66FUL
 #define UVISOR_BOX_VERSION          100

--- a/core/system/inc/svc_exports.h
+++ b/core/system/inc/svc_exports.h
@@ -60,7 +60,29 @@
 #define UVISOR_SVC_ID_UNVIC_IN       UVISOR_SVC_FIXED_TABLE(1)
 
 /* unprivileged code uses a secure gateway to switch context */
-#define UVISOR_SVC_ID_SECURE_GATEWAY(args)                                     \
-    ((UVISOR_SVC_ID_CX_IN) | (UVISOR_SVC_CUSTOM_TABLE(args)))
+#define UVISOR_SVC_ID_SECURE_GATEWAY(args) ((UVISOR_SVC_ID_CX_IN) | (UVISOR_SVC_CUSTOM_TABLE(args)))
+
+/* macro to execute an SVCall; additional metadata can be provided, which will
+ * be appended right after the svc instruction */
+/* note: the macro is implicitly overloaded to allow 0 to 4 32bits arguments */
+#if defined(__CC_ARM)
+
+#elif defined(__GNUC__)
+
+#define UVISOR_SVC(id, metadata, ...) \
+    ({ \
+        UVISOR_MACRO_REGS_ARGS(__VA_ARGS__); \
+        UVISOR_MACRO_REGS_RETVAL(res); \
+        asm volatile( \
+            "svc %[svc_id]\n" \
+            metadata \
+            :          "=r" (res) \
+            : [svc_id] "I"  (id), \
+              UVISOR_MACRO_GCC_ASM_INPUT(__VA_ARGS__) \
+        ); \
+        res; \
+    })
+
+#endif /* defined(__CC_ARM) || defined(__GNUC__) */
 
 #endif/*__SVC_EXPORTS_H__*/

--- a/core/uvisor_exports.h
+++ b/core/uvisor_exports.h
@@ -17,25 +17,28 @@
 #ifndef __UVISOR_EXPORTS_H__
 #define __UVISOR_EXPORTS_H__
 
+/* maximum number of boxes allowed: 1 is the minimum (unprivileged box) */
+#define UVISOR_MAX_BOXES 5U
+
+/* extern keyword */
 #ifdef  __cplusplus
 #define UVISOR_EXTERN extern "C"
 #else
 #define UVISOR_EXTERN extern
 #endif/*__CPP__*/
 
-#define UVISOR_NOINLINE  __attribute__((noinline))
-#define UVISOR_PACKED    __attribute__((packed))
-#define UVISOR_WEAK      __attribute__((weak))
-#define UVISOR_ALIAS(f)  __attribute__((weak, alias (#f)))
-#define UVISOR_LINKTO(f) __attribute__((alias (#f)))
-#define UVISOR_NORETURN  __attribute__((noreturn))
-#define UVISOR_NAKED     __attribute__((naked))
-#define UVISOR_RAMFUNC   __attribute__ ((section (".ramfunc"), noinline))
+/* compiler attributes */
+#define UVISOR_FORCEINLINE __attribute__((always_inline))
+#define UVISOR_NOINLINE    __attribute__((noinline))
+#define UVISOR_PACKED      __attribute__((packed))
+#define UVISOR_WEAK        __attribute__((weak))
+#define UVISOR_ALIAS(f)    __attribute__((weak, alias (#f)))
+#define UVISOR_LINKTO(f)   __attribute__((alias (#f)))
+#define UVISOR_NORETURN    __attribute__((noreturn))
+#define UVISOR_NAKED       __attribute__((naked))
+#define UVISOR_RAMFUNC     __attribute__ ((section (".ramfunc"), noinline))
 
 /* array count macro */
 #define UVISOR_ARRAY_COUNT(x) (sizeof(x)/sizeof(x[0]))
-
-/* maximum number of boxes allowed: 1 is the minimum (unprivileged box) */
-#define UVISOR_MAX_BOXES 5U
 
 #endif/*__UVISOR_EXPORTS_H__*/

--- a/core/uvisor_exports.h
+++ b/core/uvisor_exports.h
@@ -41,4 +41,69 @@
 /* array count macro */
 #define UVISOR_ARRAY_COUNT(x) (sizeof(x)/sizeof(x[0]))
 
+/* convert macro argument to string */
+/* note: this needs one level of indirection, accomplished with the helper macro
+ *       __UVISOR_TO_STRING */
+#define __UVISOR_TO_STRING(x) #x
+#define UVISOR_TO_STRING(x)   __UVISOR_TO_STRING(x)
+
+/* select an overloaded macro, so that 0 to 4 arguments can be used */
+#define __UVISOR_MACRO_SELECT(_0, _1, _2, _3, _4, NAME, ...) NAME
+
+/* count macro arguments */
+#define UVISOR_MACRO_NARGS(...) \
+     __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, 4, 3, 2, 1, 0)
+
+/* declare explicit callee-saved registers to hold input arguments (0 to 4) */
+#define UVISOR_MACRO_REGS_ARGS(...) \
+     __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, __UVISOR_MACRO_REGS_ARGS4, \
+                                              __UVISOR_MACRO_REGS_ARGS3, \
+                                              __UVISOR_MACRO_REGS_ARGS2, \
+                                              __UVISOR_MACRO_REGS_ARGS1, \
+                                              __UVISOR_MACRO_REGS_ARGS0)(__VA_ARGS__)
+#define __UVISOR_MACRO_REGS_ARGS0()
+#define __UVISOR_MACRO_REGS_ARGS1(a0) \
+        register uint32_t r0 asm("r0") = (uint32_t) a0;
+#define __UVISOR_MACRO_REGS_ARGS2(a0, a1) \
+        register uint32_t r0 asm("r0") = (uint32_t) a0; \
+        register uint32_t r1 asm("r1") = (uint32_t) a1;
+#define __UVISOR_MACRO_REGS_ARGS3(a0, a1, a2) \
+        register uint32_t r0 asm("r0") = (uint32_t) a0; \
+        register uint32_t r1 asm("r1") = (uint32_t) a1; \
+        register uint32_t r2 asm("r2") = (uint32_t) a2;
+#define __UVISOR_MACRO_REGS_ARGS4(a0, a1, a2, a3) \
+        register uint32_t r0 asm("r0") = (uint32_t) a0; \
+        register uint32_t r1 asm("r1") = (uint32_t) a1; \
+        register uint32_t r2 asm("r2") = (uint32_t) a2; \
+        register uint32_t r3 asm("r3") = (uint32_t) a3;
+
+/* declare explicit callee-saved registers to hold output values */
+/* note: currently only one 32bit output value is allowed */
+#define UVISOR_MACRO_REGS_RETVAL(name) \
+    register uint32_t name asm("r0");
+
+/* declare callee-saved input operands for gcc-style extended inline asm */
+/* note: this macro requires that a C variable having the same name of the
+ *       corresponding callee-saved register is declared; these operands follow
+ *       the official ABI for ARMv7M (e.g. 2 input arguments of 32bits each max,
+ *       imply that registers r0 and r1 are used) */
+/* note: gcc only */
+/* note: for 0 inputs a dummy immediate is passed to avoid errors on a misplaced
+ *       comma in the inline assembly */
+#ifdef __GNUC__
+
+#define UVISOR_MACRO_GCC_ASM_INPUT(...) \
+     __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, __UVISOR_MACRO_GCC_ASM_INPUT4, \
+                                              __UVISOR_MACRO_GCC_ASM_INPUT3, \
+                                              __UVISOR_MACRO_GCC_ASM_INPUT2, \
+                                              __UVISOR_MACRO_GCC_ASM_INPUT1, \
+                                              __UVISOR_MACRO_GCC_ASM_INPUT0)(__VA_ARGS__)
+#define __UVISOR_MACRO_GCC_ASM_INPUT0()               [__dummy] "I" (0)
+#define __UVISOR_MACRO_GCC_ASM_INPUT1(a0)             "r" (r0)
+#define __UVISOR_MACRO_GCC_ASM_INPUT2(a0, a1)         "r" (r0), "r" (r1)
+#define __UVISOR_MACRO_GCC_ASM_INPUT3(a0, a1, a2)     "r" (r0), "r" (r1), "r" (r2)
+#define __UVISOR_MACRO_GCC_ASM_INPUT4(a0, a1, a2, a3) "r" (r0), "r" (r1), "r" (r2), "r" (r3)
+
+#endif /* __GNUC__ */
+
 #endif/*__UVISOR_EXPORTS_H__*/


### PR DESCRIPTION
This PR is a preliminary set of changes that will enable the upcoming re-writing of inline assembly code. Changelog:

- A single SVCall macro introduced, which is easier to maintain for portability and can be used for all cases (direct SVC or secure gateways)
- All macros that were used to enable macro overloading are now made general and can be used in similar situations (for example, in `uvisor-lib/box-config.h`)
- Secure gateway changed to use these new macros

Next steps:

- apply all macros where relevant (especially for all SVCalls in uvisor-lib and when custom macro overloading was duplicated)