### PR TITLE
uvisor-lib header files not depending anymore on mbed

### DIFF
--- a/core/mbed/source/benchmark.cpp
+++ b/core/mbed/source/benchmark.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 void uvisor_benchmark_configure(void)

--- a/core/mbed/source/error.cpp
+++ b/core/mbed/source/error.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 void uvisor_error(THaltUserError reason)

--- a/core/mbed/source/interrupts.cpp
+++ b/core/mbed/source/interrupts.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 void vIRQ_SetVectorX(uint32_t irqn, uint32_t vector, uint32_t flag)

--- a/core/mbed/uvisor-lib/uvisor-lib.h
+++ b/core/mbed/uvisor-lib/uvisor-lib.h
@@ -20,8 +20,7 @@
 #include <stdint.h>
 
 /* needed for NVIC symbols */
-/* #include "cmsis-core/cmsis_nvic.h" */
-#include "cmsis_nvic.h"
+#include "cmsis-core/cmsis_nvic.h"
 
 /* the symbol UVISOR_PRESENT is defined here based on the supported platforms */
 #include "uvisor-lib/platforms.h"


### PR DESCRIPTION
cmsis-core is now enough