### PR TITLE
Fixing Error on "path/to/uvisor/release/uvisor-lib" does not exist.

### DIFF
--- a/core/Makefile.rules
+++ b/core/Makefile.rules
@@ -186,6 +186,7 @@ release: $(MBED_ASM_INPUT) $(PROJECT).bin
 	rm  -f $(RELEASE_SRC)/*.cpp
 	rm -rf $(RELEASE_SRC_HW)
 	mkdir -p $(MBED_SRC_HW)
+	mkdir -p $(RELEASE_INC)
 	mkdir -p $(RELEASE_SRC_HW)
 	echo "$(PROGRAM_VERSION)" > $(RELEASE_VER)
 	cp $(PROJECT).bin $(MBED_BIN)


### PR DESCRIPTION
When the current directory is at "path/to/uvisor/stm32f4/uvisor",the command "make release" will output the error messages like "/release/uvisor-lib" does not exist.