### PR TITLE
Remove need of SRAM_LENGTH and FLASH_LENGTH

### DIFF
--- a/core/mbed/source/uvisor-input.S
+++ b/core/mbed/source/uvisor-input.S
@@ -78,6 +78,12 @@ uvisor_config:
     /* pointer to __uvisor_box_context */
     .long __uvisor_box_context
 
+    /* Physical memories' boundaries */
+    .long __uvisor_flash_start;
+    .long __uvisor_flash_end;
+    .long __uvisor_sram_start;
+    .long __uvisor_sram_end;
+
 __uvisor_mode:
     /* uvisor default mode - user can override weak reference */
     .long 0

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -62,6 +62,12 @@ typedef struct {
 
     /* address of __uvisor_box_context */
     uint32_t **uvisor_box_context;
+
+    /* Physical memories' boundaries */
+    uint32_t *flash_start;
+    uint32_t *flash_end;
+    uint32_t *sram_start;
+    uint32_t *sram_end;
 } UVISOR_PACKED UvisorConfig;
 
 UVISOR_EXTERN const UvisorConfig __uvisor_config;

--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -20,9 +20,23 @@
 #include "vmpu_exports.h"
 #include "vmpu_unpriv_access.h"
 
-#define VMPU_FLASH_ADDR_MASK  (~(((uint32_t)(FLASH_LENGTH)) - 1))
-#define VMPU_FLASH_ADDR(addr) ((VMPU_FLASH_ADDR_MASK & (uint32_t)(addr)) == \
-                               (FLASH_ORIGIN & VMPU_FLASH_ADDR_MASK))
+/* Check if the address is in Flash/SRAM. */
+/* Note: Instead of using the '<' check on
+ *          __uvisor_config.{flash, sram}_end
+ *       we use the '<=' check on
+ *          __uvisor_config.{flash, sram}_end - 4
+ *       because unaligned accesses at a physical memory boundary have undefined
+ *       behavior and must be avoided. */
+static inline int vmpu_flash_addr(uint32_t addr)
+{
+    return (((uint32_t) addr >= FLASH_ORIGIN) &&
+            ((uint32_t) addr <= (FLASH_ORIGIN + (uint32_t) __uvisor_config.flash_end - 4)));
+}
+static inline int vmpu_sram_addr(uint32_t addr)
+{
+    return (((uint32_t) addr >= SRAM_ORIGIN) &&
+            ((uint32_t) addr <= (SRAM_ORIGIN + (uint32_t) __uvisor_config.sram_end - 4)));
+}
 
 #define VMPU_REGION_SIZE(p1, p2) ((p1 >= p2) ? 0 : \
                                              ((uint32_t) (p2) - (uint32_t) (p1)))

--- a/core/system/inc/mpu/vmpu_freescale_k64_map.h
+++ b/core/system/inc/mpu/vmpu_freescale_k64_map.h
@@ -18,7 +18,6 @@
 #define __VMPU_FREESCALE_K64_MAP_H__
 
 #define MEMORY_MAP_SRAM_START       ((uint32_t) SRAM_ORIGIN)
-#define MEMORY_MAP_SRAM_END         ((uint32_t) (SRAM_ORIGIN + SRAM_LENGTH))
 #define MEMORY_MAP_PERIPH_START     ((uint32_t) 0x40000000)
 #define MEMORY_MAP_PERIPH_END       ((uint32_t) 0x400FEFFF)
 #define MEMORY_MAP_GPIO_START       ((uint32_t) 0x400FF000)

--- a/core/system/inc/svc_gw.h
+++ b/core/system/inc/svc_gw.h
@@ -35,7 +35,7 @@ typedef struct {
 
 static inline void svc_gw_check_magic(TSecGw *svc_pc)
 {
-    if(!VMPU_FLASH_ADDR(svc_pc))
+    if(!vmpu_flash_addr((uint32_t) svc_pc))
         HALT_ERROR(SANITY_CHECK_FAILED,
                    "secure gateway not in flash (0x%08X)", svc_pc);
 

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -256,7 +256,8 @@ void vmpu_mem_init(void)
         HALT_ERROR(SANITY_CHECK_FAILED, "failed setting up SRAM_ORIGIN (%i)\n", res);
 
     /* rest of SRAM, accessible to mbed - non-executable for uvisor */
-    res = vmpu_mem_add_int(0, __uvisor_config.bss_end, (SRAM_ORIGIN+SRAM_LENGTH)-((uint32_t)__uvisor_config.bss_end),
+    res = vmpu_mem_add_int(0, __uvisor_config.bss_end,
+        ((uint32_t) __uvisor_config.sram_end) - ((uint32_t) __uvisor_config.bss_end),
         UVISOR_TACL_SREAD|
         UVISOR_TACL_SWRITE|
         UVISOR_TACL_UREAD|


### PR DESCRIPTION
The 2 symbols `SRAM_LENGTH` and `FLASH_LENGTH` are now fetched from Flash at boot time, and are provided by the host linker script.

Sanity checks have been updated accordingly. A new sanity check verifies that the values read from flash are the same as expected from the hard-coded uVisor symbols, when available.

**Note**: The symbols `FLASH_LENGTH` and `SRAM_LENGTH` are not removed. They are used only once to pre-process the uVisor linker script and to determine if the Flash/SRAM usage fits into the target device:
```C
#define FLASH_MAX (FLASH_LENGTH - RESERVED_FLASH)
#define SRAM_MAX  (SRAM_LENGTH - RESERVED_SRAM)
```
When a single uVisor port will support multiple chips at a time (ideally, a whole family), they will represent the **minimum** Flash/SRAM length needed to have uVisor fit into the target memories for that family. 

Requires a PR with [these changes](https://github.com/ARMmbed/target-kinetis-k64-gcc/compare/master...AlessandroA:master?expand=1) (mbed linker script).

@meriac 
@Patater 