### PR TITLE
Remove duplication of g_active_box

### DIFF
--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -111,8 +111,6 @@ static inline int vmpu_sram_addr(uint32_t addr)
                                                      ((VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(alias) - \
                                                      VMPU_PERIPH_START) << 5)) >> 2)
 
-extern uint8_t g_active_box;
-
 extern void vmpu_acl_add(uint8_t box_id, void *addr,
                          uint32_t size, UvisorBoxAcl acl);
 extern void vmpu_acl_irq(uint8_t box_id, void *function, uint32_t isr_id);

--- a/core/system/inc/svc_cx.h
+++ b/core/system/inc/svc_cx.h
@@ -42,7 +42,7 @@ extern TBoxCx    g_svc_cx_state[UVISOR_SVC_CONTEXT_MAX_DEPTH];
 extern int       g_svc_cx_state_ptr;
 extern uint32_t *g_svc_cx_curr_sp[UVISOR_MAX_BOXES];
 extern uint32_t *g_svc_cx_context_ptr[UVISOR_MAX_BOXES];
-extern uint8_t   g_svc_cx_curr_id;
+extern uint8_t g_active_box;
 
 static inline uint8_t svc_cx_get_src_id(void)
 {
@@ -57,11 +57,6 @@ static inline uint32_t *svc_cx_get_src_sp(void)
 static inline uint32_t *svc_cx_get_curr_sp(uint8_t box_id)
 {
     return g_svc_cx_curr_sp[box_id];
-}
-
-static inline uint8_t svc_cx_get_curr_id(void)
-{
-    return g_svc_cx_curr_id;
 }
 
 static void inline svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src_sp,
@@ -81,7 +76,7 @@ static void inline svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src
         g_svc_cx_curr_sp[src_id] = src_sp;
 
     /* update current box id */
-    g_svc_cx_curr_id = dst_id;
+    g_active_box = dst_id;
 }
 
 static inline void svc_cx_pop_state(uint8_t dst_id, uint32_t *dst_sp)
@@ -98,7 +93,7 @@ static inline void svc_cx_pop_state(uint8_t dst_id, uint32_t *dst_sp)
     g_svc_cx_curr_sp[dst_id] = dst_sp + SVC_CX_EXC_SF_SIZE + dst_sp_align;
 
     /* update current box id */
-    g_svc_cx_curr_id = svc_cx_get_src_id();
+    g_active_box = svc_cx_get_src_id();
 }
 
 uint32_t *svc_cx_validate_sf(uint32_t *sp);

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -39,7 +39,6 @@
 #endif
 
 uint32_t  g_vmpu_box_count;
-uint8_t g_active_box;
 
 static int vmpu_sanity_checks(void)
 {

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -304,9 +304,6 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
     if(!g_mpu_region_count || dst_box>=UVISOR_MAX_BOXES)
         HALT_ERROR(SANITY_CHECK_FAILED, "dst_box out of range (%u)", dst_box);
 
-    /* remember active box */
-    g_active_box = dst_box;
-
     /* update target box first to make target stack available */
     mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
     if (dst_box)

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -229,9 +229,6 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
     if(dst_box>=UVISOR_MAX_BOXES)
         HALT_ERROR(SANITY_CHECK_FAILED, "dst_box out of range (%u)", dst_box);
 
-    /* remember active box */
-    g_active_box = dst_box;
-
     /* switch ACLs for peripherals */
     vmpu_aips_switch(src_box, dst_box);
 

--- a/core/system/src/svc_cx.c
+++ b/core/system/src/svc_cx.c
@@ -24,7 +24,7 @@ TBoxCx    g_svc_cx_state[UVISOR_SVC_CONTEXT_MAX_DEPTH];
 int       g_svc_cx_state_ptr;
 uint32_t *g_svc_cx_curr_sp[UVISOR_MAX_BOXES];
 uint32_t *g_svc_cx_context_ptr[UVISOR_MAX_BOXES];
-uint8_t   g_svc_cx_curr_id;
+uint8_t g_active_box;
 
 void UVISOR_NAKED svc_cx_thunk(void)
 {
@@ -104,7 +104,7 @@ uint32_t __svc_cx_switch_in(uint32_t *svc_sp, uint32_t svc_pc,
 
     /* gather information from current state */
     src_sp = svc_cx_validate_sf(svc_sp);
-    src_id = svc_cx_get_curr_id();
+    src_id = g_active_box;
     dst_sp = svc_cx_get_curr_sp(dst_id);
 
     /* check src and dst IDs */
@@ -161,7 +161,7 @@ void __svc_cx_switch_out(uint32_t *svc_sp)
 
     /* gather information from current state */
     dst_sp = svc_cx_validate_sf(svc_sp);
-    dst_id = svc_cx_get_curr_id();
+    dst_id = g_active_box;
 
     /* gather information from previous state */
     svc_cx_pop_state(dst_id, dst_sp);

--- a/core/system/src/unvic.c
+++ b/core/system/src/unvic.c
@@ -112,7 +112,7 @@ void unvic_isr_set(uint32_t irqn, uint32_t vector, uint32_t flag)
      * note: when an IRQ is released (de-registered) the corresponding IRQn is
      *       disabled, to ensure that no spurious interrupts are served */
     if (vector) {
-        g_unvic_vector[irqn].id = svc_cx_get_curr_id();
+        g_unvic_vector[irqn].id = g_active_box;
     }
     else {
         NVIC_DisableIRQ(irqn);
@@ -126,7 +126,7 @@ void unvic_isr_set(uint32_t irqn, uint32_t vector, uint32_t flag)
     DPRINTF("IRQ %d %s box %d\n\r",
             irqn,
             vector ? "registered to" : "released by",
-            svc_cx_get_curr_id());
+            g_active_box);
 }
 
 uint32_t unvic_isr_get(uint32_t irqn)
@@ -339,7 +339,7 @@ uint32_t __unvic_svc_cx_in(uint32_t *svc_sp, uint32_t svc_pc)
     }
 
     /* gather information from current state */
-    src_id = svc_cx_get_curr_id();
+    src_id = g_active_box;
     src_sp = svc_cx_validate_sf((uint32_t *) __get_PSP());
 
     /* a proper context switch is only needed if changing box */
@@ -414,7 +414,7 @@ void __unvic_svc_cx_out(uint32_t *svc_sp, uint32_t *msp)
     uint32_t *src_sp, *dst_sp;
 
     /* gather information from current state */
-    dst_id = svc_cx_get_curr_id();
+    dst_id = g_active_box;
     dst_sp = svc_cx_validate_sf(svc_sp);
 
     /* gather information from previous state */


### PR DESCRIPTION
A duplicated state was kept in functions from `svc_cx.*`, and it is now
removed.

The state that is now kept is `g_active_box`, which has been moved to
`svc_cx.*` as that is the place where context states are kept.

@meriac @Patater 