### PR TITLE
Export uvisor_init with C-compatible binding

### DIFF
--- a/core/mbed/source/unsupported.cpp
+++ b/core/mbed/source/unsupported.cpp
@@ -17,7 +17,7 @@
 #include "uvisor-lib/uvisor-lib.h"
 
 /* uvisor hook for unsupported platforms */
-void __attribute__((section(".uvisor.main"))) uvisor_init(void)
+UVISOR_EXTERN void __attribute__((section(".uvisor.main"))) uvisor_init(void)
 {
     return;
 }


### PR DESCRIPTION
When we replaced all inline assembly with macros, we accidentally removed
UVISOR_EXTERN from the unsupported-target implementation of uvisor_init.
This broke the build of uvisor on unsupported targets. Restore
UVISOR_EXTERN on the uvisor_init implementation to ensure uvisor_init is
exported with a C-compatible binding.

Fixes: 314207ac03f3 ("All explicit inline assembly replaced with macros")