### PR TITLE
Fix bug on 0-args secure gateway

### DIFF
--- a/core/mbed/uvisor-lib/secure_gateway.h
+++ b/core/mbed/uvisor-lib/secure_gateway.h
@@ -37,8 +37,7 @@
 #define secure_gateway(dst_box, dst_fn, ...) \
     ({ \
         uint32_t res = UVISOR_SVC(UVISOR_SVC_ID_SECURE_GATEWAY(UVISOR_MACRO_NARGS(__VA_ARGS__)), \
-                                  __UVISOR_SECURE_GATEWAY_METADATA(dst_box, dst_fn), \
-                                  __VA_ARGS__); \
+                                  __UVISOR_SECURE_GATEWAY_METADATA(dst_box, dst_fn), ##__VA_ARGS__); \
         res; \
     })
 


### PR DESCRIPTION
A secure gateway with 0 arguments gave a compilation error since macro
overloading was not done properly.

GNU CPP mandates that in order to have comma swallowing when using
```C
, ## __VA_ARGS__
```
`__VA_ARGS__` must be left out completely; if it's not left out the extension
does not apply, even if `__VA_ARGS__` is an empty token.

The bug was similar to the following example:
```C
#define MACRO1(a0, ...) MACRO2(a0, __VA_ARGS__)                    // bug here
#define MACRO2(a0, ...) FINALLY_DO_SOMETHING(a0, ##__VA_ARGS__)
```
Since the GNU CPP extension is not used in MACRO1, the one in MACRO2 is ineffective,
since an empty token (not a missing token) is sent to MACRO2.

@meriac 
@Patater 