### PR TITLE
Distinguish between ARM Cortex-M3 and M4 cores

### DIFF
--- a/core/cmsis/inc/core_generic.h
+++ b/core/cmsis/inc/core_generic.h
@@ -62,10 +62,9 @@ typedef enum IRQn {
 
 /* Include the CMSIS core header files.
  * The Cortex-M specification must be defined by the release configuration. */
-/* FIXME The Cortex-M3 and -M4 header files also differ for the fact that the
- *       SCnSCB->ACTRL was introduced with REV 0x200. All bus faults on a
- *       Cortex-M3 device produced before that revision will be imprecise. */
-#if defined(CORE_CORTEX_M3) || defined(CORE_CORTEX_M4)
+#if defined(CORE_CORTEX_M3)
+#include "core_cm3.h"
+#elif defined(CORE_CORTEX_M4)
 #include "core_cm4.h"
 #else /* defined(CORE_CORTEX_M3) || defined(CORE_CORTEX_M4) */
 #error "Unsupported ARM core. Make sure CORE_* is defined in your workspace."

--- a/core/cmsis/inc/core_generic.h
+++ b/core/cmsis/inc/core_generic.h
@@ -28,8 +28,8 @@
 #if defined(ARCH_MPU_ARMv7M)
 #define __MPU_PRESENT 1
 #elif defined(ARCH_MPU_KINETIS)
-#else
 #define __MPU_PRESENT 0
+#else
 #error "Unknown MPU architecture. Check your Makefile."
 #endif /* defined(ARCH_MPU_ARMv7M) || defined(ARCH_MPU_KINETIS) */
 

--- a/core/cmsis/inc/core_generic.h
+++ b/core/cmsis/inc/core_generic.h
@@ -47,6 +47,10 @@
 extern uint8_t g_nvic_prio_bits;
 #define __NVIC_PRIO_BITS g_nvic_prio_bits
 
+/* This ensures that the CMSIS header files actively check for our
+ * configurations. If a symbol is not configured, a warning is issued. */
+#define __CHECK_DEVICE_DEFINES
+
 /* Core interrupts */
 typedef enum IRQn {
   NonMaskableInt_IRQn   = -14,

--- a/core/cmsis/inc/core_generic.h
+++ b/core/cmsis/inc/core_generic.h
@@ -51,6 +51,10 @@ extern uint8_t g_nvic_prio_bits;
  * configurations. If a symbol is not configured, a warning is issued. */
 #define __CHECK_DEVICE_DEFINES
 
+/* This header file includes the core-specific support for some hardware
+ * features. It might override some of the definitions above. */
+#include "hardware_support.h"
+
 /* Core interrupts */
 typedef enum IRQn {
   NonMaskableInt_IRQn   = -14,

--- a/core/system/inc/hardware_support.h
+++ b/core/system/inc/hardware_support.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __HARDWARE_SUPPORT_H__
+#define __HARDWARE_SUPPORT_H__
+
+/* Architecture specifications */
+#define CORE_IMPLEMENTER  0x41 /* Implementer  == ARM */
+#define CORE_ARCHITECTURE 0xF  /* Architecture == ARMv7-M */
+
+/* Core-specific architecture specifications */
+#if defined(CORE_CORTEX_M3)
+
+/* Note: Currently the revision requirement (>= r2p0) is needed because we use
+ *       the SCnSCB->ACTLR register to disable write buffering in debug mode. */
+#define CORE_PARTNO        0xC23 /* PartNO   == Cortex-M3 */
+#define CORE_REVISTION_MIN 0x2   /* Revision >= r2 */
+#define CORE_VARIANT_MIN   0x0   /* Variant  >= p0 */
+
+#elif defined(CORE_CORTEX_M4)
+
+#define CORE_PARTNO        0xC24 /* PartNO   == Cortex-M4 */
+#define CORE_REVISTION_MIN 0x0   /* Revision >= r0 */
+#define CORE_VARIANT_MIN   0x0   /* Variant  >= p0 */
+
+#else /* defined(CORE_CORTEX_M3) || defined(CORE_CORTEX_M4) */
+
+#error "Unsupported ARM core. Make sure CORE_* is defined in your workspace."
+
+#endif /* Unsupported ARM core */
+
+/* These macros will be used to check the core specifications at runtime.
+ * They return true if the check succeeds. */
+#define CORE_VERSION_CHECK() \
+    ((((SCB->CPUID & SCB_CPUID_IMPLEMENTER_Msk) >> SCB_CPUID_IMPLEMENTER_Pos) == CORE_IMPLEMENTER) && \
+     (((SCB->CPUID & SCB_CPUID_ARCHITECTURE_Msk) >> SCB_CPUID_ARCHITECTURE_Pos) == CORE_ARCHITECTURE) && \
+     (((SCB->CPUID & SCB_CPUID_PARTNO_Msk) >> SCB_CPUID_PARTNO_Pos) == CORE_PARTNO))
+#define CORE_REVISION_CHECK() \
+    ((((SCB->CPUID & SCB_CPUID_VARIANT_Msk) >> SCB_CPUID_VARIANT_Pos) >= CORE_VARIANT_MIN) && \
+     (((SCB->CPUID & SCB_CPUID_REVISION_Msk) >> SCB_CPUID_REVISION_Pos) >= CORE_REVISTION_MIN))
+
+#endif/*__HARDWARE_SUPPORT_H__*/

--- a/core/system/inc/hardware_support.h
+++ b/core/system/inc/hardware_support.h
@@ -30,11 +30,27 @@
 #define CORE_REVISTION_MIN 0x2   /* Revision >= r2 */
 #define CORE_VARIANT_MIN   0x0   /* Variant  >= p0 */
 
+/* This setting enables some conditional definitions in the core_cm3.h file. */
+/* Note: Currently (CMSIS v4.10) the __CM3_REV symbol affects the conditional
+ *       definition of the SCnSCB->ACTLR register and of the SCB_VTOR_TBLBASE_*
+ *       ones. The condition on the SCB_VTOR_TBLBASE_* symbols (revision < r2p1)
+ *       is more restrictive than the one for the SCnSCB->CTRL one (>= r2p0).
+ *       Since in uVisor we don't use the SCB_VTOR_TBLBASE_* symbols, we will
+ *       set the revision version to r2p0, which is a minimum requirement for
+ *       uVisor. */
+#define __CM3_REV 0x200
+
 #elif defined(CORE_CORTEX_M4)
 
 #define CORE_PARTNO        0xC24 /* PartNO   == Cortex-M4 */
 #define CORE_REVISTION_MIN 0x0   /* Revision >= r0 */
 #define CORE_VARIANT_MIN   0x0   /* Variant  >= p0 */
+
+/* This setting enables some conditional definitions in the core_cm4.h file. */
+/* Note: Currently (CMSIS v4.10) the __CM4_REV symbol does not affect any
+ *       conditional definition. Hence we will just set it to the uVisor minimum
+ *       requirement, r0p0. */
+#define __CM4_REV 0x0
 
 #else /* defined(CORE_CORTEX_M3) || defined(CORE_CORTEX_M4) */
 

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -59,6 +59,12 @@ static int vmpu_sanity_checks(void)
     assert(vmpu_bits(0x8001UL) == 16);
     assert(vmpu_bits(1) == 1);
 
+    /* Verify that the core version is the same as expected. */
+    if (!CORE_VERSION_CHECK() || !CORE_REVISION_CHECK()) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "This core is unsupported or there is a mismatch between the uVisor "
+                                        "configuration you are using and the core this configuration supports.\n\r");
+    }
+
     /* Verify that the known hard-coded symbols are equal to the ones taken from
      * the host linker script. */
     assert((uint32_t) __uvisor_config.flash_start == FLASH_ORIGIN);

--- a/core/uvisor.h
+++ b/core/uvisor.h
@@ -30,6 +30,9 @@
 /* CMSIS header files */
 #include "core_generic.h"
 
+/* Definitions and checks for hardware-specific support. */
+#include "hardware_support.h"
+
 /* definitions that are made visible externally */
 #include "uvisor_exports.h"
 

--- a/platform/stm32/inc/configurations.h
+++ b/platform/stm32/inc/configurations.h
@@ -53,7 +53,6 @@
 #define __STM32_HAS_CCM
 
 /* ARM core selection */
-/* Note: uVisor does not distinguish between Cortex-M3 and -M4 cores. */
 #define CORE_CORTEX_M4
 
 /* Memory boundaries */


### PR DESCRIPTION
This PR introduces:
* Distinction between M3 and M4 cores.
* Active runtime check on the actual core and the expected one.
* Explicit set of the CMSIS `__CMx_REV` symbol to ensure that all needed symbols are conditionally defined.

@meriac @Patater 