### PR TITLE
Fix debug disabled

### DIFF
--- a/core/system/src/main.c
+++ b/core/system/src/main.c
@@ -58,6 +58,14 @@ UVISOR_NOINLINE void uvisor_init_post(void)
 
 void main_entry(void)
 {
+    /* Return immediately if the magic is invalid or uVisor is disabled.
+     * This ensures that no uVisor feature that could halt the system is
+     * active in disabled mode (for example, printing debug messages to the
+     * semihosting port). */
+    if (__uvisor_config.magic != UVISOR_MAGIC || !__uvisor_config.mode || *(__uvisor_config.mode) == 0) {
+        return;
+    }
+
     /* initialize uvisor */
     uvisor_init_pre();
 


### PR DESCRIPTION
This ensures that applications can run in debug mode with uVisor
disabled. Semihosting is still a requirement for applications that run
with uVisor enabled.

@meriac @Patater 