### PR TITLE
Avoid dependency on RNR-initialisation

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -627,15 +627,15 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size)
 
 void vmpu_arch_init(void)
 {
-    /* reset MPU */
+    /* Disable the MPU. */
     MPU->CTRL = 0;
-    /* check MPU region aligment */
+    /* Check MPU region alignment using region number zero. */
     MPU->RNR = 0;
     MPU->RBAR = MPU_RBAR_ADDR_Msk;
     g_vmpu_aligment_mask = ~MPU->RBAR;
     MPU->RBAR = 0;
 
-    /* initialize round-robin slot pointer */
+    /* Initialize round-robin slot pointer. */
     g_mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
 
     /* show basic mpu settings */
@@ -643,26 +643,26 @@ void vmpu_arch_init(void)
     DPRINTF("MPU.ALIGNMENT=0x%08X\r\n", g_vmpu_aligment_mask);
     DPRINTF("MPU.ALIGNMENT_BITS=%i\r\n", vmpu_bits(g_vmpu_aligment_mask));
 
-    /* sanity checks */
+    /* Perform sanity checks. */
     assert(ARMv7M_MPU_REGIONS == ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF));
     assert(ARMv7M_MPU_ALIGNMENT_BITS == vmpu_bits(g_vmpu_aligment_mask));
 
-    /* init protected box memory enumation pointer */
+    /* Init protected box memory enumeration pointer. */
     DPRINTF("\n\rbox stack segment start=0x%08X end=0x%08X (length=%i)\n\r",
         __uvisor_config.bss_boxes_start, __uvisor_config.bss_boxes_start,
         ((uint32_t)__uvisor_config.bss_boxes_end)-((uint32_t)__uvisor_config.bss_boxes_start));
     g_box_mem_pos = (uint32_t)__uvisor_config.bss_boxes_start;
 
-    /* enable mem, bus and usage faults */
+    /* Enable mem, bus and usage faults. */
     SCB->SHCSR |= 0x70000;
 
-    /* initialize static MPU regions */
+    /* Initialize static MPU regions. */
     vmpu_arch_init_hw();
 
-    /* finally enable MPU */
+    /* Finally enable the MPU. */
     MPU->CTRL = MPU_CTRL_ENABLE_Msk|MPU_CTRL_PRIVDEFENA_Msk;
 
-    /* dump MPU configuration */
+    /* Dump MPU configuration in debug mode. */
 #ifndef NDEBUG
     debug_mpu_config();
 #endif/*NDEBUG*/

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -630,6 +630,7 @@ void vmpu_arch_init(void)
     /* reset MPU */
     MPU->CTRL = 0;
     /* check MPU region aligment */
+    MPU->RNR = 0;
     MPU->RBAR = MPU_RBAR_ADDR_Msk;
     g_vmpu_aligment_mask = ~MPU->RBAR;
     MPU->RBAR = 0;

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -109,8 +109,6 @@ uint32_t g_mpu_region_count, g_box_mem_pos;
 TMpuRegion g_mpu_list[MPU_REGION_COUNT];
 TMpuBox g_mpu_box[UVISOR_MAX_BOXES];
 
-static uint32_t g_vmpu_aligment_mask;
-
 static const TMpuRegion* vmpu_fault_find_box_region(uint32_t fault_addr, const TMpuBox *box)
 {
     int count;
@@ -627,12 +625,14 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size)
 
 void vmpu_arch_init(void)
 {
+    uint32_t aligment_mask;
+
     /* Disable the MPU. */
     MPU->CTRL = 0;
     /* Check MPU region alignment using region number zero. */
     MPU->RNR = 0;
     MPU->RBAR = MPU_RBAR_ADDR_Msk;
-    g_vmpu_aligment_mask = ~MPU->RBAR;
+    aligment_mask = ~MPU->RBAR;
     MPU->RBAR = 0;
 
     /* Initialize round-robin slot pointer. */
@@ -640,13 +640,16 @@ void vmpu_arch_init(void)
 
     /* show basic mpu settings */
     DPRINTF("MPU.REGIONS=%i\r\n", (uint8_t)(MPU->TYPE >> MPU_TYPE_DREGION_Pos));
-    DPRINTF("MPU.ALIGNMENT=0x%08X\r\n", g_vmpu_aligment_mask);
-    DPRINTF("MPU.ALIGNMENT_BITS=%i\r\n", vmpu_bits(g_vmpu_aligment_mask));
+    DPRINTF("MPU.ALIGNMENT=0x%08X\r\n", aligment_mask);
+    DPRINTF("MPU.ALIGNMENT_BITS=%i\r\n", vmpu_bits(aligment_mask));
 
     /* Perform sanity checks. */
-    assert(ARMv7M_MPU_REGIONS == ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF));
-    assert(ARMv7M_MPU_ALIGNMENT_BITS == vmpu_bits(g_vmpu_aligment_mask));
-
+    if (ARMv7M_MPU_REGIONS != ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_REGIONS is inconsistent with actual region count.\n\r");
+    }
+    if (ARMv7M_MPU_ALIGNMENT_BITS == vmpu_bits(aligment_mask)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_ALIGNMENT_BITS are inconsistent with actual MPU alignment\n\r");
+    }
     /* Init protected box memory enumeration pointer. */
     DPRINTF("\n\rbox stack segment start=0x%08X end=0x%08X (length=%i)\n\r",
         __uvisor_config.bss_boxes_start, __uvisor_config.bss_boxes_start,

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -104,10 +104,10 @@ typedef struct {
     uint32_t count;
 } TMpuBox;
 
-uint32_t g_mpu_slot;
-uint32_t g_mpu_region_count, g_box_mem_pos;
-TMpuRegion g_mpu_list[MPU_REGION_COUNT];
-TMpuBox g_mpu_box[UVISOR_MAX_BOXES];
+static uint32_t g_mpu_slot;
+static uint32_t g_mpu_region_count, g_box_mem_pos;
+static TMpuRegion g_mpu_list[MPU_REGION_COUNT];
+static TMpuBox g_mpu_box[UVISOR_MAX_BOXES];
 
 static const TMpuRegion* vmpu_fault_find_box_region(uint32_t fault_addr, const TMpuBox *box)
 {


### PR DESCRIPTION
In case the RNR register is initialised to a region outside of the supported region count the core behaviour is undefined by the architecture. To avoid that we specifically enforce region number zero.

@AlessandroA @Patater