### PR TITLE
Fix config tables

### DIFF
--- a/core/mbed/uvisor-lib/box_config.h
+++ b/core/mbed/uvisor-lib/box_config.h
@@ -43,7 +43,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         acl_list_count \
     }; \
     \
-    const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) volatile void* main_cfg_ptr = &main_cfg;
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_cfg;
 
 /* this macro selects an overloaded macro (variable number of arguments) */
 #define __UVISOR_BOX_MACRO(_1, _2, _3, _4, NAME, ...) NAME
@@ -62,8 +62,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         UVISOR_ARRAY_COUNT(acl_list) \
     }; \
     \
-    const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) \
-          volatile void *box_name ## _cfg_ptr  =  & box_name ## _cfg;
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) void * const box_name ## _cfg_ptr = &box_name ## _cfg;
 
 #define __UVISOR_BOX_CONFIG_NOCONTEXT(box_name, acl_list, stack_size) \
     __UVISOR_BOX_CONFIG(box_name, acl_list, stack_size, 0) \

--- a/core/mbed/uvisor-lib/unsupported.h
+++ b/core/mbed/uvisor-lib/unsupported.h
@@ -39,12 +39,11 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 #define UVISOR_SET_MODE_ACL_COUNT(mode, acl_list, acl_list_count) \
     UVISOR_EXTERN const uint32_t __uvisor_mode = UVISOR_DISABLED; \
     static const void *main_acl = acl_list; \
-    const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) volatile void *main_cfg_ptr = &main_acl;
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_acl;
 
 #define __UVISOR_BOX_CONFIG_NOCONTEXT(box_name, acl_list, stack_size) \
     static const void *box_acl_ ## box_name = acl_list; \
-    const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) volatile void *box_name ## _cfg_ptr = \
-        &box_acl_ ## box_name;
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) void * const box_name ## _cfg_ptr = &box_acl_ ## box_name;
 
 #define __UVISOR_BOX_CONFIG_CONTEXT(box_name, acl_list, stack_size, context_type) \
     context_type box_ctx_ ## box_name; \

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -262,7 +262,7 @@ void vmpu_mem_init(void)
         HALT_ERROR(SANITY_CHECK_FAILED, "failed setting up box 0 SRAM (%i)\n", res);
 
     /* enable read access to unsecure flash regions - allow execution */
-    res = vmpu_mem_add_int(0, (void*)FLASH_ORIGIN, ((uint32_t)__uvisor_config.secure_start)-FLASH_ORIGIN,
+    res = vmpu_mem_add_int(0, (void*)FLASH_ORIGIN, ((uint32_t)__uvisor_config.secure_end)-FLASH_ORIGIN,
         UVISOR_TACL_SREAD|
         UVISOR_TACL_SEXECUTE|
         UVISOR_TACL_UREAD|


### PR DESCRIPTION
Two changes related to config tables:
- Flash MPU region for K64F fixed (was ending at `__uvisor_secure_start` instead of `_end`); the config tables do not need to be read-protected (the bug is not found in STM32F4)
- Fixed type of pointer to config table (also helps with armlink -- the config table is not mistaken for RW data to load into SRAM): it is now `const void * const` and it is also marked as `extern` for use in the secure gateway

@meriac 