### PR TITLE
Updating uVisor to the new linker script symbols

### DIFF
--- a/core/mbed/source/uvisor-gcc-input.S
+++ b/core/mbed/source/uvisor-gcc-input.S
@@ -47,35 +47,40 @@ uvisor_config:
        2: enabled */
     .long __uvisor_mode
 
-    /* start and end address of box list */
-    .long __uvisor_cfgtbl_start
-    .long __uvisor_cfgtbl_end
-
-    /* flash origin of initialized secret data */
-    .long __uvisor_data_src
-
-    /* initialized secret data section */
-    .long __uvisor_data_start
-    .long __uvisor_data_end
-
-    /* uninitialized secret data section */
+    /* start and end address of protected bss */
     .long __uvisor_bss_start
     .long __uvisor_bss_end
 
-    /* start and end of flash protection - remaining flash size is
-       available for configuration storage */
+    /* start and end address of uvisor main bss */
+    .long __uvisor_bss_main_start
+    .long __uvisor_bss_main_end
+
+    /* start and end address of uvisor secure boxes bss */
+    .long __uvisor_bss_boxes_start
+    .long __uvisor_bss_boxes_end
+
+    /* start and end address of uvisor code and data */
+    .long __uvisor_main_start
+    .long __uvisor_main_end
+
+    /* start and end address of protected flash region
+    /* note: remaining flash size is available for configuration storage */
     .long __uvisor_secure_start
     .long __uvisor_secure_end
 
-    /* start and end of uvisor stack */
-    .long __uvisor_reserved_start
-    .long __uvisor_reserved_end
+     /* start and end address of boxes configuration tables */
+    .long __uvisor_cfgtbl_start
+    .long __uvisor_cfgtbl_end
+
+    /* start and end address of list of pointers to boxes configuration tables */
+    .long __uvisor_cfgtbl_ptr_start
+    .long __uvisor_cfgtbl_ptr_end
 
     /* pointer to __uvisor_box_context */
     .long __uvisor_box_context
 
-    /* uvisor default mode - user can override weak reference */
 __uvisor_mode:
+    /* uvisor default mode - user can override weak reference */
     .long 0
 
     .align 5
@@ -85,7 +90,5 @@ __uvisor_box_context:
 uvisor_ctx:
     .long 0
 
-.section .uvisor.bss.main,"awM",@nobits
-__uvisor_reserved_start:
+.section .keep.uvisor.bss.main,"awM",@nobits
     .space USE_SRAM_SIZE
-__uvisor_reserved_end:

--- a/core/mbed/uvisor-lib/box_config.h
+++ b/core/mbed/uvisor-lib/box_config.h
@@ -30,12 +30,11 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
     UVISOR_SET_MODE_ACL_COUNT(mode, acl_list, UVISOR_ARRAY_COUNT(acl_list))
 
 #define UVISOR_SET_MODE_ACL_COUNT(mode, acl_list, acl_list_count) \
-    uint8_t __attribute__((section(".uvisor.bss.stack"), aligned(32))) \
-        __reserved_stack[UVISOR_STACK_BAND_SIZE]; \
+    uint8_t __attribute__((section(".keep.uvisor.bss.boxes"), aligned(32))) __reserved_stack[UVISOR_STACK_BAND_SIZE]; \
     \
     UVISOR_EXTERN const uint32_t __uvisor_mode = (mode); \
     \
-    static UVISOR_SECURE_CONST UvisorBoxConfig main_cfg = { \
+    static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig main_cfg = { \
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         0, \
@@ -44,30 +43,17 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         acl_list_count \
     }; \
     \
-    const __attribute__((section(".uvisor.cfgtbl_first"), aligned(4))) \
-          volatile void* main_cfg_ptr  =  & main_cfg;
-
-#define UVISOR_SECURE_CONST \
-    const volatile __attribute__((section(".uvisor.secure"), aligned(32)))
-
-#define UVISOR_SECURE_BSS \
-    __attribute__((section(".uvisor.bss.data"), aligned(32)))
-
-/* we currently only support secure data sections in Flash on the K64F */
-#ifdef TARGET_LIKE_FRDM_K64F_GCC
-#define UVISOR_SECURE_DATA \
-    __attribute__((section(".uvisor.data"), aligned(32)))
-#endif
+    const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) volatile void* main_cfg_ptr = &main_cfg;
 
 /* this macro selects an overloaded macro (variable number of arguments) */
 #define __UVISOR_BOX_MACRO(_1, _2, _3, _4, NAME, ...) NAME
 
 #define __UVISOR_BOX_CONFIG(box_name, acl_list, stack_size, context_size) \
     \
-    uint8_t __attribute__((section(".uvisor.bss.stack"), aligned(32))) \
+    uint8_t __attribute__((section(".keep.uvisor.bss.boxes"), aligned(32))) \
         box_name ## _reserved[UVISOR_STACK_SIZE_ROUND(((UVISOR_MIN_STACK(stack_size) + (context_size))*8)/6)]; \
     \
-    static UVISOR_SECURE_CONST UvisorBoxConfig box_name ## _cfg = { \
+    static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig box_name ## _cfg = { \
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         UVISOR_MIN_STACK(stack_size), \
@@ -76,7 +62,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         UVISOR_ARRAY_COUNT(acl_list) \
     }; \
     \
-    const __attribute__((section(".uvisor.cfgtbl"), aligned(4))) \
+    const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) \
           volatile void *box_name ## _cfg_ptr  =  & box_name ## _cfg;
 
 #define __UVISOR_BOX_CONFIG_NOCONTEXT(box_name, acl_list, stack_size) \

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -39,20 +39,26 @@ typedef struct {
     uint32_t version;
     uint32_t *mode;
 
-    /* initialized secret data section */
-    uint32_t *cfgtbl_start, *cfgtbl_end;
-
-    /* initialized secret data section */
-    uint32_t *data_src, *data_start, *data_end;
-
-    /* uninitialized secret data section */
+    /* protected bss */
     uint32_t *bss_start, *bss_end;
 
-    /* uvisors protected flash memory regions */
+        /* uvisor main bss */
+    uint32_t *bss_main_start, *bss_main_end;
+
+        /* secure boxes bss */
+    uint32_t *bss_boxes_start, *bss_boxes_end;
+
+    /* uvisor code and data */
+    uint32_t *main_start, *main_end;
+
+    /* protected flash memory region */
     uint32_t *secure_start, *secure_end;
 
-    /* memory reserved for uvisor */
-    uint32_t *reserved_start, *reserved_end;
+        /* boxes configuration tables */
+    uint32_t *cfgtbl_start, *cfgtbl_end;
+
+        /* pointers to boxes configuration tables */
+    uint32_t *cfgtbl_ptr_start, *cfgtbl_ptr_end;
 
     /* address of __uvisor_box_context */
     uint32_t **uvisor_box_context;

--- a/core/system/inc/svc_gw.h
+++ b/core/system/inc/svc_gw.h
@@ -56,7 +56,7 @@ static inline uint32_t svc_gw_get_dst_fn(TSecGw *svc_pc)
 
 static inline uint8_t svc_gw_get_dst_id(TSecGw *svc_pc)
 {
-    uint32_t box_id = svc_pc->cfg_ptr - __uvisor_config.cfgtbl_start;
+    uint32_t box_id = svc_pc->cfg_ptr - __uvisor_config.cfgtbl_ptr_start;
 
     if(box_id <= 0 || box_id >= g_vmpu_box_count)
         HALT_ERROR(SANITY_CHECK_FAILED, "box_id out of range (%i)", box_id);

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -434,7 +434,7 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size)
         g_box_mem_pos = (g_box_mem_pos & ~(size-1)) + size;
 
     /* check if we have enough memory left */
-    if((g_box_mem_pos + size)>((uint32_t)__uvisor_config.bss_start))
+    if((g_box_mem_pos + size)<=((uint32_t)__uvisor_config.bss_boxes_end))
         HALT_ERROR(SANITY_CHECK_FAILED,
             "memory overflow - increase uvisor memory "
             "allocation\n\r");
@@ -486,9 +486,9 @@ void vmpu_arch_init(void)
 
     /* init protected box memory enumation pointer */
     DPRINTF("\n\rbox stack segment start=0x%08X end=0x%08X (length=%i)\n\r",
-        __uvisor_config.reserved_end, __uvisor_config.bss_start,
-        ((uint32_t)__uvisor_config.bss_start)-((uint32_t)__uvisor_config.reserved_end));
-    g_box_mem_pos = (uint32_t)__uvisor_config.reserved_end;
+        __uvisor_config.bss_boxes_start, __uvisor_config.bss_boxes_start,
+        ((uint32_t)__uvisor_config.bss_boxes_end)-((uint32_t)__uvisor_config.bss_boxes_start));
+    g_box_mem_pos = (uint32_t)__uvisor_config.bss_boxes_start;
 
     /* enable mem, bus and usage faults */
     SCB->SHCSR |= 0x70000;

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -242,7 +242,7 @@ void vmpu_arch_init(void)
 
     /* initialize box memories, leave stack-band sized gap */
     g_box_mem_pos = UVISOR_REGION_ROUND_UP(
-        (uint32_t)__uvisor_config.reserved_end) +
+        (uint32_t)__uvisor_config.bss_boxes_start) +
         UVISOR_STACK_BAND_SIZE;
 
     /* init memory protection */


### PR DESCRIPTION
This PR applies the changes introduced in https://github.com/AlessandroA/target-frdm-k64f-gcc/pull/1
The new linker symbols have been used in place of the old ones. Sometimes the changes were slightly more complex (sanity checks), because different memory regions boundaries were used.

Changelog:
- some symbols names changed to reflect their functionality better
- sometimes the boundary of a region was used as a boundary for an adjacent one, which is hard to maintain and read; names have been introduced for both start and end addresses, always (even when some symbols end up being the same)
- all functions (`vmpu_*` and sanity checks) have been updated accordingly
- the mbed-facing files (`*.s`, `box_config.h`) have been updated accordingly
- the support for protected bss and Flash regions (`UVISOR_SECURE_{CONST, BSS}`) has been removed