### PR TITLE
Fixed check for YOTTA_CFG_UVISOR_PRESENT

### DIFF
--- a/core/mbed/uvisor-lib/uvisor-lib.h
+++ b/core/mbed/uvisor-lib/uvisor-lib.h
@@ -30,7 +30,7 @@
 #include "uvisor-lib/svc_gw_exports.h"
 
 /* conditionally included header files */
-#ifdef YOTTA_CFG_UVISOR_PRESENT
+#if YOTTA_CFG_UVISOR_PRESENT == 1
 
 #include "uvisor-lib/benchmark.h"
 #include "uvisor-lib/box_config.h"
@@ -40,10 +40,10 @@
 #include "uvisor-lib/secure_access.h"
 #include "uvisor-lib/secure_gateway.h"
 
-#else /* YOTTA_CFG_UVISOR_PRESENT */
+#else /* YOTTA_CFG_UVISOR_PRESENT == 1 */
 
 #include "uvisor-lib/unsupported.h"
 
-#endif /* YOTTA_CFG_UVISOR_PRESENT */
+#endif /* YOTTA_CFG_UVISOR_PRESENT == 1 */
 
 #endif /* __UVISOR_LIB_UVISOR_LIB_H__ */


### PR DESCRIPTION
It is not enough for the `YOTTA_CFG_UVISOR_PRESENT` symbol to be defined; it must be set to 1 (true), so that using yotta cfg for explicitly turning it into false (0) still gives the correct result.

The right approach was already used in other header files (like [here](https://github.com/ARMmbed/uvisor/blob/master/core/mbed/uvisor-lib/override.h#L41)).

This solves https://github.com/ARMmbed/uvisor/issues/107

@meriac 