### PR TITLE
Fix bug in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ source.c.tags: $(SOURCES)
 	CFLAGS="$(CFLAGS_PRE)" geany -g $@ $^
 
 __rm_objs:
-	find $(ROOT_DIR) -iname '*.o' -not -path "$(MBED_DIR)/*" -delete
+	find $(ROOT_DIR) -iname '*.o' -not -path "$(RELEASE_DIR)/*" -not -path "$(MBED_DIR)/*" -delete
 
 clean:
 	rm -f source.c.tags


### PR DESCRIPTION
The removal of object files between builds must exclude the release
folder as well.

Fixes: 327a925 ("Fix bug in makefile for debug/release builds")

@meriac @Patater 