### PR TITLE
Add bitbanding support

### DIFF
--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -66,6 +66,33 @@
 #define VMPU_OPCODE16_UPPER_LDRH_MASK   0x88
 #define VMPU_OPCODE16_UPPER_LDRB_MASK   0x78
 
+/* bit-banding regions boundaries */
+#define VMPU_SRAM_START           0x20000000
+#define VMPU_SRAM_BITBAND_START   0x22000000
+#define VMPU_SRAM_BITBAND_END     0x23FFFFFF
+#define VMPU_PERIPH_START         0x40000000
+#define VMPU_PERIPH_BITBAND_START 0x42000000
+#define VMPU_PERIPH_BITBAND_END   0x43FFFFFF
+
+/* bit-banding aliases macros
+ * physical address ---> bit-banded alias
+ * bit-banded alias ---> physical address
+ * bit-banded alias ---> specific bit accessed at physical address */
+#define VMPU_SRAM_BITBAND_ADDR_TO_ALIAS(addr, bit)   (VMPU_SRAM_BITBAND_START + 32U * (((uint32_t) (addr)) - \
+                                                     VMPU_SRAM_START) + 4U * ((uint32_t) (bit)))
+#define VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(alias)       ((((((uint32_t) (alias)) - VMPU_SRAM_BITBAND_START) >> 5) & \
+                                                     ~0x3U) + VMPU_SRAM_START)
+#define VMPU_SRAM_BITBAND_ALIAS_TO_BIT(alias)        (((((uint32_t) (alias)) - VMPU_SRAM_BITBAND_START) - \
+                                                     ((VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(alias) - \
+                                                     VMPU_SRAM_START) << 5)) >> 2)
+#define VMPU_PERIPH_BITBAND_ADDR_TO_ALIAS(addr, bit) (VMPU_PERIPH_BITBAND_START + 32U * (((uint32_t) (addr)) - \
+                                                     VMPU_PERIPH_START) + 4U * ((uint32_t) (bit)))
+#define VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(alias)     ((((((uint32_t) (alias)) - VMPU_PERIPH_BITBAND_START) >> 5) & \
+                                                     ~0x3U) + VMPU_PERIPH_START)
+#define VMPU_PERIPH_BITBAND_ALIAS_TO_BIT(alias)      (((((uint32_t) (alias)) - VMPU_PERIPH_BITBAND_START) - \
+                                                     ((VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(alias) - \
+                                                     VMPU_PERIPH_START) << 5)) >> 2)
+
 extern uint8_t g_active_box;
 
 extern void vmpu_acl_add(uint8_t box_id, void *addr,

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -124,6 +124,14 @@ uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)
         case (uint32_t) &SCB->SCR:
             return UVISOR_TACL_UWRITE | UVISOR_TACL_UREAD;
         default:
+            /* translate fault_addr into its physical address if it is in the bit-banding region */
+            if (fault_addr >= VMPU_PERIPH_BITBAND_START && fault_addr <= VMPU_PERIPH_BITBAND_END) {
+                fault_addr = VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(fault_addr);
+            }
+            else if (fault_addr >= VMPU_SRAM_BITBAND_START && fault_addr <= VMPU_SRAM_BITBAND_END) {
+                fault_addr = VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(fault_addr);
+            }
+
             /* search base box and active box ACLs */
             region = vmpu_fault_find_box(fault_addr);
 

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -239,6 +239,15 @@ uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)
         case (uint32_t) &SCB->SCR:
             return UVISOR_TACL_UWRITE | UVISOR_TACL_UREAD;
         default:
+            /* translate fault_addr into its physical address if it is in the bit-banding region */
+            if (fault_addr >= VMPU_PERIPH_BITBAND_START && fault_addr <= VMPU_PERIPH_BITBAND_END) {
+                fault_addr = VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(fault_addr);
+            }
+            else if (fault_addr >= VMPU_SRAM_BITBAND_START && fault_addr <= VMPU_SRAM_BITBAND_END) {
+                fault_addr = VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(fault_addr);
+            }
+
+            /* look for ACL */
             if( (fault_addr>=AIPS0_BASE) &&
                 ((fault_addr<(AIPS0_BASE+(0xFEUL*(AIPSx_SLOT_SIZE))))) )
                 return vmpu_fault_find_acl_aips(g_active_box, fault_addr, size);


### PR DESCRIPTION
This PR introduces macros to translate bitbanded aliases to their physical address counterpart.

The macros are then used in fault recovery to use the physical address as argument to search for ACLs

@meriac 