### PR TITLE
Improve comment on NONBASETHRDENA bit

### DIFF
--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -343,9 +343,9 @@ int vmpu_init_pre(void)
 
 void vmpu_init_post(void)
 {
-    /* enable non-base thread mode */
-    /* exceptions can now return to thread mode regardless their origin
-     * (supervisor or thread mode); the opposite is not true */
+    /* Enable non-base thread mode (NONBASETHRDENA).
+     * Exceptions can now return to thread mode regardless their origin
+     * (supervisor or thread mode); the opposite is not true. */
     SCB->CCR |= 1;
 
     /* init memory protection */


### PR DESCRIPTION
The bit is set but it's name does not appear explicitly, which makes it
difficult to `grep`. It is important for this information to stand out as the
feature is vital for interrupts de-privileging.

@Patater @meriac 