### PR TITLE
Replace all inline asm in uvisor-lib

### DIFF
--- a/core/mbed/source/benchmark.cpp
+++ b/core/mbed/source/benchmark.cpp
@@ -20,39 +20,22 @@
 void uvisor_benchmark_configure(void)
 {
     /* in sequence:
-     *   - configure the DWT (default overhead = 0)
+     *   - initialize the benchmarking unit (default overhead = 0)
      *   - execute a nop measurement to assess the overhead introduced by the
      *     measurement itself
-     *   - pass the computed overhead to the configuration routine for future
-     *     measurements */
-    __asm__ volatile(
-        "push {lr}\n"
-        "mov  r0, #0\n"
-        "svc  %[svc_id_benchmark_cfg]\n"
-        "bl   uvisor_benchmark_start\n"
-        "bl   uvisor_benchmark_stop\n"
-        "svc  %[svc_id_benchmark_cfg]\n"
-        "pop  {pc}\n"
-        :: [svc_id_benchmark_cfg]  "i" (UVISOR_SVC_ID_BENCHMARK_CFG)
-         : "r0"
-    );
+     *   - pass the computed overhead to the configuration routine to complete
+     *     the calibration */
+    UVISOR_SVC(UVISOR_SVC_ID_BENCHMARK_CFG, "", 0);
+    uvisor_benchmark_start();
+    UVISOR_SVC(UVISOR_SVC_ID_BENCHMARK_CFG, "", uvisor_benchmark_stop());
 }
 
 void uvisor_benchmark_start(void)
 {
-    __asm__ volatile(
-        "svc %[svc_id_benchmark_rst]\n"
-        :: [svc_id_benchmark_rst] "i" (UVISOR_SVC_ID_BENCHMARK_RST)
-    );
+    UVISOR_SVC(UVISOR_SVC_ID_BENCHMARK_RST, "");
 }
 
 uint32_t uvisor_benchmark_stop(void)
 {
-    register uint32_t __res __asm__("r0");
-    __asm__ volatile(
-        "svc %[svc_id_benchmark_stop]\n"
-        : [res]                   "=r" (__res)
-        : [svc_id_benchmark_stop] "i"  (UVISOR_SVC_ID_BENCHMARK_STOP)
-    );
-    return __res;
+    return UVISOR_SVC(UVISOR_SVC_ID_BENCHMARK_STOP, "");
 }

--- a/core/mbed/source/error.cpp
+++ b/core/mbed/source/error.cpp
@@ -19,11 +19,5 @@
 
 void uvisor_error(THaltUserError reason)
 {
-    register uint32_t __r0 __asm__("r0") = (uint32_t) reason;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [svc_id] "i" (UVISOR_SVC_ID_HALT_USER_ERR)
-    );
+    UVISOR_SVC(UVISOR_SVC_ID_HALT_USER_ERR, "", reason);
 }

--- a/core/mbed/source/interrupts.cpp
+++ b/core/mbed/source/interrupts.cpp
@@ -17,113 +17,92 @@
 #include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
-void __uvisor_isr_set(uint32_t irqn, uint32_t vector, uint32_t flag)
+void vIRQ_SetVectorX(uint32_t irqn, uint32_t vector, uint32_t flag)
 {
-    register uint32_t __r0 __asm__("r0") = irqn;
-    register uint32_t __r1 __asm__("r1") = vector;
-    register uint32_t __r2 __asm__("r2") = flag;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [r1]     "r" (__r1),
-          [r2]     "r" (__r2),
-          [svc_id] "i" (UVISOR_SVC_ID_ISR_SET)
-    );
+    if(__uvisor_mode == 0) {
+        NVIC_SetVector((IRQn_Type) irqn, vector);
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_ISR_SET, "", irqn, vector, flag);
+    }
 }
 
-uint32_t __uvisor_isr_get(uint32_t irqn)
+uint32_t vIRQ_GetVector(uint32_t irqn)
 {
-    register uint32_t __r0  __asm__("r0") = irqn;
-    register uint32_t __res __asm__("r0");
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        : [res]    "=r" (__res)
-        : [r0]     "r"  (__r0),
-          [svc_id] "i"  (UVISOR_SVC_ID_ISR_GET)
-    );
-    return __res;
+    if(__uvisor_mode == 0) {
+        return NVIC_GetVector((IRQn_Type) irqn);
+    }
+    else {
+        return UVISOR_SVC(UVISOR_SVC_ID_ISR_GET, "", irqn);
+    }
 }
 
-void __uvisor_irq_enable(uint32_t irqn)
+void vIRQ_EnableIRQ(uint32_t irqn)
 {
-    register uint32_t __r0 __asm__("r0") = irqn;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [svc_id] "i" (UVISOR_SVC_ID_IRQ_ENABLE)
-    );
+    if(__uvisor_mode == 0) {
+        NVIC_EnableIRQ((IRQn_Type) irqn);
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_IRQ_ENABLE, "", irqn);
+    }
 }
 
-void __uvisor_irq_disable(uint32_t irqn)
+void vIRQ_DisableIRQ(uint32_t irqn)
 {
-    register uint32_t __r0 __asm__("r0") = irqn;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [svc_id] "i" (UVISOR_SVC_ID_IRQ_DISABLE)
-    );
+    if(__uvisor_mode == 0) {
+        NVIC_DisableIRQ((IRQn_Type) irqn);
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_IRQ_DISABLE, "", irqn);
+    }
 }
 
-void __uvisor_irq_pending_clr(uint32_t irqn)
+void vIRQ_ClearPendingIRQ(uint32_t irqn)
 {
-    register uint32_t __r0 __asm__("r0") = irqn;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [svc_id] "i" (UVISOR_SVC_ID_IRQ_PEND_CLR)
-    );
+    if(__uvisor_mode == 0) {
+        NVIC_ClearPendingIRQ((IRQn_Type) irqn);
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_IRQ_PEND_CLR, "", irqn);
+    }
 }
 
-void __uvisor_irq_pending_set(uint32_t irqn)
+void vIRQ_SetPendingIRQ(uint32_t irqn)
 {
-    register uint32_t __r0 __asm__("r0") = irqn;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [svc_id] "i" (UVISOR_SVC_ID_IRQ_PEND_SET)
-    );
+    if(__uvisor_mode == 0) {
+        NVIC_SetPendingIRQ((IRQn_Type) irqn);
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_IRQ_PEND_SET, "", irqn);
+    }
 }
 
-uint32_t __uvisor_irq_pending_get(uint32_t irqn)
+uint32_t vIRQ_GetPendingIRQ(uint32_t irqn)
 {
-    register uint32_t __r0  __asm__("r0") = irqn;
-    register uint32_t __res __asm__("r0");
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        : [res]    "=r" (__res)
-        : [r0]     "r"  (__r0),
-          [svc_id] "i"  (UVISOR_SVC_ID_IRQ_PEND_GET)
-    );
-    return __res;
+    if(__uvisor_mode == 0) {
+        return NVIC_GetPendingIRQ((IRQn_Type) irqn);
+    }
+    else {
+        return UVISOR_SVC(UVISOR_SVC_ID_IRQ_PEND_GET, "", irqn);
+    }
 }
 
-void __uvisor_irq_priority_set(uint32_t irqn, uint32_t priority)
+void vIRQ_SetPriority(uint32_t irqn, uint32_t priority)
 {
-    register uint32_t __r0 __asm__("r0") = irqn;
-    register uint32_t __r1 __asm__("r1") = priority;
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        :
-        : [r0]     "r" (__r0),
-          [r1]     "r" (__r1),
-          [svc_id] "i" (UVISOR_SVC_ID_IRQ_PRIO_SET)
-    );
+    if(__uvisor_mode == 0) {
+        NVIC_SetPriority((IRQn_Type) irqn, priority);
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_IRQ_PRIO_SET, "", irqn, priority);
+    }
 }
 
-uint32_t __uvisor_irq_priority_get(uint32_t irqn)
+uint32_t vIRQ_GetPriority(uint32_t irqn)
 {
-    register uint32_t __r0  __asm__("r0") = irqn;
-    register uint32_t __res __asm__("r0");
-    __asm__ volatile(
-        "svc %[svc_id]\n"
-        : [res]    "=r" (__res)
-        : [r0]     "r"  (__r0),
-          [svc_id] "i"  (UVISOR_SVC_ID_IRQ_PRIO_GET)
-    );
-    return __res;
+    if(__uvisor_mode == 0) {
+        return NVIC_GetPriority((IRQn_Type) irqn);
+    }
+    else {
+        return UVISOR_SVC(UVISOR_SVC_ID_IRQ_PRIO_GET, "", irqn);
+    }
 }

--- a/core/mbed/source/unsupported.cpp
+++ b/core/mbed/source/unsupported.cpp
@@ -17,7 +17,7 @@
 #include "uvisor-lib/uvisor-lib.h"
 
 /* uvisor hook for unsupported platforms */
-UVISOR_EXTERN void uvisor_init(void)
+void uvisor_init(void)
 {
     return;
 }

--- a/core/mbed/uvisor-lib/interrupts.h
+++ b/core/mbed/uvisor-lib/interrupts.h
@@ -17,135 +17,17 @@
 #ifndef __INTERRUPTS_H__
 #define __INTERRUPTS_H__
 
-UVISOR_EXTERN void     __uvisor_isr_set(uint32_t irqn, uint32_t vector,
-                                        uint32_t flag);
-UVISOR_EXTERN uint32_t __uvisor_isr_get(uint32_t irqn);
+UVISOR_EXTERN void vIRQ_SetVectorX(uint32_t irqn, uint32_t vector, uint32_t flag);
+UVISOR_EXTERN uint32_t vIRQ_GetVector(uint32_t irqn);
+UVISOR_EXTERN void vIRQ_EnableIRQ(uint32_t irqn);
+UVISOR_EXTERN void vIRQ_DisableIRQ(uint32_t irqn);
+UVISOR_EXTERN void vIRQ_ClearPendingIRQ(uint32_t irqn);
+UVISOR_EXTERN void vIRQ_SetPendingIRQ(uint32_t irqn);
+UVISOR_EXTERN uint32_t vIRQ_GetPendingIRQ(uint32_t irqn);
+UVISOR_EXTERN void vIRQ_SetPriority(uint32_t irqn, uint32_t priority);
+UVISOR_EXTERN uint32_t vIRQ_GetPriority(uint32_t irqn);
 
-UVISOR_EXTERN void     __uvisor_irq_enable(uint32_t irqn);
-UVISOR_EXTERN void     __uvisor_irq_disable(uint32_t irqn);
-UVISOR_EXTERN void     __uvisor_irq_pending_clr(uint32_t irqn);
-UVISOR_EXTERN void     __uvisor_irq_pending_set(uint32_t irqn);
-UVISOR_EXTERN uint32_t __uvisor_irq_pending_get(uint32_t irqn);
-UVISOR_EXTERN void     __uvisor_irq_priority_set(uint32_t irqn,
-                                                 uint32_t priority);
-UVISOR_EXTERN uint32_t __uvisor_irq_priority_get(uint32_t irqn);
-
-#define vIRQ_SetVectorX(irqn, vector, flag)                                    \
-    ({                                                                         \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            NVIC_SetVector((IRQn_Type) (irqn), (uint32_t) (vector));           \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            __uvisor_isr_set((uint32_t) (irqn), (uint32_t) (vector),           \
-                             (uint32_t) (flag));                               \
-        }                                                                      \
-    })
-
+/* this definition is kept for backward compatibility with NVIC_SetVector */
 #define vIRQ_SetVector(irqn, vector) vIRQ_SetVectorX(irqn, vector, 0)
-
-#define vIRQ_GetVector(irqn)                                                   \
-    ({                                                                         \
-        uint32_t res;                                                          \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            res = NVIC_GetVector((IRQn_Type) (irqn));                          \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            res = __uvisor_isr_get((uint32_t) (irqn));                         \
-        }                                                                      \
-        res;                                                                   \
-    })
-
-#define vIRQ_EnableIRQ(irqn)                                                   \
-    ({                                                                         \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            NVIC_EnableIRQ((IRQn_Type) (irqn));                                \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            __uvisor_irq_enable((uint32_t) (irqn));                            \
-        }                                                                      \
-    })
-
-#define vIRQ_DisableIRQ(irqn)                                                  \
-    ({                                                                         \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            NVIC_DisableIRQ((IRQn_Type) (irqn));                               \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            __uvisor_irq_disable((uint32_t) (irqn));                           \
-        }                                                                      \
-    })
-
-#define vIRQ_ClearPendingIRQ(irqn)                                             \
-    ({                                                                         \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            NVIC_ClearPendingIRQ((IRQn_Type) (irqn));                          \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            __uvisor_irq_pending_clr((uint32_t) (irqn));                       \
-        }                                                                      \
-    })
-
-#define vIRQ_SetPendingIRQ(irqn)                                               \
-    ({                                                                         \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            NVIC_SetPendingIRQ((IRQn_Type) (irqn));                            \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            __uvisor_irq_pending_set((uint32_t) (irqn));                       \
-        }                                                                      \
-    })
-
-#define vIRQ_GetPendingIRQ(irqn)                                               \
-    ({                                                                         \
-        uint32_t res;                                                          \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            res = NVIC_GetPendingIRQ((IRQn_Type) (irqn));                      \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            res =  __uvisor_irq_pending_get((uint32_t) (irqn));                \
-        }                                                                      \
-        res;                                                                   \
-    })
-
-#define vIRQ_SetPriority(irqn, priority)                                       \
-    ({                                                                         \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            NVIC_SetPriority((IRQn_Type) (irqn), (uint32_t) (priority));       \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            __uvisor_irq_priority_set((uint32_t) (irqn),                       \
-                                      (uint32_t) (priority));                  \
-        }                                                                      \
-    })
-
-#define vIRQ_GetPriority(irqn)                                                 \
-    ({                                                                         \
-        uint32_t res;                                                          \
-        if(__uvisor_mode == 0)                                                 \
-        {                                                                      \
-            res = NVIC_GetPriority((IRQn_Type) (irqn));                        \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            res =  __uvisor_irq_priority_get((uint32_t) (irqn));               \
-        }                                                                      \
-        res;                                                                   \
-    })
 
 #endif/*__INTERRUPTS_H__*/

--- a/core/mbed/uvisor-lib/secure_access.h
+++ b/core/mbed/uvisor-lib/secure_access.h
@@ -54,76 +54,34 @@
         res.fieldB; \
     })
 
-static inline __attribute__((always_inline)) void uvisor_write32(uint32_t volatile *addr, uint32_t val)
+static inline UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile *addr, uint32_t val)
 {
-    register uint32_t r0 __asm__("r0") = (uint32_t) addr;
-    register uint32_t r1 __asm__("r1") = val;
-    __asm__ volatile(
-        "str %[v], [%[a]]\n"
-        UVISOR_NOP_GROUP
-        :: [a] "r" (r0),
-           [v] "r" (r1)
-    );
+    UVISOR_ASM_MEMORY_ACCESS(str, uint32_t, addr, val);
 }
 
-static inline __attribute__((always_inline)) void uvisor_write16(uint16_t volatile *addr, uint16_t val)
+static inline UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile *addr, uint16_t val)
 {
-    register uint32_t r0 __asm__("r0") = (uint32_t) addr;
-    register uint16_t r1 __asm__("r1") = val;
-    __asm__ volatile(
-        "strh %[v], [%[a]]\n"
-        UVISOR_NOP_GROUP
-        :: [a] "r" (r0),
-           [v] "r" (r1)
-    );
+    UVISOR_ASM_MEMORY_ACCESS(strh, uint16_t, addr, val);
 }
 
-static inline __attribute__((always_inline)) void uvisor_write8(uint8_t volatile *addr, uint8_t val)
+static inline UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile *addr, uint8_t val)
 {
-    register uint32_t r0 __asm__("r0") = (uint32_t) addr;
-    register uint8_t  r1 __asm__("r1") = val;
-    __asm__ volatile(
-        "strb %[v], [%[a]]\n"
-        UVISOR_NOP_GROUP
-        :: [a] "r" (r0),
-           [v] "r" (r1)
-    );
+    UVISOR_ASM_MEMORY_ACCESS(strb, uint8_t, addr, val);
 }
 
-static inline __attribute__((always_inline)) uint32_t uvisor_read32(uint32_t volatile *addr)
+static inline UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile *addr)
 {
-    register uint32_t r0  __asm__("r0") = (uint32_t) addr;
-    register uint32_t res __asm__("r0");
-    __asm__ volatile(
-        "ldr %[r], [%[a]]\n"
-        : [r] "=r" (res)
-        : [a] "r"  (r0)
-    );
-    return (uint32_t) res;
+    return UVISOR_ASM_MEMORY_ACCESS(ldr, uint32_t, addr);
 }
 
-static inline __attribute__((always_inline)) uint16_t uvisor_read16(uint16_t volatile *addr)
+static inline UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile *addr)
 {
-    register uint32_t r0  __asm__("r0") = (uint32_t) addr;
-    register uint16_t res __asm__("r0");
-    __asm__ volatile(
-        "ldrh %[r], [%[a]]\n"
-        : [r] "=r" (res)
-        : [a] "r"  (r0)
-    );
-    return res;
+    return UVISOR_ASM_MEMORY_ACCESS(ldrh, uint16_t, addr);
 }
 
-static inline __attribute__((always_inline)) uint8_t uvisor_read8(uint8_t volatile *addr)
+static inline UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
 {
-    register uint32_t r0  __asm__("r0") = (uint32_t) addr;
-    register uint8_t  res __asm__("r0");
-    __asm__ volatile(
-        "ldrb %[r], [%[a]]\n"
-        : [r] "=r" (res)
-        : [a] "r"  (r0)
-    );
-    return res;
+    return UVISOR_ASM_MEMORY_ACCESS(ldrb, uint8_t, addr);
 }
 
 #endif/*__SECURE_ACCESS_H__*/

--- a/core/mbed/uvisor-lib/uvisor-lib.h
+++ b/core/mbed/uvisor-lib/uvisor-lib.h
@@ -18,6 +18,7 @@
 #define __UVISOR_LIB_H__
 
 #include <stdint.h>
+#include "cmsis_nvic.h"
 
 /* the symbol UVISOR_PRESENT is defined here based on the supported platforms */
 #include "uvisor-lib/platforms.h"
@@ -30,14 +31,15 @@
 /* conditionally included header files */
 #ifdef  UVISOR_PRESENT
 
+#include "uvisor-lib/svc_exports.h"
+#include "uvisor-lib/svc_gw_exports.h"
+
 #include "uvisor-lib/benchmark.h"
 #include "uvisor-lib/secure_access.h"
 #include "uvisor-lib/box_config.h"
 #include "uvisor-lib/error.h"
 #include "uvisor-lib/interrupts.h"
 #include "uvisor-lib/secure_gateway.h"
-#include "uvisor-lib/svc_exports.h"
-#include "uvisor-lib/svc_gw_exports.h"
 
 #else /*UVISOR_PRESENT*/
 

--- a/core/system/inc/svc_exports.h
+++ b/core/system/inc/svc_exports.h
@@ -71,14 +71,14 @@
 
 #define UVISOR_SVC(id, metadata, ...) \
     ({ \
-        UVISOR_MACRO_REGS_ARGS(__VA_ARGS__); \
-        UVISOR_MACRO_REGS_RETVAL(res); \
+        UVISOR_MACRO_REGS_ARGS(uint32_t, ##__VA_ARGS__); \
+        UVISOR_MACRO_REGS_RETVAL(uint32_t, res); \
         asm volatile( \
             "svc %[svc_id]\n" \
             metadata \
-            :          "=r" (res) \
-            : [svc_id] "I"  (id), \
-              UVISOR_MACRO_GCC_ASM_INPUT(__VA_ARGS__) \
+            : UVISOR_MACRO_GCC_ASM_OUTPUT(res) \
+            : UVISOR_MACRO_GCC_ASM_INPUT(__VA_ARGS__), \
+              [svc_id] "I" (id) \
         ); \
         res; \
     })

--- a/core/uvisor_exports.h
+++ b/core/uvisor_exports.h
@@ -55,34 +55,35 @@
      __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, 4, 3, 2, 1, 0)
 
 /* declare explicit callee-saved registers to hold input arguments (0 to 4) */
-#define UVISOR_MACRO_REGS_ARGS(...) \
+/* note: sizeof(type) must be less than or equal to 4 */
+#define UVISOR_MACRO_REGS_ARGS(type, ...) \
      __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, __UVISOR_MACRO_REGS_ARGS4, \
                                               __UVISOR_MACRO_REGS_ARGS3, \
                                               __UVISOR_MACRO_REGS_ARGS2, \
                                               __UVISOR_MACRO_REGS_ARGS1, \
-                                              __UVISOR_MACRO_REGS_ARGS0)(__VA_ARGS__)
-#define __UVISOR_MACRO_REGS_ARGS0()
-#define __UVISOR_MACRO_REGS_ARGS1(a0) \
-        register uint32_t r0 asm("r0") = (uint32_t) a0;
-#define __UVISOR_MACRO_REGS_ARGS2(a0, a1) \
-        register uint32_t r0 asm("r0") = (uint32_t) a0; \
-        register uint32_t r1 asm("r1") = (uint32_t) a1;
-#define __UVISOR_MACRO_REGS_ARGS3(a0, a1, a2) \
-        register uint32_t r0 asm("r0") = (uint32_t) a0; \
-        register uint32_t r1 asm("r1") = (uint32_t) a1; \
-        register uint32_t r2 asm("r2") = (uint32_t) a2;
-#define __UVISOR_MACRO_REGS_ARGS4(a0, a1, a2, a3) \
-        register uint32_t r0 asm("r0") = (uint32_t) a0; \
-        register uint32_t r1 asm("r1") = (uint32_t) a1; \
-        register uint32_t r2 asm("r2") = (uint32_t) a2; \
-        register uint32_t r3 asm("r3") = (uint32_t) a3;
+                                              __UVISOR_MACRO_REGS_ARGS0)(type, ##__VA_ARGS__)
+#define __UVISOR_MACRO_REGS_ARGS0(type)
+#define __UVISOR_MACRO_REGS_ARGS1(type, a0) \
+        register type r0 asm("r0") = (type) a0;
+#define __UVISOR_MACRO_REGS_ARGS2(type, a0, a1) \
+        register type r0 asm("r0") = (type) a0; \
+        register type r1 asm("r1") = (type) a1;
+#define __UVISOR_MACRO_REGS_ARGS3(type, a0, a1, a2) \
+        register type r0 asm("r0") = (type) a0; \
+        register type r1 asm("r1") = (type) a1; \
+        register type r2 asm("r2") = (type) a2;
+#define __UVISOR_MACRO_REGS_ARGS4(type, a0, a1, a2, a3) \
+        register type r0 asm("r0") = (type) a0; \
+        register type r1 asm("r1") = (type) a1; \
+        register type r2 asm("r2") = (type) a2; \
+        register type r3 asm("r3") = (type) a3;
 
 /* declare explicit callee-saved registers to hold output values */
-/* note: currently only one 32bit output value is allowed */
-#define UVISOR_MACRO_REGS_RETVAL(name) \
-    register uint32_t name asm("r0");
+/* note: currently only one output value is allowed, up to 32bits */
+#define UVISOR_MACRO_REGS_RETVAL(type, name) \
+    register type name asm("r0");
 
-/* declare callee-saved input operands for gcc-style extended inline asm */
+/* declare callee-saved input/output operands for gcc-style inline asm */
 /* note: this macro requires that a C variable having the same name of the
  *       corresponding callee-saved register is declared; these operands follow
  *       the official ABI for ARMv7M (e.g. 2 input arguments of 32bits each max,
@@ -99,11 +100,57 @@
                                               __UVISOR_MACRO_GCC_ASM_INPUT1, \
                                               __UVISOR_MACRO_GCC_ASM_INPUT0)(__VA_ARGS__)
 #define __UVISOR_MACRO_GCC_ASM_INPUT0()               [__dummy] "I" (0)
-#define __UVISOR_MACRO_GCC_ASM_INPUT1(a0)             "r" (r0)
-#define __UVISOR_MACRO_GCC_ASM_INPUT2(a0, a1)         "r" (r0), "r" (r1)
-#define __UVISOR_MACRO_GCC_ASM_INPUT3(a0, a1, a2)     "r" (r0), "r" (r1), "r" (r2)
-#define __UVISOR_MACRO_GCC_ASM_INPUT4(a0, a1, a2, a3) "r" (r0), "r" (r1), "r" (r2), "r" (r3)
+#define __UVISOR_MACRO_GCC_ASM_INPUT1(a0)             [r0] "r" (r0)
+#define __UVISOR_MACRO_GCC_ASM_INPUT2(a0, a1)         [r0] "r" (r0), [r1] "r" (r1)
+#define __UVISOR_MACRO_GCC_ASM_INPUT3(a0, a1, a2)     [r0] "r" (r0), [r1] "r" (r1), [r2] "r" (r2)
+#define __UVISOR_MACRO_GCC_ASM_INPUT4(a0, a1, a2, a3) [r0] "r" (r0), [r1] "r" (r1), [r2] "r" (r2), [r3] "r" (r3)
+
+#define UVISOR_MACRO_GCC_ASM_OUTPUT(name) [res] "=r" (name)
 
 #endif /* __GNUC__ */
+
+/* this macro multiplexes read/write opcodes depending on the number of
+ * arguments */
+#define UVISOR_ASM_MEMORY_ACCESS(opcode, type, ...) \
+    __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, /* no macro for 4 args */   , \
+                                             /* no macro for 3 args */   , \
+                                             __UVISOR_ASM_MEMORY_ACCESS_W, \
+                                             __UVISOR_ASM_MEMORY_ACCESS_R, \
+                                             /* no macro for 0 args */   )(opcode, type, ##__VA_ARGS__)
+/* the macros that actually generate the assembly code for the memory access are
+ * toolchain-specific */
+#if defined(__CC_ARM)
+
+/* TODO/FIXME */
+
+#elif defined(__GNUC__)
+
+#ifndef asm
+#define asm __asm__
+#endif
+
+#define __UVISOR_ASM_MEMORY_ACCESS_R(opcode, type, ...) \
+    ({ \
+        UVISOR_MACRO_REGS_ARGS(uint32_t, ##__VA_ARGS__); \
+        UVISOR_MACRO_REGS_RETVAL(type, res); \
+        asm volatile( \
+            UVISOR_TO_STRING(opcode)" %[res], [%[r0]]\n" \
+            UVISOR_NOP_GROUP \
+            : UVISOR_MACRO_GCC_ASM_OUTPUT(res) \
+            : UVISOR_MACRO_GCC_ASM_INPUT(__VA_ARGS__) \
+        ); \
+        res; \
+    })
+
+#define __UVISOR_ASM_MEMORY_ACCESS_W(opcode, type, ...) \
+    UVISOR_MACRO_REGS_ARGS(uint32_t, ##__VA_ARGS__); \
+    asm volatile( \
+        UVISOR_TO_STRING(opcode)" %[r1], [%[r0]]\n" \
+        UVISOR_NOP_GROUP \
+        : \
+        : UVISOR_MACRO_GCC_ASM_INPUT(__VA_ARGS__) \
+    );
+
+#endif /* defined(__CC_ARM) || defined(__GNUC__) */
 
 #endif/*__UVISOR_EXPORTS_H__*/

--- a/core/uvisor_exports.h
+++ b/core/uvisor_exports.h
@@ -27,6 +27,11 @@
 #define UVISOR_EXTERN extern
 #endif/*__CPP__*/
 
+/* asm keyword */
+#ifndef asm
+#define asm __asm__
+#endif
+
 /* compiler attributes */
 #define UVISOR_FORCEINLINE __attribute__((always_inline))
 #define UVISOR_NOINLINE    __attribute__((noinline))
@@ -124,10 +129,6 @@
 /* TODO/FIXME */
 
 #elif defined(__GNUC__)
-
-#ifndef asm
-#define asm __asm__
-#endif
 
 #define __UVISOR_ASM_MEMORY_ACCESS_R(opcode, type, ...) \
     ({ \


### PR DESCRIPTION
This PR replaces all occurrences of inline `asm` in uvisor-lib with macros that allow the assembly to be defined, changed and ported to other toolchains more easily.

In particular:
- All SVCall-based APIs (`vIRQ`, benchmarking, error) bodies have been replaced with the `UVISOR_SVC(...)` variadic macro
    - in addition `vIRQ` APIs have been simplified to remove one level of indirection
- The low-level functions for special memory accesses (see https://github.com/ARMmbed/mbed-hal-k64f/pull/6) have been replaced with assembly templates (`UVISOR_ASM_MEMORY_ACCESS(...)`) that are maintained in a separate header file
- Existing support variadic macros have been updated to be more flexible (you can specify the type of the inline `register asm(...)` constructs)

Next step: port the (now very few) inline `asm`s to armcc