### PR TITLE
Fix out-by-one error in vmpu_region_bits

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -367,14 +367,15 @@ static int vmpu_region_bits(uint32_t size)
 
     bits = vmpu_bits(size)-1;
 
-    /* minimum region size is 32 bytes */
-    if(bits<ARMv7M_MPU_ALIGNMENT_BITS)
-        bits=ARMv7M_MPU_ALIGNMENT_BITS;
-
     /* round up if needed */
     if((1UL << bits) != size)
         bits++;
 
+    /* minimum region size is 32 bytes */
+    if(bits<ARMv7M_MPU_ALIGNMENT_BITS)
+        bits=ARMv7M_MPU_ALIGNMENT_BITS;
+
+    assert(bits == UVISOR_REGION_BITS(size));
     return bits;
 }
 


### PR DESCRIPTION
This function should compute ceil(log2(size)); the number of bits needed to
address a region of 'size' bytes. If size < 32 then this should be 5 bits
(since the minimum supported region size in v7M is 32 bytes). The function was
incorrect for this case (returning 6 bits) because it rounded-up *after* the
minimum size check.

The fix has been checked exhaustively by CBMC.