### PR TITLE
Allow owning system IRQs with UVISOR_DISABLED

### DIFF
--- a/core/mbed/source/disabled.cpp
+++ b/core/mbed/source/disabled.cpp
@@ -139,11 +139,11 @@ static void uvisor_disabled_default_vector(void)
     int ipsr;
 
     /* Get current IRQ number, from the IPSR.
-     * We only allow user IRQs to be registered (NVIC). This is consistent with
-     * the corresponding API when uVisor is enabled. */
+     * We also allow system IRQs. This is inconsistent with the uVisor API, so
+     * code written before uVisor might stop working when uVisor is enabled. */
     irqn = 0;
     ipsr = ((int) (__get_IPSR() & 0x1FF)) - NVIC_USER_IRQ_OFFSET;
-    if (ipsr < 0 || ipsr >= NVIC_USER_IRQ_NUMBER) {
+    if (ipsr < NonMaskableInt_IRQn || ipsr >= NVIC_USER_IRQ_NUMBER) {
         uvisor_error(USER_NOT_ALLOWED);
     } else {
         irqn = (uint32_t) ipsr;


### PR DESCRIPTION
Code written to work with uVisor would never touch system IRQs because
they are restricted. So if `__uvisor_mode == UVISOR_DISABLED` it was
natural to only allow user IRQs in interrupt manipulation (`vIRQ_*`
APIs).

The problem is that `__uvisor_mode == UVISOR_DISABLED` also when code
was not written to work with uVisor but it runs on a supported platform
(by default a supported platform has `YOTTA_CFG_UVISOR_PRESENT == 1` but
`__uvisor_mode == UVISOR_DISABLED`).

**This commit allows `vIRQ_*` APIs to work with system IRQs when the
uVisor is disabled.**

Fixes: ARMmbed/uvisor-lib#36 ("uvisor will not allow SysTick_IRQn to be reconfigured")
Fixes: e44d0c8 ("Add IRQ context switch fallback for disabled.cpp")

@meriac @Patater 