### PR TITLE
Fix 2 ARMv7-M sanity check bugs

### DIFF
--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -36,19 +36,19 @@
 static UVISOR_FORCEINLINE int vmpu_public_flash_addr(uint32_t addr)
 {
     return (((uint32_t) addr >= FLASH_ORIGIN) &&
-            ((uint32_t) addr <= (FLASH_ORIGIN + (uint32_t) __uvisor_config.secure_start - 4)));
+            ((uint32_t) addr <= ((uint32_t) __uvisor_config.secure_start - 4)));
 }
 
 static UVISOR_FORCEINLINE int vmpu_flash_addr(uint32_t addr)
 {
     return (((uint32_t) addr >= FLASH_ORIGIN) &&
-            ((uint32_t) addr <= (FLASH_ORIGIN + (uint32_t) __uvisor_config.flash_end - 4)));
+            ((uint32_t) addr <= ((uint32_t) __uvisor_config.flash_end - 4)));
 }
 
 static UVISOR_FORCEINLINE int vmpu_sram_addr(uint32_t addr)
 {
     return (((uint32_t) addr >= SRAM_ORIGIN) &&
-            ((uint32_t) addr <= (SRAM_ORIGIN + (uint32_t) __uvisor_config.sram_end - 4)));
+            ((uint32_t) addr <= ((uint32_t) __uvisor_config.sram_end - 4)));
 }
 
 #define VMPU_REGION_SIZE(p1, p2) ((p1 >= p2) ? 0 : \

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -648,7 +648,7 @@ void vmpu_arch_init(void)
     if (ARMv7M_MPU_REGIONS != ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF)) {
         HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_REGIONS is inconsistent with actual region count.\n\r");
     }
-    if (ARMv7M_MPU_ALIGNMENT_BITS == vmpu_bits(aligment_mask)) {
+    if (ARMv7M_MPU_ALIGNMENT_BITS != vmpu_bits(aligment_mask)) {
         HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_ALIGNMENT_BITS are inconsistent with actual MPU alignment\n\r");
     }
     /* Init protected box memory enumeration pointer. */


### PR DESCRIPTION
Two bugs fixed:

* Wrong sanity check for MPU alignment bits in ARMv7-M. Fixes #207.
* Wrong offset in flash/SRAM address check when the memory origin is different from `0x0`.

@meriac @niklas-arm @Patater 