### PR TITLE
Declare uvisor_disabled_{s,g}et_vector weak

### DIFF
--- a/api/inc/disabled.h
+++ b/api/inc/disabled.h
@@ -23,6 +23,8 @@
 UVISOR_EXTERN void uvisor_disabled_switch_in(const uint32_t *dst_box_cfgtbl_ptr);
 UVISOR_EXTERN void uvisor_disabled_switch_out(void);
 
+/* The host OS can override the implementations of these functions in case a
+ * different handling of IRQs is required when uVisor is disabled. */
 UVISOR_EXTERN void uvisor_disabled_set_vector(uint32_t irqn, uint32_t vector);
 UVISOR_EXTERN uint32_t uvisor_disabled_get_vector(uint32_t irqn);
 

--- a/api/src/disabled.c
+++ b/api/src/disabled.c
@@ -187,7 +187,7 @@ static void uvisor_disabled_default_vector(void)
     uvisor_disabled_switch_out();
 }
 
-void uvisor_disabled_set_vector(uint32_t irqn, uint32_t vector)
+UVISOR_WEAK void uvisor_disabled_set_vector(uint32_t irqn, uint32_t vector)
 {
     uint8_t prio_bits, box_id;
     uint8_t volatile *prio;
@@ -227,7 +227,7 @@ void uvisor_disabled_set_vector(uint32_t irqn, uint32_t vector)
     g_uvisor_disabled_vectors[irqn].vector = vector;
 }
 
-uint32_t uvisor_disabled_get_vector(uint32_t irqn)
+UVISOR_WEAK uint32_t uvisor_disabled_get_vector(uint32_t irqn)
 {
     /* Check IRQn.
      * We only allow user IRQs to be registered (NVIC). This is consistent with


### PR DESCRIPTION
This will allow an host OS to override the functions implementation to
use a different IRQ handling approach when uVisor is disabled.

@meriac @niklas-arm @Patater 