### PR TITLE
Revert "Allow owning system IRQs with UVISOR_DISABLED"

### DIFF
--- a/core/mbed/source/disabled.cpp
+++ b/core/mbed/source/disabled.cpp
@@ -139,11 +139,11 @@ static void uvisor_disabled_default_vector(void)
     int ipsr;
 
     /* Get current IRQ number, from the IPSR.
-     * We also allow system IRQs. This is inconsistent with the uVisor API, so
-     * code written before uVisor might stop working when uVisor is enabled. */
+     * We only allow user IRQs to be registered (NVIC). This is consistent with
+     * the corresponding API when uVisor is enabled. */
     irqn = 0;
     ipsr = ((int) (__get_IPSR() & 0x1FF)) - NVIC_USER_IRQ_OFFSET;
-    if (ipsr < NonMaskableInt_IRQn || ipsr >= NVIC_USER_IRQ_NUMBER) {
+    if (ipsr < 0 || ipsr >= NVIC_USER_IRQ_NUMBER) {
         uvisor_error(USER_NOT_ALLOWED);
     } else {
         irqn = (uint32_t) ipsr;


### PR DESCRIPTION
This reverts commit b183d4a551eebf3e03e922f140c7d8ee29991331.

The reason for reverting is that NVIC APIs cannot be used with system IRQs
anyway. The previous implementation was not just being backward compatible
with the uVisor-supported APIs, but also (and more importantly) with the
NVIC ones.

@meriac @Patater 