### PR TITLE
simplified vmpu_bits

### DIFF
--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -148,7 +148,7 @@ typedef struct
 
 static inline int vmpu_bits(uint32_t size)
 {
-    return (size == 0) ? 0 : (32 - __builtin_clz(size));
+    return 32 - __builtin_clz(size);
 }
 
 #endif/*__VMPU_EXPORTS_H__*/

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -49,6 +49,15 @@ static int vmpu_sanity_checks(void)
             __uvisor_config.magic,
             UVISOR_MAGIC);
 
+    /* verify basic assumptions about vmpu_bits/__builtin_clz */
+    assert(__builtin_clz(0) == 32);
+    assert(__builtin_clz(1UL << 31) == 0);
+    assert(vmpu_bits(0) == 0);
+    assert(vmpu_bits(1UL << 31) == 32);
+    assert(vmpu_bits(0x8000UL) == 16);
+    assert(vmpu_bits(0x8001UL) == 16);
+    assert(vmpu_bits(1) == 1);
+
     /* verify if configuration mode is inside flash memory */
     assert((uint32_t)__uvisor_config.mode >= FLASH_ORIGIN);
     assert((uint32_t)__uvisor_config.mode <= (FLASH_ORIGIN + FLASH_LENGTH - 4));


### PR DESCRIPTION
The special case of comparing zero is not necessary
- it's the exception under normal operations, so a speed-up is not justified for size==0. Instead the overhead of the comparison is applied on all the more common cases.
- size==zero has 32 leading zeros: (32-32)==0 which correctly results in zero bits.


