### PR TITLE
Add box id information for unvic_acl_check

### DIFF
--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -66,6 +66,8 @@
 #define VMPU_OPCODE16_UPPER_LDRH_MASK   0x88
 #define VMPU_OPCODE16_UPPER_LDRB_MASK   0x78
 
+extern uint8_t g_active_box;
+
 extern void vmpu_acl_add(uint8_t box_id, void *addr,
                          uint32_t size, UvisorBoxAcl acl);
 extern void vmpu_acl_irq(uint8_t box_id, void *function, uint32_t isr_id);

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -37,6 +37,7 @@
 #endif
 
 uint32_t  g_vmpu_box_count;
+uint8_t g_active_box;
 
 static int vmpu_sanity_checks(void)
 {

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -75,7 +75,6 @@ typedef struct {
 } TMpuBox;
 
 uint32_t g_mpu_slot;
-static uint8_t g_active_box;
 uint32_t g_mpu_region_count, g_box_mem_pos;
 TMpuRegion g_mpu_list[MPU_REGION_COUNT];
 TMpuBox g_mpu_box[UVISOR_MAX_BOXES];

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -24,7 +24,6 @@
 #include "vmpu_freescale_k64_aips.h"
 #include "vmpu_freescale_k64_mem.h"
 
-static uint8_t g_active_box;
 uint32_t g_box_mem_pos;
 
 /* TODO/FIXME: implement recovery from Freescale MPU fault */


### PR DESCRIPTION
The `unvic_acl_check` function (`unvic.c` scope only) checks if accesses to the virtual NVIC module is allowed. It always used `g_active_box` to tell if the access is allowed, which is too restrictive for the cross-box interrupt context switch.

In that case the information for the context switch comes from trusted internal uVisor tables, for which only a basic ACL check is needed.

Fixes https://github.com/ARMmbed/uvisor/issues/99

@meriac