### PR TITLE
Fix IAR again

### DIFF
--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -167,9 +167,9 @@ static UVISOR_FORCEINLINE uint8_t uvisor_read8(uint8_t volatile *addr)
 /* The conditional statement will be optimised away since the compiler already
  * knows the sizeof(type). */
 #define ADDRESS_READ(type, addr) \
-    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t * volatile) (addr)) : \
-     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t * volatile) (addr)) : \
-     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t * volatile) (addr)) : 0)
+    (sizeof(type) == 4 ? uvisor_read32((volatile uint32_t *) (addr)) : \
+     sizeof(type) == 2 ? uvisor_read16((volatile uint16_t *) (addr)) : \
+     sizeof(type) == 1 ? uvisor_read8((volatile uint8_t *) (addr)) : 0)
 
 /* The switch statement will be optimised away since the compiler already knows
  * the sizeof_type. */
@@ -177,13 +177,13 @@ static UVISOR_FORCEINLINE void __address_write(size_t sizeof_type, volatile uint
 {
     switch(sizeof_type) {
         case 4:
-            uvisor_write32((volatile uint32_t * volatile) addr, (uint32_t) val);
+            uvisor_write32((volatile uint32_t *) addr, (uint32_t) val);
             break;
         case 2:
-            uvisor_write16((volatile uint16_t * volatile) addr, (uint16_t) val);
+            uvisor_write16((volatile uint16_t *) addr, (uint16_t) val);
             break;
         case 1:
-            uvisor_write8((volatile uint8_t * volatile) addr, (uint8_t) val);
+            uvisor_write8((volatile uint8_t *) addr, (uint8_t) val);
             break;
     }
 }

--- a/api/inc/uvisor_exports.h
+++ b/api/inc/uvisor_exports.h
@@ -37,13 +37,17 @@
 /* Shared compiler attributes */
 #if defined(__ICCARM__)
 #define UVISOR_FORCEINLINE inline
+#define UVISOR_PACKED      __packed
+#define UVISOR_WEAK        __weak
+#define UVISOR_NORETURN    __noreturn
+#define UVISOR_RAMFUNC     __ramfunc
 #else
 #define UVISOR_FORCEINLINE inline __attribute__((always_inline))
-#endif
 #define UVISOR_PACKED      __attribute__((packed))
 #define UVISOR_WEAK        __attribute__((weak))
 #define UVISOR_NORETURN    __attribute__((noreturn))
 #define UVISOR_RAMFUNC     __attribute__ ((section (".ramfunc"), noinline))
+#endif
 
 /* array count macro */
 #define UVISOR_ARRAY_COUNT(x) (sizeof(x)/sizeof(x[0]))


### PR DESCRIPTION
Fixes:

* Attributes not re-defined for IAR.
* Wrong `volatile` cast previously introduced (see commit description).

@meriac @Patater @niklas-arm  @c1728p9 