### PR TITLE
Add comment to clarify the 0x10000000 is CCM SRAM.

### DIFF
--- a/core/linker/STM32F429xx.h
+++ b/core/linker/STM32F429xx.h
@@ -17,5 +17,9 @@
 #define FLASH_ORIGIN 0x08000000
 #define FLASH_LENGTH 0x200000
 
+/* 
+ * 0x10000000 is the start address of CCM SRAM,
+ * 0x20000000 is the start address of normal SRAM.
+ */
 #define SRAM_ORIGIN  0x10000000
 #define SRAM_LENGTH  0x10000


### PR DESCRIPTION
Usually,the start address of SRAM in STM32F429i-Discovery means 0x20000000.
Adding some comments may reduce the confusion about the address.
Thanks!