### PR TITLE
Improve security checks on vIRQ APIs

### DIFF
--- a/core/system/inc/unvic.h
+++ b/core/system/inc/unvic.h
@@ -20,6 +20,9 @@
 
 #include "svc.h"
 
+#define UNVIC_IS_IRQ_ENABLED(irqn) (NVIC->ISER[(((uint32_t) ((int32_t) (irqn))) >> 5UL)] & \
+                                    (uint32_t) (1UL << (((uint32_t) ((int32_t) (irqn))) & 0x1FUL)))
+
 #define UNVIC_MIN_PRIORITY (uint32_t) 1
 
 #define IRQn_OFFSET            16


### PR DESCRIPTION
The `unvic_acl_check(irqn)` function now returns whether `irqn` is registered or not.

This information is used by specific APIs to decide whether a state can be changed
for a certain interrupt. In particular:
- setting/clearing pending status for IRQs is only possible when they are registered
- enabling/disabling IRQs is possible even if IRQn is unregistered but only if
  this does not change the current state (enabled/disabled); this loosens a bit
  the requirement on function calls order for vIRQ APIs
- setting the priority of unregistered IRQs will always fail

The consequences of these changes are that, as a best practice, all IRQs should always registered (`vIRQ_SetVector(irqn, isr)`) before being enabled/disabled/set as pending/etc. Common patterns as clearing the pending bit before enabling an interrupt are still valid (and encouraged), but they require the vector to be set first (i.e., registered).

@meriac 