### PR TITLE
Export symbol of max priority level allowed (users)

### DIFF
--- a/core/mbed/uvisor-lib/uvisor-lib.h
+++ b/core/mbed/uvisor-lib/uvisor-lib.h
@@ -28,6 +28,7 @@
 #include "uvisor-lib/halt_exports.h"
 #include "uvisor-lib/svc_exports.h"
 #include "uvisor-lib/svc_gw_exports.h"
+#include "uvisor-lib/unvic_exports.h"
 
 /* conditionally included header files */
 #if YOTTA_CFG_UVISOR_PRESENT == 1

--- a/core/system/inc/unvic.h
+++ b/core/system/inc/unvic.h
@@ -19,11 +19,10 @@
 #define __UNVIC_H__
 
 #include "svc.h"
+#include "unvic_exports.h"
 
 #define UNVIC_IS_IRQ_ENABLED(irqn) (NVIC->ISER[(((uint32_t) ((int32_t) (irqn))) >> 5UL)] & \
                                     (uint32_t) (1UL << (((uint32_t) ((int32_t) (irqn))) & 0x1FUL)))
-
-#define UNVIC_MIN_PRIORITY (uint32_t) 1
 
 #define IRQn_OFFSET            16
 #define ISR_VECTORS            ((IRQn_OFFSET) + (HW_IRQ_VECTORS))

--- a/core/system/inc/unvic_exports.h
+++ b/core/system/inc/unvic_exports.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UNVIC_EXPORTS_H__
+#define __UNVIC_EXPORTS_H__
+
+/* this value refers to the minimum allowable priority in the physical NVIC
+ * module, but not in the virtualised one (vIRQ) */
+#define __UVISOR_NVIC_MIN_PRIORITY ((uint32_t) 1)
+
+/* this is the maximum priority allowed for the vIRQ module */
+/* users of uVisor APIs can use this to determine the maximum level of
+ * priorities available to them */
+#define UVISOR_VIRQ_MAX_PRIORITY ((uint32_t) (1 << __NVIC_PRIO_BITS) - 1 - __UVISOR_NVIC_MIN_PRIORITY)
+
+#endif/*__UNVIC_EXPORTS_H__*/

--- a/core/system/src/unvic.c
+++ b/core/system/src/unvic.c
@@ -237,11 +237,10 @@ void unvic_irq_priority_set(uint32_t irqn, uint32_t priority)
     }
 
     /* set priority for device specific interrupts */
-    NVIC_SetPriority(irqn, __UVISOR_NVIC_MIN_PRIORITY + priority);
-
     if (is_irqn_registered) {
-        DPRINTF("IRQ %d priority set to %d\n\r", irqn, priority);
-        NVIC_SetPriority(irqn, priority);
+        DPRINTF("IRQ %d priority set to %d (NVIC), %d (virtual)\n\r", irqn, __UVISOR_NVIC_MIN_PRIORITY + priority,
+                                                                            priority);
+        NVIC_SetPriority(irqn, __UVISOR_NVIC_MIN_PRIORITY + priority);
         return;
     }
     else {


### PR DESCRIPTION
With the classic NVIC module, a user would typically use `__NVIC_PRIO_BITS` to
determine the max priority level available. This commit makes sure that a
similar macro is exported for vIRQ users. Currently the symbol still relies on
`__NVIC_PRIO_BITS`, but this could change in the future if more complex
virtualisation is implemented.

Note that the minimum NVIC priority must be exported as well, but the name
has been prefixed with a double underscore to avoid that users use it
explicitly (it would make no sense as the NVIC module cannot be accessed
directly).