### PR TITLE
Add warning in README after refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Further reading:
 uVisor in the press:
 - [Q&A with ARM](http://eecatalog.com/IoT/2015/08/18/qa-with-arm-securing-the-iot-using-arm-cortex-processors-and-a-growing-mbed-platform-suite/): Securing the IoT using ARM Cortex Processors, and a growing mbed platform suite
 
+### Warning: Enabling Debug Features on uVisor
+Please note that currently the latest version of uVisor (the `HEAD` of the `uvisor` repository) does not support the following features:
+* LED blinking patterns
+* Memory mapped debugging
+
+This means that the support for hardware-specific debugging is temporarily unavailable. If you want to revert back to a version of uVisor that still supports those features, please checkout the `uvisor_with_memory_map_debug` branch:
+```bash
+git clone --recursive -b uvisor_with_memory_map_debug git@github.com:ARMmbed/uvisor.git
+```
+This command will clone both `uvisor` and `uvisor-lib`. You can then build uVisor as usual, as reported in [the branch `README.md`](https://github.com/ARMmbed/uvisor/blob/uvisor_with_memory_map_debug/README.md).
+
 ### Word of Caution
 This version of the uVisor is an early technology preview with an **incomplete implementation of the security features** of the final product. Future versions of uVisor will add these functions.
 


### PR DESCRIPTION
The `README` now includes a warning on the debug features that have been
temporarily removed from uVisor after the refactoring. It also includes
instructions on how to fetch a fallback branch that is kept for users to
use the features in a previous uVisor version.

Note: The `README` on that branch (`uvisor_with_memory_map_debug`) does
not include this warning. It will present the old building instructions
normally as they apply to the old version of uVisor.

@meriac 
@Patater 