### PR TITLE
Fix box enumeration

### DIFF
--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -125,6 +125,9 @@ extern void vmpu_init_post(void);
 
 extern void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp);
 
+/* contains the total number of boxes
+ * boxes are enumerated from 0 to (g_vmpu_box_count - 1) and the following
+ * condition must hold: g_vmpu_box_count < UVISOR_MAX_BOXES */
 extern uint32_t  g_vmpu_box_count;
 
 extern uint32_t vmpu_register_gateway(uint32_t addr, uint32_t val);

--- a/core/system/src/mpu/vmpu_freescale_k64_aips.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_aips.c
@@ -101,7 +101,7 @@ int vmpu_aips_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
         }
         else {
             /* box 0 ACLs are applied to all boxes */
-            for (box_count = 0; box_count <= g_vmpu_box_count; box_count++) {
+            for (box_count = 0; box_count < g_vmpu_box_count; box_count++) {
                 g_aipsx_box[box_count][i] |= t;
             }
         }


### PR DESCRIPTION
With this PR boxes are enumerated more consistently.
Boxes IDs go from `0` to `(g_vmpu_box_count - 1)` and the following condition must hold:
```g_vmpu_box_count < UVISOR_MAX_BOXES```

The PR also fixes the bug for which ACLs were parsed before boxes were fully enumerated;
in that case box 0 ACLs were not applied to all boxes, but only to the boxes enumerated
so far.

@meriac 
@Patater 