### PR TITLE
Fix conditional macros definition in exported file

### DIFF
--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -48,11 +48,11 @@
 #define UVISOR_TACL_IRQ             0x1000UL
 
 /* subregion mask for ARMv7M */
-#ifdef  ARCH_MPU_ARMv7M
+#if defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS))
 #define UVISOR_TACL_SUBREGIONS_POS  24
 #define UVISOR_TACL_SUBREGIONS_MASK (0xFFUL<<UVISOR_TACL_SUBREGIONS_POS)
 #define UVISOR_TACL_SUBREGIONS(x)   ( (((uint32_t)(x))<<UVISOR_TACL_SUBREGIONS_POS) & UVISOR_TACL_SUBREGIONS_MASK )
-#endif/*ARCH_MPU_ARMv7M*/
+#endif /* defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS)) */
 
 #define UVISOR_TACLDEF_SECURE_BSS   (UVISOR_TACL_UREAD          |\
                                      UVISOR_TACL_UWRITE         |\
@@ -88,16 +88,18 @@
 #define UVISOR_MIN_STACK_SIZE       1024
 #define UVISOR_MIN_STACK(x)         (((x)<UVISOR_MIN_STACK_SIZE)?UVISOR_MIN_STACK_SIZE:(x))
 
-#ifdef  ARCH_MPU_MK64F
-#define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~0x1FUL)
-#define UVISOR_REGION_ROUND_UP(x)   UVISOR_REGION_ROUND_DOWN((x)+31UL)
-#define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP((x) + \
-                                    (UVISOR_STACK_BAND_SIZE * 2))
-#else /*ARCH_MPU_ARMv7M*/
-#define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~((1UL<<UVISOR_REGION_BITS(x))-1))
-#define UVISOR_REGION_ROUND_UP(x)   (1UL<<UVISOR_REGION_BITS(x))
+#if defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS))
+#define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~((1UL << UVISOR_REGION_BITS(x)) - 1))
+#define UVISOR_REGION_ROUND_UP(x)   (1UL << UVISOR_REGION_BITS(x))
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP(x)
-#endif/*ARCH_MPU_ARMv7M*/
+#elif defined(ARCH_MPU_MK64F) || (defined(YOTTA_CFG_UVISOR_PRESENT) && defined(TARGET_LIKE_KINETIS))
+#define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~0x1FUL)
+#define UVISOR_REGION_ROUND_UP(x)   UVISOR_REGION_ROUND_DOWN((x) + 31UL)
+#define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP((x) + (UVISOR_STACK_BAND_SIZE * 2))
+#else
+#error "Unknown MPU architecture. uvisor: Check your Makefile. uvisor-lib: Check if uVisor is supported"
+#endif /* defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS)) or
+          defined(ARCH_MPU_MK64F) || (defined(YOTTA_CFG_UVISOR_PRESENT) && defined(TARGET_LIKE_KINETIS)) */
 
 #ifndef UVISOR_BOX_STACK_SIZE
 #define UVISOR_BOX_STACK_SIZE UVISOR_MIN_STACK_SIZE


### PR DESCRIPTION
`vmpu_export.h` is exported to mbed, which means that the definitions `ARCH_MPU_*`
do not apply. The wrong macros for rounding were selected.

Now the file checks for either the uvisor-facing definitions or for the uvisor-lib-facing ones.

@Patater @meriac 