### PR TITLE
Fix the Kinetis Makefile for debug releases

### DIFF
--- a/platform/kinetis/Makefile
+++ b/platform/kinetis/Makefile
@@ -42,7 +42,7 @@ kinetis_r:
 kinetis_d:
 	$(foreach CONFIGURATION, \
 	          $(CONFIGURATIONS), \
-	          CONFIGURATION=$(CONFIGURATION) OPT= make -f ../../core/Makefile.rules clean release)
+	          CONFIGURATION=$(CONFIGURATION) make OPT= -f ../../core/Makefile.rules clean release)
 
 # We include the main Makefile so that global rules are still available.
 include ../../core/Makefile.rules


### PR DESCRIPTION
The `OPT=` configuration was not properly passed to the sub-make hence
generating a release binary even with the `kinetis_d` make rule.

Fixes: 7d60c75 ("Re-add support for K64F after refactoring ")

@Patater 