### PR TITLE
Explicitly test for YOTTA_CFG_UVISOR_PRESENT

### DIFF
--- a/core/mbed/uvisor-lib/override.h
+++ b/core/mbed/uvisor-lib/override.h
@@ -42,7 +42,7 @@ extern uint32_t vIRQ_GetPriority(uint32_t irqn);
 
 #define vIRQ_SetVector(irqn, vector) vIRQ_SetVectorX((uint32_t) (irqn), (uint32_t) (vector), 0)
 
-#if defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(UVISOR_NO_HOOKS)
+#if YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(UVISOR_NO_HOOKS)
 
 /* re-definition of NVIC APIs supported by uVisor */
 #define NVIC_ClearPendingIRQ(irqn)       vIRQ_ClearPendingIRQ((uint32_t) (irqn))
@@ -55,6 +55,6 @@ extern uint32_t vIRQ_GetPriority(uint32_t irqn);
 #define NVIC_EnableIRQ(irqn)             vIRQ_EnableIRQ((uint32_t) (irqn))
 #define NVIC_DisableIRQ(irqn)            vIRQ_DisableIRQ((uint32_t) (irqn))
 
-#endif /* defined(UVISOR_PRESENT) && !defined(UVISOR_NO_HOOKS) */
+#endif /* YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(UVISOR_NO_HOOKS) */
 
 #endif /* __UVISOR_LIB_OVERRIDE_H__ */

--- a/core/mbed/uvisor-lib/platforms.h
+++ b/core/mbed/uvisor-lib/platforms.h
@@ -21,7 +21,7 @@
 #if defined(TARGET_LIKE_FRDM_K64F_GCC)         || \
     defined(TARGET_LIKE_STM32F429I_DISCO_GCC)
 
-#define UVISOR_PRESENT
+#define UVISOR_PRESENT 1
 
 #endif /* TARGET_LIKE_FRDM_K64F_GCC        or
           TARGET_LIKE_STM32F429I_DISCO_GCC */


### PR DESCRIPTION
This is safer as `SYMBOL` re-definition would always lead `#if defined(SYMBOL)` to be resolved in "true"

@meriac 
@bogdanm 