### PR TITLE
Return the proper number of bytes copied when reading box namespaces

### DIFF
--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -444,10 +444,17 @@ static int copy_box_namespace(const char *src, char *dst)
 
         if (src[bytes_copied] == '\0') {
             /* We've reached the end of the box namespace. */
-            break;
+            goto done;
         }
     }
 
+    /* We did not find a terminating null in the src. The src has been verified
+     * in vmpu_box_namespace_from_id as being in the box config table. It is a
+     * programmer error if the namespace in the box config table is not
+     * null-terminated, so we halt. */
+    HALT_ERROR(SANITY_CHECK_FAILED, "vmpu: Box namespace missing terminating-null\r\n");
+
+done:
     return bytes_copied;
 }
 

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -444,6 +444,7 @@ static int copy_box_namespace(const char *src, char *dst)
 
         if (src[bytes_copied] == '\0') {
             /* We've reached the end of the box namespace. */
+            ++bytes_copied; /* Include the terminating-null in bytes_copied. */
             goto done;
         }
     }


### PR DESCRIPTION
@AlessandroA @meriac