### PR TITLE
Disable interrupt when releasing ownership of IRQn

### DIFF
--- a/core/system/src/unvic.c
+++ b/core/system/src/unvic.c
@@ -107,9 +107,17 @@ void unvic_isr_set(uint32_t irqn, uint32_t vector, uint32_t flag)
      * note: if the handler is NULL the IRQn gets de-registered for the current
      *       box, meaning that other boxes can still use it. In this way boxes
      *       can share un-exclusive IRQs. A secure box should not do that if it
-     *       wants to hold exclusivity over an IRQn */
+     *       wants to hold exclusivity over an IRQn
+     * note: when an IRQ is released (de-registered) the corresponding IRQn is
+     *       disabled, to ensure that no spurious interrupts are served */
+    if (vector) {
+        g_unvic_vector[irqn].id = svc_cx_get_curr_id();
+    }
+    else {
+        NVIC_DisableIRQ(irqn);
+        g_unvic_vector[irqn].id = 0;
+    }
     g_unvic_vector[irqn].hdlr = (TIsrVector) vector;
-    g_unvic_vector[irqn].id   = vector ? svc_cx_get_curr_id() : 0;
 
     /* set default priority (SVC must always be higher) */
     NVIC_SetPriority(irqn, UNVIC_MIN_PRIORITY);


### PR DESCRIPTION
If an IRQn is released (de-registered) but left enabled, a spurious interrupt could be served.

When serving an interrupt we trust the information that we hold for the IRQn, that is, the ID of the interrupt owner and the ISR vector.

**More details**
If an interrupt is released but it is still enabled, when it gets served the default handler `__unvic_svc_cx_in()` wil see the following:
ID of owner: `0`
associated ISR: `0x0`
and it will serve it without any further check (some default checks are implemented in `unvic_default_check()` but they do not cover this corner case; see [this previous comment](https://github.com/ARMmbed/uvisor/blob/master/core/system/src/unvic.c#L323)).

@meriac 
@Patater 