### PR TITLE
Introduce consistent use of vmpu_is_box_id_valid

### DIFF
--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -149,4 +149,12 @@ extern int vmpu_box_id_self(void);
 extern int vmpu_box_id_caller(void);
 extern int vmpu_box_namespace_from_id(int box_id, char *box_name, size_t length);
 
+static inline bool vmpu_is_box_id_valid(int box_id)
+{
+    /* Return true if the box_id is valid. This function assumes that
+     * g_vmpu_box_count is valid, which happens after vmpu_load_boxes has been
+     * called. */
+    return box_id >= 0 && box_id < g_vmpu_box_count;
+}
+
 #endif/*__VMPU_H__*/

--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -142,6 +142,7 @@ extern void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp);
  * boxes are enumerated from 0 to (g_vmpu_box_count - 1) and the following
  * condition must hold: g_vmpu_box_count < UVISOR_MAX_BOXES */
 extern uint32_t  g_vmpu_box_count;
+bool g_vmpu_boxes_counted;
 
 extern uint32_t vmpu_register_gateway(uint32_t addr, uint32_t val);
 
@@ -151,10 +152,10 @@ extern int vmpu_box_namespace_from_id(int box_id, char *box_name, size_t length)
 
 static inline bool vmpu_is_box_id_valid(int box_id)
 {
-    /* Return true if the box_id is valid. This function assumes that
-     * g_vmpu_box_count is valid, which happens after vmpu_load_boxes has been
-     * called. */
-    return box_id >= 0 && box_id < g_vmpu_box_count;
+    /* Return true if the box_id is valid.
+     * This function checks box_id against UVISOR_MAX_BOXES if boxes have not
+     * been enumerated yet, otherwise it checks against g_vmpu_box_count. */
+    return (box_id >= 0 && (g_vmpu_boxes_counted ? (box_id < g_vmpu_box_count) : (box_id < UVISOR_MAX_BOXES)));
 }
 
 #endif/*__VMPU_H__*/

--- a/core/system/inc/svc_gw.h
+++ b/core/system/inc/svc_gw.h
@@ -55,12 +55,13 @@ static inline uint32_t svc_gw_get_dst_fn(TSecGw *svc_pc)
 
 static inline uint8_t svc_gw_get_dst_id(TSecGw *svc_pc)
 {
-    uint32_t box_id = svc_pc->cfg_ptr - __uvisor_config.cfgtbl_ptr_start;
+    uint8_t box_id;
 
+    box_id = (uint8_t) ((svc_pc->cfg_ptr - __uvisor_config.cfgtbl_ptr_start) & 0xFF);
     if(box_id <= 0 || box_id >= g_vmpu_box_count)
         HALT_ERROR(SANITY_CHECK_FAILED, "box_id out of range (%i)", box_id);
 
-    return (uint8_t) (box_id & 0xFF);
+    return box_id;
 }
 
 #endif/*__SVC_GW_H__*/

--- a/core/system/inc/svc_gw.h
+++ b/core/system/inc/svc_gw.h
@@ -58,8 +58,12 @@ static inline uint8_t svc_gw_get_dst_id(TSecGw *svc_pc)
     uint8_t box_id;
 
     box_id = (uint8_t) ((svc_pc->cfg_ptr - __uvisor_config.cfgtbl_ptr_start) & 0xFF);
-    if(box_id <= 0 || box_id >= g_vmpu_box_count)
-        HALT_ERROR(SANITY_CHECK_FAILED, "box_id out of range (%i)", box_id);
+
+    /* We explicitly check that box_id is not 0 as we currently do not allow
+     * secure gateways to box 0. */
+    if (!box_id || !vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "Secure gateway: The box ID is out of range (%i).\r\n", box_id);
+    }
 
     return box_id;
 }

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -461,8 +461,7 @@ int vmpu_box_namespace_from_id(int box_id, char *box_namespace, size_t length)
     const UvisorBoxConfig **box_cfgtbl;
     box_cfgtbl = (const UvisorBoxConfig**) __uvisor_config.cfgtbl_ptr_start;
 
-    if (!vmpu_is_box_id_valid(box_id))
-    {
+    if (!vmpu_is_box_id_valid(box_id)) {
         /* The box_id is not valid, so return an error to prevent reading
          * non-box-configuration data from flash. */
         return UVISOR_ERROR_INVALID_BOX_ID;

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -39,6 +39,8 @@
 #endif
 
 uint32_t  g_vmpu_box_count;
+bool g_vmpu_boxes_counted;
+uint8_t g_active_box;
 
 static int vmpu_sanity_checks(void)
 {
@@ -169,6 +171,7 @@ static void vmpu_load_boxes(void)
     if (g_vmpu_box_count >= UVISOR_MAX_BOXES) {
         HALT_ERROR(SANITY_CHECK_FAILED, "box number overflow\n");
     }
+    g_vmpu_boxes_counted = TRUE;
 
     /* initialize boxes */
     box_id = 0;

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -431,14 +431,6 @@ int vmpu_box_id_caller(void)
     return box_ctx->src_id;
 }
 
-static bool vmpu_is_box_id_valid(int box_id)
-{
-    /* Return true if the box_id is valid. This function assumes that
-     * g_vmpu_box_count is valid, which happens after vmpu_load_boxes has been
-     * called. */
-    return box_id >= 0 && box_id < g_vmpu_box_count;
-}
-
 static int copy_box_namespace(const char *src, char *dst)
 {
     int bytes_copied;

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -301,8 +301,13 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
 
     /* DPRINTF("switching from %i to %i\n\r", src_box, dst_box); */
 
-    if(!g_mpu_region_count || dst_box>=UVISOR_MAX_BOXES)
-        HALT_ERROR(SANITY_CHECK_FAILED, "dst_box out of range (%u)", dst_box);
+    /* Sanity checks */
+    if (!g_mpu_region_count) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions left.\r\n");
+    }
+    if (!vmpu_is_box_id_valid(dst_box)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The destination box ID is out of range (%u).\r\n", dst_box);
+    }
 
     /* update target box first to make target stack available */
     mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
@@ -517,8 +522,9 @@ void vmpu_acl_add(uint8_t box_id, void* addr, uint32_t size, UvisorBoxAcl acl)
     if(g_mpu_region_count>=MPU_REGION_COUNT)
         HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_acl_add ran out of regions\n\r");
 
-    if(box_id>=UVISOR_MAX_BOXES)
-        HALT_ERROR(SANITY_CHECK_FAILED, "box_id out of range\n\r");
+    if (!vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box id is out of range (%u).\r\n", box_id);
+    }
 
     /* assign box region pointer */
     box = &g_mpu_box[box_id];

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -126,8 +126,9 @@ void vmpu_acl_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
 #endif/*NDEBUG*/
 
     /* check for maximum box ID */
-    if(box_id>=UVISOR_MAX_BOXES)
-        HALT_ERROR(SANITY_CHECK_FAILED, "box ID out of range (%i)\n", box_id);
+    if (!vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box ID is out of range (%u).\r\n", box_id);
+    }
 
     /* check for alignment to 32 bytes */
     if(((uint32_t)start) & 0x1F)
@@ -226,8 +227,9 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size)
 void vmpu_switch(uint8_t src_box, uint8_t dst_box)
 {
     /* check for errors */
-    if(dst_box>=UVISOR_MAX_BOXES)
-        HALT_ERROR(SANITY_CHECK_FAILED, "dst_box out of range (%u)", dst_box);
+    if (!vmpu_is_box_id_valid(dst_box)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The destination box ID is out of range (%u).\r\n", dst_box);
+    }
 
     /* switch ACLs for peripherals */
     vmpu_aips_switch(src_box, dst_box);

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -50,9 +50,13 @@ void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box)
     TBoxACL *box;
     TMemACL *rgd;
 
-    /* get box config */
-    assert(dst_box < UVISOR_MAX_BOXES);
-    assert(src_box < UVISOR_MAX_BOXES);
+    /* Sanity checks. */
+    if (!vmpu_is_box_id_valid(src_box)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The source box ID is out of range (%u).\r\n", src_box);
+    }
+    if (!vmpu_is_box_id_valid(dst_box)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The destination box ID is out of range (%u).\n", dst_box);
+    }
 
     box = &g_mem_box[dst_box];
 
@@ -145,8 +149,9 @@ static int vmpu_mem_add_int(uint8_t box_id, void* start, uint32_t size, UvisorBo
     }
 
     /* get box config */
-    if(box_id >= UVISOR_MAX_BOXES)
-        return -23;
+    if (!vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The box ID is out of range (%u).\n", box_id);
+    }
     box = &g_mem_box[box_id];
 
     /* initialize acl pointer */


### PR DESCRIPTION
This function is now consistently used to check if a box ID is valid. If the boxes have not been enumerated yet the check is done agains the maximum number of boxes allowed.

@meriac @Patater 