### PR TITLE
Background ACLs for AIPS periph added to each box

### DIFF
--- a/core/system/src/mpu/vmpu_freescale_k64_aips.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_aips.c
@@ -29,7 +29,7 @@ static uint32_t g_aipsx_exc[AIPSx_DWORDS];
 
 int vmpu_aips_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
 {
-    int i, slot_count;
+    int i, slot_count, box_count;
     uint8_t aips_slot;
     uint32_t base, t, address;
 
@@ -79,11 +79,6 @@ int vmpu_aips_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
     }
     slot_count -= aips_slot;
 
-
-    /* initialize box[0] ACL's as background regions */
-    if(box_id)
-        memcpy(g_aipsx_box[box_id], g_aipsx_box[0], sizeof(g_aipsx_box[0]));
-
     /* iterate through all slots */
     while(slot_count--)
     {
@@ -99,8 +94,18 @@ int vmpu_aips_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
 
         /* ensure we have a list of all peripherals */
         g_aipsx_all[i] |= t;
+
         /* remember box-specific peripherals */
-        g_aipsx_box[box_id][i] |= t;
+        if (box_id) {
+            g_aipsx_box[box_id][i] |= t;
+        }
+        else {
+            /* box 0 ACLs are applied to all boxes */
+            for (box_count = 0; box_count <= g_vmpu_box_count; box_count++) {
+                g_aipsx_box[box_count][i] |= t;
+            }
+        }
+
         /* remember exclusive peripherals */
         if( (acl & UVISOR_TACL_SHARED) == 0 )
             g_aipsx_exc[i] |= t;


### PR DESCRIPTION
When a new ACL (AIPS) was added to a box, a `memcpy` was always performed to copy
box 0 ACLs, overriding the previously-scanned ACLs for that box. This commit
fixes that bug by removing the `memcpy` and or-ing all boxes ACLs with the ones
from box 0, when box 0 is parsed.

@meriac 
@Patater 