### PR TITLE
Makefile: Create new platform BUILD_MODE folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ yotta: $(BINARY_RELEASE)
 	rm -f $(RELEASE_SRC)/*.cpp
 	rm -f $(RELEASE_OBJ) $(RELEASE_VER)
 	mkdir -p $(RELEASE_INC)
-	mkdir -p $(RELEASE_SRC)/$(PLATFORM)
+	mkdir -p $(RELEASE_SRC)/$(PLATFORM)/$(BUILD_MODE)
 	echo "$(PROGRAM_VERSION)" > $(RELEASE_SRC)/$(PLATFORM)/version.txt
 	cp $(MBED_INC)/*.h   $(RELEASE_INC)/
 	cp $(MBED_SRC)/*.cpp $(RELEASE_SRC)/


### PR DESCRIPTION
Automatically create new platform BUILD_MODE (debug, release) folders in
the uvisor-lib. Without this, the uvisor build will fail for new platforms.

@AlessandroA 
@meriac