### PR TITLE
Move fault status register clearing to end of handler

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -185,13 +185,13 @@ void vmpu_sys_mux_handler(uint32_t lr)
                 sp = __get_PSP();
                 pc = vmpu_unpriv_uint32_read(sp + (6 * 4));
 
-                /* backup fault address and status, then clear the MMARVALID flag */
+                /* backup fault address and status */
                 fault_addr = SCB->MMFAR;
                 fault_status = VMPU_SCB_MMFSR;
-                VMPU_SCB_MMFSR = fault_status;
 
                 /* check if the fault is an MPU fault */
                 if (vmpu_fault_recovery_mpu(pc, sp, fault_addr, fault_status)) {
+                    VMPU_SCB_MMFSR = fault_status;
                     return;
                 }
 
@@ -221,14 +221,15 @@ void vmpu_sys_mux_handler(uint32_t lr)
                 sp = __get_PSP();
                 pc = vmpu_unpriv_uint32_read(sp + (6 * 4));
 
-                /* backup fault address and status, then clear the BFARVALID flag */
+                /* backup fault address and status */
                 fault_addr = SCB->BFAR;
                 fault_status = VMPU_SCB_BFSR;
-                VMPU_SCB_BFSR = fault_status;
 
                 /* check if the fault is the special register corner case */
-                if(!vmpu_fault_recovery_bus(pc, sp, fault_addr, fault_status))
+                if (!vmpu_fault_recovery_bus(pc, sp, fault_addr, fault_status)) {
+                    VMPU_SCB_BFSR = fault_status;
                     return;
+                }
 
                 /* if recovery was not successful, throw an error and halt */
                 DEBUG_FAULT(FAULT_BUS, lr);


### PR DESCRIPTION
This allows the fault-related registers to be still valid for the rest of the handler execution, where
they could be used for debugging purposes. The flags are always cleared right before returning from
the exception handler.

@meriac 