### PR TITLE
Fix compiler attributes and functions for IAR and unsupported targets

### DIFF
--- a/api/inc/secure_access.h
+++ b/api/inc/secure_access.h
@@ -19,42 +19,8 @@
 
 #include "api/inc/uvisor_exports.h"
 #include "api/inc/vmpu_exports.h"
+#include <stddef.h>
 #include <stdint.h>
-
-/* the switch statement will be optimised away since the compiler already knows
- * the sizeof(type) */
-#define ADDRESS_WRITE(type, addr, val) \
-    { \
-        switch(sizeof(type)) \
-        { \
-            case 4: \
-                uvisor_write32((uint32_t volatile * volatile) (addr), (uint32_t) (val)); \
-                break; \
-            case 2: \
-                uvisor_write16((uint16_t volatile * volatile) (addr), (uint16_t) (val)); \
-                break; \
-            case 1: \
-                uvisor_write8((uint8_t volatile * volatile) (addr), (uint8_t ) (val)); \
-                break; \
-            default: \
-                uvisor_error(USER_NOT_ALLOWED); \
-                break; \
-        } \
-    }
-
-/* the conditional statement will be optimised away since the compiler already
- * knows the sizeof(type) */
-#define ADDRESS_READ(type, addr) \
-    (sizeof(type) == 4 ? uvisor_read32((uint32_t volatile * volatile) (addr)) : \
-     sizeof(type) == 2 ? uvisor_read16((uint16_t volatile * volatile) (addr)) : \
-     sizeof(type) == 1 ? uvisor_read8((uint8_t volatile * volatile) (addr)) : 0)
-
-#define UNION_READ(type, addr, fieldU, fieldB) \
-    ({ \
-        type res; \
-        res.fieldU = ADDRESS_READ(type, addr); \
-        res.fieldB; \
-    })
 
 static UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile * volatile addr, uint32_t val)
 {
@@ -85,5 +51,41 @@ static UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile * volatile addr)
 {
     return UVISOR_ASM_MEMORY_ACCESS(ldrb, uint8_t, addr);
 }
+
+/* The switch statement will be optimised away since the compiler already knows
+ * the sizeof_type. */
+static UVISOR_FORCEINLINE void __address_write(size_t sizeof_type, volatile uint32_t *addr, uint32_t val)
+{
+    switch(sizeof_type) {
+        case 4:
+            uvisor_write32((volatile uint32_t * volatile) addr, (uint32_t) val);
+            break;
+        case 2:
+            uvisor_write16((volatile uint16_t * volatile) addr, (uint16_t) val);
+            break;
+        case 1:
+            uvisor_write8((volatile uint8_t * volatile) addr, (uint8_t) val);
+            break;
+        default:
+            uvisor_error(USER_NOT_ALLOWED);
+            break;
+    }
+}
+
+#define ADDRESS_WRITE(type, addr, val) __address_write(sizeof(type), (volatile uint32_t *) addr, (uint32_t) val)
+
+/* the conditional statement will be optimised away since the compiler already
+ * knows the sizeof(type) */
+#define ADDRESS_READ(type, addr) \
+    (sizeof(type) == 4 ? uvisor_read32((uint32_t volatile * volatile) (addr)) : \
+     sizeof(type) == 2 ? uvisor_read16((uint16_t volatile * volatile) (addr)) : \
+     sizeof(type) == 1 ? uvisor_read8((uint8_t volatile * volatile) (addr)) : 0)
+
+#define UNION_READ(type, addr, fieldU, fieldB) \
+    ({ \
+        type res; \
+        res.fieldU = ADDRESS_READ(type, addr); \
+        res.fieldB; \
+    })
 
 #endif /* __UVISOR_API_SECURE_ACCESS_H__ */

--- a/api/inc/secure_access.h
+++ b/api/inc/secure_access.h
@@ -56,32 +56,32 @@
         res.fieldB; \
     })
 
-static inline UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile * volatile addr, uint32_t val)
+static UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile * volatile addr, uint32_t val)
 {
     UVISOR_ASM_MEMORY_ACCESS(str, uint32_t, addr, val);
 }
 
-static inline UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile * volatile addr, uint16_t val)
+static UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile * volatile addr, uint16_t val)
 {
     UVISOR_ASM_MEMORY_ACCESS(strh, uint16_t, addr, val);
 }
 
-static inline UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile * volatile addr, uint8_t val)
+static UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile * volatile addr, uint8_t val)
 {
     UVISOR_ASM_MEMORY_ACCESS(strb, uint8_t, addr, val);
 }
 
-static inline UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile * volatile addr)
+static UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile * volatile addr)
 {
     return UVISOR_ASM_MEMORY_ACCESS(ldr, uint32_t, addr);
 }
 
-static inline UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile * volatile addr)
+static UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile * volatile addr)
 {
     return UVISOR_ASM_MEMORY_ACCESS(ldrh, uint16_t, addr);
 }
 
-static inline UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile * volatile addr)
+static UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile * volatile addr)
 {
     return UVISOR_ASM_MEMORY_ACCESS(ldrb, uint8_t, addr);
 }

--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -90,7 +90,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 /* Default mask for whole register operatins */
 #define __UVISOR_OP_DEFAULT_MASK 0x0
 
-static inline UVISOR_FORCEINLINE uint32_t uvisor_read(uint32_t addr, uint32_t op, uint32_t mask)
+static UVISOR_FORCEINLINE uint32_t uvisor_read(uint32_t addr, uint32_t op, uint32_t mask)
 {
     switch(op)
     {
@@ -110,7 +110,7 @@ static inline UVISOR_FORCEINLINE uint32_t uvisor_read(uint32_t addr, uint32_t op
 
 #define uvisor_read(addr) uvisor_read((uint32_t) (addr), UVISOR_OP_READ(UVISOR_OP_NOP), __UVISOR_OP_DEFAULT_MASK)
 
-static inline UVISOR_FORCEINLINE void uvisor_write(uint32_t addr, uint32_t val, uint32_t op, uint32_t mask)
+static UVISOR_FORCEINLINE void uvisor_write(uint32_t addr, uint32_t val, uint32_t op, uint32_t mask)
 {
     switch(op)
     {
@@ -160,32 +160,32 @@ static inline UVISOR_FORCEINLINE void uvisor_write(uint32_t addr, uint32_t val, 
 
 #define UNION_READ(type, addr, fieldU, fieldB) ((*((volatile type *) (addr))).fieldB)
 
-static inline UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile *addr, uint32_t val)
+static UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile *addr, uint32_t val)
 {
     *(addr) = val;
 }
 
-static inline UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile *addr, uint16_t val)
+static UVISOR_FORCEINLINE void uvisor_write16(uint16_t volatile *addr, uint16_t val)
 {
     *(addr) = val;
 }
 
-static inline UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile *addr, uint8_t val)
+static UVISOR_FORCEINLINE void uvisor_write8(uint8_t volatile *addr, uint8_t val)
 {
     *(addr) = val;
 }
 
-static inline UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile *addr)
+static UVISOR_FORCEINLINE uint32_t uvisor_read32(uint32_t volatile *addr)
 {
     return *(addr);
 }
 
-static inline UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile *addr)
+static UVISOR_FORCEINLINE uint16_t uvisor_read16(uint16_t volatile *addr)
 {
     return *(addr);
 }
 
-static inline UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
+static UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
 {
     return *(addr);
 }

--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -167,9 +167,9 @@ static UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
 /* The conditional statement will be optimised away since the compiler already
  * knows the sizeof(type). */
 #define ADDRESS_READ(type, addr) \
-    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t *) (addr)) : \
-     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t *) (addr)) : \
-     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t *) (addr)) : 0)
+    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t * volatile) (addr)) : \
+     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t * volatile) (addr)) : \
+     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t * volatile) (addr)) : 0)
 
 /* The switch statement will be optimised away since the compiler already knows
  * the sizeof_type. */

--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -18,6 +18,7 @@
 #define __UVISOR_API_UNSUPPORTED_H__
 
 #include "uvisor/api/inc/uvisor_exports.h"
+#include <stddef.h>
 #include <stdint.h>
 
 /* uVisor hook for unsupported platforms */
@@ -133,33 +134,6 @@ static UVISOR_FORCEINLINE void uvisor_write(uint32_t addr, uint32_t val, uint32_
 
 /* uvisor-lib/secure_access.h */
 
-/* The conditional statement will be optimised away since the compiler already
- * knows the sizeof(type). */
-#define ADDRESS_READ(type, addr) \
-    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t *) (addr)) : \
-     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t *) (addr)) : \
-     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t *) (addr)) : 0)
-
-/* The switch statement will be optimised away since the compiler already knows
- * the sizeof(type). */
-#define ADDRESS_WRITE(type, addr, val) \
-    { \
-        switch(sizeof(type)) \
-        { \
-            case 4: \
-                uvisor_write32((volatile uint32_t *) (addr), (uint32_t) (val)); \
-                break; \
-            case 2: \
-                uvisor_write16((volatile uint16_t *) (addr), (uint16_t) (val)); \
-                break; \
-            case 1: \
-                uvisor_write8((volatile uint8_t *) (addr), (uint8_t) (val)); \
-                break; \
-        } \
-    }
-
-#define UNION_READ(type, addr, fieldU, fieldB) ((*((volatile type *) (addr))).fieldB)
-
 static UVISOR_FORCEINLINE void uvisor_write32(uint32_t volatile *addr, uint32_t val)
 {
     *(addr) = val;
@@ -189,6 +163,34 @@ static UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
 {
     return *(addr);
 }
+
+/* The conditional statement will be optimised away since the compiler already
+ * knows the sizeof(type). */
+#define ADDRESS_READ(type, addr) \
+    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t *) (addr)) : \
+     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t *) (addr)) : \
+     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t *) (addr)) : 0)
+
+/* The switch statement will be optimised away since the compiler already knows
+ * the sizeof_type. */
+static UVISOR_FORCEINLINE void __address_write(size_t sizeof_type, volatile uint32_t *addr, uint32_t val)
+{
+    switch(sizeof_type) {
+        case 4:
+            uvisor_write32((volatile uint32_t * volatile) addr, (uint32_t) val);
+            break;
+        case 2:
+            uvisor_write16((volatile uint16_t * volatile) addr, (uint16_t) val);
+            break;
+        case 1:
+            uvisor_write8((volatile uint8_t * volatile) addr, (uint8_t) val);
+            break;
+    }
+}
+
+#define ADDRESS_WRITE(type, addr, val) __address_write(sizeof(type), (volatile uint32_t *) addr, (uint32_t) val)
+
+#define UNION_READ(type, addr, fieldU, fieldB) ((*((volatile type *) (addr))).fieldB)
 
 /* uvisor-lib/secure_gateway.h */
 

--- a/api/inc/uvisor_exports.h
+++ b/api/inc/uvisor_exports.h
@@ -34,8 +34,12 @@
 #define asm __asm__
 #endif
 
-/* compiler attributes */
-#define UVISOR_FORCEINLINE __attribute__((always_inline))
+/* Shared compiler attributes */
+#if defined(__ICCARM__)
+#define UVISOR_FORCEINLINE inline
+#else
+#define UVISOR_FORCEINLINE inline __attribute__((always_inline))
+#endif
 #define UVISOR_NOINLINE    __attribute__((noinline))
 #define UVISOR_PACKED      __attribute__((packed))
 #define UVISOR_WEAK        __attribute__((weak))

--- a/api/inc/uvisor_exports.h
+++ b/api/inc/uvisor_exports.h
@@ -40,13 +40,9 @@
 #else
 #define UVISOR_FORCEINLINE inline __attribute__((always_inline))
 #endif
-#define UVISOR_NOINLINE    __attribute__((noinline))
 #define UVISOR_PACKED      __attribute__((packed))
 #define UVISOR_WEAK        __attribute__((weak))
-#define UVISOR_ALIAS(f)    __attribute__((weak, alias (#f)))
-#define UVISOR_LINKTO(f)   __attribute__((alias (#f)))
 #define UVISOR_NORETURN    __attribute__((noreturn))
-#define UVISOR_NAKED       __attribute__((naked))
 #define UVISOR_RAMFUNC     __attribute__ ((section (".ramfunc"), noinline))
 
 /* array count macro */

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -171,7 +171,7 @@ typedef struct
     31:32)))))))))))))))))))))))))))
 
 #if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
-static inline int vmpu_bits(uint32_t size)
+static UVISOR_FORCEINLINE int vmpu_bits(uint32_t size)
 {
     return 32 - __builtin_clz(size);
 }

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -170,9 +170,11 @@ typedef struct
     28:(((x)<=536870912UL)?29:(((x)<=1073741824UL)?30:(((x)<=2147483648UL)?\
     31:32)))))))))))))))))))))))))))
 
+#if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
 static inline int vmpu_bits(uint32_t size)
 {
     return 32 - __builtin_clz(size);
 }
+#endif /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
 
 #endif /* __UVISOR_API_VMPU_EXPORTS_H__ */

--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -33,19 +33,19 @@
  *       from the flash origin to this symbol contains the uVisor and
  *       main box code and data and excludes the configuration tables. */
 
-static inline int vmpu_public_flash_addr(uint32_t addr)
+static UVISOR_FORCEINLINE int vmpu_public_flash_addr(uint32_t addr)
 {
     return (((uint32_t) addr >= FLASH_ORIGIN) &&
             ((uint32_t) addr <= (FLASH_ORIGIN + (uint32_t) __uvisor_config.secure_start - 4)));
 }
 
-static inline int vmpu_flash_addr(uint32_t addr)
+static UVISOR_FORCEINLINE int vmpu_flash_addr(uint32_t addr)
 {
     return (((uint32_t) addr >= FLASH_ORIGIN) &&
             ((uint32_t) addr <= (FLASH_ORIGIN + (uint32_t) __uvisor_config.flash_end - 4)));
 }
 
-static inline int vmpu_sram_addr(uint32_t addr)
+static UVISOR_FORCEINLINE int vmpu_sram_addr(uint32_t addr)
 {
     return (((uint32_t) addr >= SRAM_ORIGIN) &&
             ((uint32_t) addr <= (SRAM_ORIGIN + (uint32_t) __uvisor_config.sram_end - 4)));
@@ -162,7 +162,7 @@ extern int vmpu_box_id_self(void);
 extern int vmpu_box_id_caller(void);
 extern int vmpu_box_namespace_from_id(int box_id, char *box_name, size_t length);
 
-static inline bool vmpu_is_box_id_valid(int box_id)
+static UVISOR_FORCEINLINE bool vmpu_is_box_id_valid(int box_id)
 {
     /* Return true if the box_id is valid.
      * This function checks box_id against UVISOR_MAX_BOXES if boxes have not

--- a/core/system/inc/mpu/vmpu_unpriv_access.h
+++ b/core/system/inc/mpu/vmpu_unpriv_access.h
@@ -17,28 +17,28 @@
 #ifndef __VMPU_UNPRIV_ACCESS_H__
 #define __VMPU_UNPRIV_ACCESS_H__
 
-static inline __attribute__((always_inline)) void vmpu_unpriv_uint8_write(uint32_t addr, uint8_t data)
+static UVISOR_FORCEINLINE void vmpu_unpriv_uint8_write(uint32_t addr, uint8_t data)
 {
     asm volatile(
         "strbt %[data], [%[addr]]"
     :: [addr] "r" (addr), [data] "r" (data));
 }
 
-static inline __attribute__((always_inline)) void vmpu_unpriv_uint16_write(uint32_t addr, uint16_t data)
+static UVISOR_FORCEINLINE void vmpu_unpriv_uint16_write(uint32_t addr, uint16_t data)
 {
     asm volatile(
         "strht %[data], [%[addr]]"
     :: [addr] "r" (addr), [data] "r" (data));
 }
 
-static inline __attribute__((always_inline)) void vmpu_unpriv_uint32_write(uint32_t addr, uint32_t data)
+static UVISOR_FORCEINLINE void vmpu_unpriv_uint32_write(uint32_t addr, uint32_t data)
 {
     asm volatile(
         "strt %[data], [%[addr]]"
     :: [addr] "r" (addr), [data] "r" (data));
 }
 
-static inline __attribute__((always_inline)) uint8_t vmpu_unpriv_uint8_read(uint32_t addr)
+static UVISOR_FORCEINLINE uint8_t vmpu_unpriv_uint8_read(uint32_t addr)
 {
     uint8_t res;
     asm volatile(
@@ -47,7 +47,7 @@ static inline __attribute__((always_inline)) uint8_t vmpu_unpriv_uint8_read(uint
     return res;
 }
 
-static inline __attribute__((always_inline)) uint16_t vmpu_unpriv_uint16_read(uint32_t addr)
+static UVISOR_FORCEINLINE uint16_t vmpu_unpriv_uint16_read(uint32_t addr)
 {
     uint16_t res;
     asm volatile(
@@ -56,7 +56,7 @@ static inline __attribute__((always_inline)) uint16_t vmpu_unpriv_uint16_read(ui
     return res;
 }
 
-static inline __attribute__((always_inline)) uint32_t vmpu_unpriv_uint32_read(uint32_t addr)
+static UVISOR_FORCEINLINE uint32_t vmpu_unpriv_uint32_read(uint32_t addr)
 {
     uint32_t res;
     asm volatile(

--- a/core/system/inc/svc_cx.h
+++ b/core/system/inc/svc_cx.h
@@ -44,22 +44,22 @@ extern uint32_t *g_svc_cx_curr_sp[UVISOR_MAX_BOXES];
 extern uint32_t *g_svc_cx_context_ptr[UVISOR_MAX_BOXES];
 extern uint8_t g_active_box;
 
-static inline uint8_t svc_cx_get_src_id(void)
+static UVISOR_FORCEINLINE uint8_t svc_cx_get_src_id(void)
 {
     return g_svc_cx_state[g_svc_cx_state_ptr].src_id;
 }
 
-static inline uint32_t *svc_cx_get_src_sp(void)
+static UVISOR_FORCEINLINE uint32_t *svc_cx_get_src_sp(void)
 {
     return g_svc_cx_state[g_svc_cx_state_ptr].src_sp;
 }
 
-static inline uint32_t *svc_cx_get_curr_sp(uint8_t box_id)
+static UVISOR_FORCEINLINE uint32_t *svc_cx_get_curr_sp(uint8_t box_id)
 {
     return g_svc_cx_curr_sp[box_id];
 }
 
-static void inline svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src_sp,
+static UVISOR_FORCEINLINE void svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src_sp,
                                      uint8_t dst_id)
 {
     /* check state stack overflow */
@@ -79,7 +79,7 @@ static void inline svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src
     g_active_box = dst_id;
 }
 
-static inline void svc_cx_pop_state(uint8_t dst_id, uint32_t *dst_sp)
+static UVISOR_FORCEINLINE void svc_cx_pop_state(uint8_t dst_id, uint32_t *dst_sp)
 {
     /* check state stack underflow */
     if(!g_svc_cx_state_ptr)

--- a/core/system/inc/svc_cx.h
+++ b/core/system/inc/svc_cx.h
@@ -59,8 +59,7 @@ static UVISOR_FORCEINLINE uint32_t *svc_cx_get_curr_sp(uint8_t box_id)
     return g_svc_cx_curr_sp[box_id];
 }
 
-static UVISOR_FORCEINLINE void svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src_sp,
-                                     uint8_t dst_id)
+static UVISOR_FORCEINLINE void svc_cx_push_state(uint8_t src_id, uint8_t type, uint32_t *src_sp, uint8_t dst_id)
 {
     /* check state stack overflow */
     if(g_svc_cx_state_ptr == UVISOR_SVC_CONTEXT_MAX_DEPTH)

--- a/core/system/inc/svc_gw.h
+++ b/core/system/inc/svc_gw.h
@@ -33,7 +33,7 @@ typedef struct {
     uint32_t *cfg_ptr;
 } UVISOR_PACKED TSecGw;
 
-static inline void svc_gw_check_magic(TSecGw *svc_pc)
+static UVISOR_FORCEINLINE void svc_gw_check_magic(TSecGw *svc_pc)
 {
     if(!vmpu_public_flash_addr((uint32_t) svc_pc))
         HALT_ERROR(SANITY_CHECK_FAILED,
@@ -48,12 +48,12 @@ static inline void svc_gw_check_magic(TSecGw *svc_pc)
                    "secure gateway magic invalid (0x%08X)\n", &svc_pc->magic);
 }
 
-static inline uint32_t svc_gw_get_dst_fn(TSecGw *svc_pc)
+static UVISOR_FORCEINLINE uint32_t svc_gw_get_dst_fn(TSecGw *svc_pc)
 {
     return svc_pc->dst_fn;
 }
 
-static inline uint8_t svc_gw_get_dst_id(TSecGw *svc_pc)
+static UVISOR_FORCEINLINE uint8_t svc_gw_get_dst_id(TSecGw *svc_pc)
 {
     uint8_t box_id;
 

--- a/core/uvisor.h
+++ b/core/uvisor.h
@@ -67,6 +67,13 @@ typedef void (*UnprivilegedBoxEntry)(void);
 #endif
 #endif/*CHANNEL_DEBUG*/
 
+/* Core-only compiler attributes
+ * These definitions should be shared by the uVisor library. */
+#define UVISOR_NOINLINE    __attribute__((noinline))
+#define UVISOR_ALIAS(f)    __attribute__((weak, alias (#f)))
+#define UVISOR_LINKTO(f)   __attribute__((alias (#f)))
+#define UVISOR_NAKED       __attribute__((naked))
+
 /* system wide error codes  */
 #include <iot-error.h>
 


### PR DESCRIPTION
This PR is a modification of [this previously filed PR](https://github.com/ARMmbed/uvisor/pull/210) by @c1728p9 .

It introduces the following changes:
* `ADDRESS_WRITE` is now a static inline function.
* Compiler attributes have been split into core-only and shared.
    * `UVISOR_FORCEINLINE` is now conditionally defined based on the toolchain.
* `vmpu_bits` is only defined with `UVISOR_PRESENT=1`.

@meriac @Patater @niklas-arm @c1728p9 

@c1728p9 Please it would help if you could test this on IAR as we don't have access to it yet.