### PR TITLE
Add uvisor_{read,write}{32,16,8} to fallback APIs

### DIFF
--- a/core/mbed/uvisor-lib/unsupported.h
+++ b/core/mbed/uvisor-lib/unsupported.h
@@ -76,9 +76,9 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 /* the conditional statement will be optimised away since the compiler already
  * knows the sizeof(type) */
 #define ADDRESS_READ(type, addr) \
-    (sizeof(type) == 4 ? *((volatile uint32_t *) (addr)) : \
-     sizeof(type) == 2 ? *((volatile uint16_t *) (addr)) : \
-     sizeof(type) == 1 ? *((volatile uint8_t  *) (addr)) : 0)
+    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t *) (addr)) : \
+     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t *) (addr)) : \
+     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t *) (addr)) : 0)
 
 /* the switch statement will be optimised away since the compiler already knows
  * the sizeof(type) */
@@ -87,18 +87,48 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         switch(sizeof(type)) \
         { \
             case 4: \
-                *((volatile uint32_t *) (addr)) = (uint32_t) (val); \
+                uvisor_write32((volatile uint32_t *) (addr), (uint32_t) (val)); \
                 break; \
             case 2: \
-                *((volatile uint16_t *) (addr)) = (uint16_t) (val); \
+                uvisor_write16((volatile uint16_t *) (addr), (uint16_t) (val)); \
                 break; \
             case 1: \
-                *((volatile uint8_t  *) (addr)) = (uint8_t ) (val); \
+                uvisor_write8((volatile uint8_t *) (addr), (uint8_t) (val)); \
                 break; \
         } \
     }
 
 #define UNION_READ(type, addr, fieldU, fieldB) ((*((volatile type *) (addr))).fieldB)
+
+static inline UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile *addr, uint32_t val)
+{
+    *(addr) = val;
+}
+
+static inline UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile *addr, uint16_t val)
+{
+    *(addr) = val;
+}
+
+static inline UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile *addr, uint8_t val)
+{
+    *(addr) = val;
+}
+
+static inline UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile *addr)
+{
+    return *(addr);
+}
+
+static inline UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile *addr)
+{
+    return *(addr);
+}
+
+static inline UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
+{
+    return *(addr);
+}
 
 /* uvisor-lib/secure_gateway.h */
 


### PR DESCRIPTION
`ADDRESS_{READ,WRITE}` macro are less meaningful and will only be used for massive header files (see the mighty PR for K64F macros); generally code should use these functions (`uvisor_{read,write}{32,16,8}`) to access special registers.

**Note**: this is temporary; when register-level access will be enabled there won't be need for these APIs