### PR TITLE
Add explicit vIRQ_SetVector API to override.h (mbed)

### DIFF
--- a/core/mbed/uvisor-lib/override.h
+++ b/core/mbed/uvisor-lib/override.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 extern void vIRQ_SetVectorX(uint32_t irqn, uint32_t vector, uint32_t flag);
+extern void vIRQ_SetVector(uint32_t irqn, uint32_t vector);
 extern uint32_t vIRQ_GetVector(uint32_t irqn);
 extern void vIRQ_EnableIRQ(uint32_t irqn);
 extern void vIRQ_DisableIRQ(uint32_t irqn);
@@ -35,8 +36,6 @@ extern void vIRQ_SetPendingIRQ(uint32_t irqn);
 extern uint32_t vIRQ_GetPendingIRQ(uint32_t irqn);
 extern void vIRQ_SetPriority(uint32_t irqn, uint32_t priority);
 extern uint32_t vIRQ_GetPriority(uint32_t irqn);
-
-#define vIRQ_SetVector(irqn, vector) vIRQ_SetVectorX((uint32_t) (irqn), (uint32_t) (vector), 0)
 
 #if YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(UVISOR_NO_HOOKS)
 


### PR DESCRIPTION
In this previous commit:
https://github.com/ARMmbed/uvisor/commit/f83a82d881207f28ce01bd34e67d8df9dd0b9822
`vIRQ_SetVector` has been turned in an actual API instead of a preprocessor macro
redefinition.

This commit mirrors that change to the `override.h` file, which is used in mbed
to override NVIC symbols when one does not want to replace them manually in the
source code.

An example use case:
https://github.com/ARMmbed/mbed-hal-st-stm32f4/blob/master/source/hal_tick.c#L36.

@Patater 
@meriac 