### PR TITLE
Fix -DUVISOR_PRESENT=1 definition for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ CFLAGS_PRE:=\
         $(OPT) \
         $(DEBUG) \
         $(WARNING) \
-        -DUVISOR_PRESENT \
+        -DUVISOR_PRESENT=1 \
         -DARCH_MPU_$(ARCH_MPU) \
         -D$(CONFIGURATION) \
         -DPROGRAM_VERSION=\"$(PROGRAM_VERSION)\" \


### PR DESCRIPTION
The symbol is expected to be defined AND set to 1 explicitly by
uvisor-lib. It should behave the same for uvisor-core itself, although
in this case it was not critical.

@meriac @patater @niklas-arm 