### PR TITLE
Simplify uvisor lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ CFLAGS_PRE:=\
         $(OPT) \
         $(DEBUG) \
         $(WARNING) \
+        -DUVISOR_PRESENT \
         -DARCH_MPU_$(ARCH_MPU) \
         -D$(CONFIGURATION) \
         -DPROGRAM_VERSION=\"$(PROGRAM_VERSION)\" \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,10 @@ API_RELEASE:=$(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)/$(CONFIGURATION_LOWER).a
 API_VERSION:=$(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)/$(CONFIGURATION_LOWER).txt
 
 # Release library source files
+# Note: We explicitly remove unsupported.c from the list of source files. It
+#       will be compiled by the host OS in case uVisor is not supported.
 API_SOURCES:=$(wildcard $(API_DIR)/src/*.c)
+API_SOURCES:=$(filter-out $(API_DIR)/src/unsupported.c, $(API_SOURCES))
 API_OBJS:=$(foreach API_SOURCE, $(API_SOURCES), $(API_SOURCE).$(CONFIGURATION_LOWER).$(BUILD_MODE).o) $(API_ASM_OUTPUT:.s=.o)
 
 # make ARMv7-M MPU driver the default

--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_API_UNSUPPORTED_H__
+#define __UVISOR_API_UNSUPPORTED_H__
+
+#include "uvisor/api/inc/uvisor_exports.h"
+#include <stdint.h>
+
+/* uVisor hook for unsupported platforms */
+UVISOR_EXTERN void uvisor_init(void);
+
+/*******************************************************************************
+ * Re-definitions from:
+ ******************************************************************************/
+
+/* uvisor-lib/box-config.h */
+
+UVISOR_EXTERN const uint32_t __uvisor_mode;
+
+#define UVISOR_DISABLED 0
+
+#define UVISOR_SET_MODE(mode) \
+    UVISOR_SET_MODE_ACL_COUNT(mode, NULL, 0)
+
+#define UVISOR_SET_MODE_ACL(mode, acl_list) \
+    UVISOR_SET_MODE_ACL_COUNT(mode, acl_list, UVISOR_ARRAY_COUNT(acl_list))
+
+#define UVISOR_SET_MODE_ACL_COUNT(mode, acl_list, acl_list_count) \
+    UVISOR_EXTERN const uint32_t __uvisor_mode = UVISOR_DISABLED; \
+    static const void *main_acl = acl_list; \
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_acl;
+
+#define __UVISOR_BOX_CONFIG_NOCONTEXT(box_name, acl_list, stack_size) \
+    static const void *box_acl_ ## box_name = acl_list; \
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) void * const box_name ## _cfg_ptr = &box_acl_ ## box_name;
+
+#define __UVISOR_BOX_CONFIG_CONTEXT(box_name, acl_list, stack_size, context_type) \
+    context_type box_ctx_ ## box_name; \
+    context_type * const uvisor_ctx = &box_ctx_ ## box_name; \
+    static const void *box_acl_ ## box_name = acl_list; \
+    const __attribute__((section(".keep.uvisor.cfgtbl_ptr"), aligned(4))) volatile void *box_name ## _cfg_ptr = \
+        &box_acl_ ## box_name;
+
+#define __UVISOR_BOX_MACRO(_1, _2, _3, _4, NAME, ...) NAME
+#define UVISOR_BOX_CONFIG(...) \
+    __UVISOR_BOX_MACRO(__VA_ARGS__, __UVISOR_BOX_CONFIG_CONTEXT, \
+                                    __UVISOR_BOX_CONFIG_NOCONTEXT)(__VA_ARGS__)
+
+#define UVISOR_BOX_CONFIG_ACL(...) UVISOR_BOX_CONFIG(__VA_ARGS__)
+
+#define UVISOR_BOX_CONFIG_CTX(...) UVISOR_BOX_CONFIG(__VA_ARGS__)
+
+/* uvisor-lib/interrupts.h */
+
+#define vIRQ_SetVector(irqn, vector)        NVIC_SetVector((IRQn_Type) (irqn), (uint32_t) (vector))
+#define vIRQ_GetVector(irqn)                NVIC_GetVector((IRQn_Type) (irqn))
+#define vIRQ_EnableIRQ(irqn)                NVIC_EnableIRQ((IRQn_Type) (irqn))
+#define vIRQ_DisableIRQ(irqn)               NVIC_DisableIRQ((IRQn_Type) (irqn))
+#define vIRQ_ClearPendingIRQ(irqn)          NVIC_ClearPendingIRQ((IRQn_Type) (irqn))
+#define vIRQ_SetPendingIRQ(irqn)            NVIC_SetPendingIRQ((IRQn_Type) (irqn))
+#define vIRQ_GetPendingIRQ(irqn)            NVIC_GetPendingIRQ((IRQn_Type) (irqn))
+#define vIRQ_SetPriority(irqn, priority)    NVIC_SetPriority((IRQn_Type) (irqn), (uint32_t) (priority))
+#define vIRQ_GetPriority(irqn)              NVIC_GetPriority((IRQn_Type) (irqn))
+
+/* uvisor-lib/register_gateway.h */
+
+#define UVISOR_OP_READ(op)  (op)
+#define UVISOR_OP_WRITE(op) ((1 << 4) | (op))
+#define UVISOR_OP_NOP       0x0
+#define UVISOR_OP_AND       0x1
+#define UVISOR_OP_OR        0x2
+#define UVISOR_OP_XOR       0x3
+
+/* Default mask for whole register operatins */
+#define __UVISOR_OP_DEFAULT_MASK 0x0
+
+static inline UVISOR_FORCEINLINE uint32_t uvisor_read(uint32_t addr, uint32_t op, uint32_t mask)
+{
+    switch(op)
+    {
+        case UVISOR_OP_READ(UVISOR_OP_NOP):
+            return *((uint32_t *) addr);
+        case UVISOR_OP_READ(UVISOR_OP_AND):
+            return *((uint32_t *) addr) & mask;
+        case UVISOR_OP_READ(UVISOR_OP_OR):
+            return *((uint32_t *) addr) | mask;
+        case UVISOR_OP_READ(UVISOR_OP_XOR):
+            return *((uint32_t *) addr) ^ mask;
+        default:
+            /* FIXME */
+            return 0;
+    }
+}
+
+#define uvisor_read(addr) uvisor_read((uint32_t) (addr), UVISOR_OP_READ(UVISOR_OP_NOP), __UVISOR_OP_DEFAULT_MASK)
+
+static inline UVISOR_FORCEINLINE void uvisor_write(uint32_t addr, uint32_t val, uint32_t op, uint32_t mask)
+{
+    switch(op)
+    {
+        case UVISOR_OP_WRITE(UVISOR_OP_NOP):
+            *((uint32_t *) addr) = val;
+        case UVISOR_OP_WRITE(UVISOR_OP_AND):
+            *((uint32_t *) addr) &= val | ~mask;
+        case UVISOR_OP_WRITE(UVISOR_OP_OR):
+            *((uint32_t *) addr) |= val & mask;
+        case UVISOR_OP_WRITE(UVISOR_OP_XOR):
+            *((uint32_t *) addr) ^= val & mask;
+        default:
+            /* FIXME */
+            return;
+    }
+}
+
+#define uvisor_write(addr, val) uvisor_write((uint32_t) (addr), (uint32_t) (val), \
+                                             UVISOR_OP_WRITE(UVISOR_OP_NOP), __UVISOR_OP_DEFAULT_MASK)
+
+/* uvisor-lib/secure_access.h */
+
+/* The conditional statement will be optimised away since the compiler already
+ * knows the sizeof(type). */
+#define ADDRESS_READ(type, addr) \
+    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t *) (addr)) : \
+     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t *) (addr)) : \
+     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t *) (addr)) : 0)
+
+/* The switch statement will be optimised away since the compiler already knows
+ * the sizeof(type). */
+#define ADDRESS_WRITE(type, addr, val) \
+    { \
+        switch(sizeof(type)) \
+        { \
+            case 4: \
+                uvisor_write32((volatile uint32_t *) (addr), (uint32_t) (val)); \
+                break; \
+            case 2: \
+                uvisor_write16((volatile uint16_t *) (addr), (uint16_t) (val)); \
+                break; \
+            case 1: \
+                uvisor_write8((volatile uint8_t *) (addr), (uint8_t) (val)); \
+                break; \
+        } \
+    }
+
+#define UNION_READ(type, addr, fieldU, fieldB) ((*((volatile type *) (addr))).fieldB)
+
+static inline UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile *addr, uint32_t val)
+{
+    *(addr) = val;
+}
+
+static inline UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile *addr, uint16_t val)
+{
+    *(addr) = val;
+}
+
+static inline UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile *addr, uint8_t val)
+{
+    *(addr) = val;
+}
+
+static inline UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile *addr)
+{
+    return *(addr);
+}
+
+static inline UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile *addr)
+{
+    return *(addr);
+}
+
+static inline UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
+{
+    return *(addr);
+}
+
+/* uvisor-lib/secure_gateway.h */
+
+#define secure_gateway(dst_box, dst_fn, ...) dst_fn(__VA_ARGS__)
+
+#endif /* __UVISOR_API_UNSUPPORTED_H__ */

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -14,10 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __UVISOR_API_UVISOR_H__
-#define __UVISOR_API_UVISOR_H__
+#ifndef __UVISOR_API_UVISOR_LIB_H__
+#define __UVISOR_API_UVISOR_LIB_H__
 
-/* This file includes all the uVisor library header files at once. */
+/* This file includes all the uVisor library header files at once.
+ * If uVisor is used on a host OS that includes unsupported targets, then
+ * unsupported.h is included, which defines a fallback version of those APIs,
+ * with no security feature. */
+
+#if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
 
 /* Library header files */
 #include "api/inc/benchmark.h"
@@ -30,7 +35,15 @@
 #include "api/inc/secure_access.h"
 #include "api/inc/secure_gateway.h"
 
-/* Include all exported header files used by uVisor internally. */
+#else /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
+
+#include "api/inc/unsupported.h"
+
+#endif /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
+
+/* Include all exported header files used by uVisor internally.
+ * These are included independently on whether uVisor is supported or not by the
+ * target platform. */
 #include "api/inc/debug_exports.h"
 #include "api/inc/halt_exports.h"
 #include "api/inc/svc_exports.h"
@@ -39,4 +52,4 @@
 #include "api/inc/uvisor_exports.h"
 #include "api/inc/vmpu_exports.h"
 
-#endif /* __UVISOR_API_UVISOR_H__ */
+#endif /* __UVISOR_API_UVISOR_LIB_H__ */

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -55,12 +55,16 @@
 #define UVISOR_TACL_USER            0x0800UL
 #define UVISOR_TACL_IRQ             0x1000UL
 
+#if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
+
 /* subregion mask for ARMv7M */
-#if defined(ARCH_MPU_ARMv7M) || (YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(TARGET_LIKE_KINETIS))
+#if defined(ARCH_MPU_ARMv7M)
 #define UVISOR_TACL_SUBREGIONS_POS  24
 #define UVISOR_TACL_SUBREGIONS_MASK (0xFFUL<<UVISOR_TACL_SUBREGIONS_POS)
 #define UVISOR_TACL_SUBREGIONS(x)   ( (((uint32_t)(x))<<UVISOR_TACL_SUBREGIONS_POS) & UVISOR_TACL_SUBREGIONS_MASK )
 #endif
+
+#endif /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
 
 #define UVISOR_TACLDEF_SECURE_BSS   (UVISOR_TACL_UREAD          |\
                                      UVISOR_TACL_UWRITE         |\
@@ -96,20 +100,26 @@
 #define UVISOR_MIN_STACK_SIZE       1024
 #define UVISOR_MIN_STACK(x)         (((x)<UVISOR_MIN_STACK_SIZE)?UVISOR_MIN_STACK_SIZE:(x))
 
-#if defined(ARCH_MPU_ARMv7M) || (YOTTA_CFG_UVISOR_PRESENT == 1 && !defined(TARGET_LIKE_KINETIS))
+#if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
+
+#if defined(ARCH_MPU_ARMv7M)
 #define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~((1UL << UVISOR_REGION_BITS(x)) - 1))
 #define UVISOR_REGION_ROUND_UP(x)   (1UL << UVISOR_REGION_BITS(x))
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP(x)
-#elif defined(ARCH_MPU_KINETIS) || (YOTTA_CFG_UVISOR_PRESENT == 1 && defined(TARGET_LIKE_KINETIS))
+#elif defined(ARCH_MPU_KINETIS)
 #define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~0x1FUL)
 #define UVISOR_REGION_ROUND_UP(x)   UVISOR_REGION_ROUND_DOWN((x) + 31UL)
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP((x) + (UVISOR_STACK_BAND_SIZE * 2))
-#elif !defined(YOTTA_CFG_UVISOR_PRESENT) || YOTTA_CFG_UVISOR_PRESENT == 0
+#else
+#error "Unknown MPU architecture. uvisor: Check your Makefile. uvisor-lib: Check if uVisor is supported"
+#endif
+
+#else /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
+
 #define UVISOR_REGION_ROUND_DOWN(x) (x)
 #define UVISOR_REGION_ROUND_UP(x)   (x)
 #define UVISOR_STACK_SIZE_ROUND(x)  (x)
-#else
-#error "Unknown MPU architecture. uvisor: Check your Makefile. uvisor-lib: Check if uVisor is supported"
+
 #endif
 
 #ifndef UVISOR_BOX_STACK_SIZE

--- a/api/src/unsupported.c
+++ b/api/src/unsupported.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "api/inc/uvisor-lib.h"
+#include "core/uvisor.h"
+
+/* Note: This file is not included in the uVisor release library. Instead, the
+ *       host OS needs to compile it separately if a platform does not support
+ *       uVisor (but uVisor API header files are still used). */
+
+/* uVisor hook for unsupported platforms */
+UVISOR_EXTERN void __attribute__((section(".uvisor.main"))) uvisor_init(void)
+{
+    return;
+}


### PR DESCRIPTION
This PR ensures that internally uVisor does not rely on any yotta-specific symbol. Instead, it is the job of the host-OS glue layer (uvisor-lib) to define the relevant symbols based on OS-specific information.

Currently the only 2 symbols that are used for this are:
* `UVISOR_PRESENT`.
* `ARCH_MPU_${ARCH_MPU}`.

**Example**:

In mbed OS the symbol `UVISOR_PRESENT` is mapped to `YOTTA_CFG_UVISOR_PRESENT`. The symbol `ARCH_MPU_*` depends on the target, which can be inferred using `TARGET_LIKE_*` from the config symbols.

See the [related PR](https://github.com/ARMmbed/uvisor-lib/pull/43) to check how this is implemented in uvisor-lib.

@meriac @Patater @niklas-arm 