### PR TITLE
Fix conditional macro def. (unsupported device)

### DIFF
--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -52,7 +52,7 @@
 #define UVISOR_TACL_SUBREGIONS_POS  24
 #define UVISOR_TACL_SUBREGIONS_MASK (0xFFUL<<UVISOR_TACL_SUBREGIONS_POS)
 #define UVISOR_TACL_SUBREGIONS(x)   ( (((uint32_t)(x))<<UVISOR_TACL_SUBREGIONS_POS) & UVISOR_TACL_SUBREGIONS_MASK )
-#endif /* defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS)) */
+#endif
 
 #define UVISOR_TACLDEF_SECURE_BSS   (UVISOR_TACL_UREAD          |\
                                      UVISOR_TACL_UWRITE         |\
@@ -98,8 +98,7 @@
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP((x) + (UVISOR_STACK_BAND_SIZE * 2))
 #else
 #error "Unknown MPU architecture. uvisor: Check your Makefile. uvisor-lib: Check if uVisor is supported"
-#endif /* defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS)) or
-          defined(ARCH_MPU_KINETIS) || (defined(YOTTA_CFG_UVISOR_PRESENT) && defined(TARGET_LIKE_KINETIS)) */
+#endif
 
 #ifndef UVISOR_BOX_STACK_SIZE
 #define UVISOR_BOX_STACK_SIZE UVISOR_MIN_STACK_SIZE

--- a/core/system/inc/mpu/vmpu_exports.h
+++ b/core/system/inc/mpu/vmpu_exports.h
@@ -48,7 +48,7 @@
 #define UVISOR_TACL_IRQ             0x1000UL
 
 /* subregion mask for ARMv7M */
-#if defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS))
+#if defined(ARCH_MPU_ARMv7M) || (YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(TARGET_LIKE_KINETIS))
 #define UVISOR_TACL_SUBREGIONS_POS  24
 #define UVISOR_TACL_SUBREGIONS_MASK (0xFFUL<<UVISOR_TACL_SUBREGIONS_POS)
 #define UVISOR_TACL_SUBREGIONS(x)   ( (((uint32_t)(x))<<UVISOR_TACL_SUBREGIONS_POS) & UVISOR_TACL_SUBREGIONS_MASK )
@@ -88,14 +88,18 @@
 #define UVISOR_MIN_STACK_SIZE       1024
 #define UVISOR_MIN_STACK(x)         (((x)<UVISOR_MIN_STACK_SIZE)?UVISOR_MIN_STACK_SIZE:(x))
 
-#if defined(ARCH_MPU_ARMv7M) || (defined(YOTTA_CFG_UVISOR_PRESENT) && !defined(TARGET_LIKE_KINETIS))
+#if defined(ARCH_MPU_ARMv7M) || (YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(TARGET_LIKE_KINETIS))
 #define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~((1UL << UVISOR_REGION_BITS(x)) - 1))
 #define UVISOR_REGION_ROUND_UP(x)   (1UL << UVISOR_REGION_BITS(x))
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP(x)
-#elif defined(ARCH_MPU_KINETIS) || (defined(YOTTA_CFG_UVISOR_PRESENT) && defined(TARGET_LIKE_KINETIS))
+#elif defined(ARCH_MPU_KINETIS) || (YOTTA_CFG_UVISOR_PRESENT == 1 && defined(TARGET_LIKE_KINETIS))
 #define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~0x1FUL)
 #define UVISOR_REGION_ROUND_UP(x)   UVISOR_REGION_ROUND_DOWN((x) + 31UL)
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP((x) + (UVISOR_STACK_BAND_SIZE * 2))
+#elif !defined(YOTTA_CFG_UVISOR_PRESENT) || YOTTA_CFG_UVISOR_PRESENT == 0
+#define UVISOR_REGION_ROUND_DOWN(x) (x)
+#define UVISOR_REGION_ROUND_UP(x)   (x)
+#define UVISOR_STACK_SIZE_ROUND(x)  (x)
 #else
 #error "Unknown MPU architecture. uvisor: Check your Makefile. uvisor-lib: Check if uVisor is supported"
 #endif


### PR DESCRIPTION
The changes introduced in the previous commit (see below) introduced a
further bug for unsupported devices, for which an "Unknown MPU" error
message was thrown.

For unsupported devices the rounding macros are bypassed. No rounding is
applied.

Fixes: 143c256f5ba6 ("Fix conditional macros definition in exported file")

@Patater 
@meriac 