### PR TITLE
2. Add box index structure and initialize it

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -44,6 +44,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         0, \
         sizeof(UvisorBoxIndex), \
         0, \
+        0, \
         NULL, \
         acl_list, \
         acl_list_count \
@@ -62,6 +63,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
                 ( \
                     (UVISOR_MIN_STACK(stack_size) + \
                     (context_size) + \
+                    (__uvisor_box_heapsize) + \
                     sizeof(UvisorBoxIndex) \
                 ) \
             * 8) \
@@ -73,6 +75,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         UVISOR_MIN_STACK(stack_size), \
         sizeof(UvisorBoxIndex), \
         context_size, \
+        __uvisor_box_heapsize, \
         __uvisor_box_namespace, \
         acl_list, \
         acl_list_count \
@@ -112,6 +115,9 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
  * box_namespace as NULL. */
 #define UVISOR_BOX_NAMESPACE(box_namespace) \
     static const char *const __uvisor_box_namespace = box_namespace
+
+#define UVISOR_BOX_HEAPSIZE(heap_size) \
+    static const uint32_t __uvisor_box_heapsize = heap_size;
 
 #define uvisor_ctx (*__uvisor_ps)
 

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -42,6 +42,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         0, \
+        sizeof(UvisorBoxIndex), \
         0, \
         NULL, \
         acl_list, \
@@ -56,12 +57,21 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 #define __UVISOR_BOX_CONFIG(box_name, acl_list, acl_list_count, stack_size, context_size) \
     \
     uint8_t __attribute__((section(".keep.uvisor.bss.boxes"), aligned(32))) \
-        box_name ## _reserved[UVISOR_STACK_SIZE_ROUND(((UVISOR_MIN_STACK(stack_size) + (context_size))*8)/6)]; \
+        box_name ## _reserved[ \
+            UVISOR_STACK_SIZE_ROUND( \
+                ( \
+                    (UVISOR_MIN_STACK(stack_size) + \
+                    (context_size) + \
+                    sizeof(UvisorBoxIndex) \
+                ) \
+            * 8) \
+        / 6)]; \
     \
     static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig box_name ## _cfg = { \
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         UVISOR_MIN_STACK(stack_size), \
+        sizeof(UvisorBoxIndex), \
         context_size, \
         __uvisor_box_namespace, \
         acl_list, \
@@ -75,11 +85,11 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 
 #define __UVISOR_BOX_CONFIG_CONTEXT(box_name, acl_list, stack_size, context_type) \
     __UVISOR_BOX_CONFIG(box_name, acl_list, UVISOR_ARRAY_COUNT(acl_list), stack_size, sizeof(context_type)) \
-    UVISOR_EXTERN context_type * const uvisor_ctx;
+    UVISOR_EXTERN context_type *const *const __uvisor_ps;
 
 #define __UVISOR_BOX_CONFIG_NOACL(box_name, stack_size, context_type) \
     __UVISOR_BOX_CONFIG(box_name, NULL, 0, stack_size, sizeof(context_type)) \
-    UVISOR_EXTERN context_type * const uvisor_ctx;
+    UVISOR_EXTERN context_type *const *const __uvisor_ps;
 
 #define __UVISOR_BOX_CONFIG_NOACL_NOCONTEXT(box_name, stack_size) \
     __UVISOR_BOX_CONFIG(box_name, NULL, 0, stack_size, 0)
@@ -103,6 +113,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 #define UVISOR_BOX_NAMESPACE(box_namespace) \
     static const char *const __uvisor_box_namespace = box_namespace
 
+#define uvisor_ctx (*__uvisor_ps)
 
 /* Return the numeric box ID of the current box. */
 UVISOR_EXTERN int uvisor_box_id_self(void);

--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -67,6 +67,8 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 
 #define UVISOR_BOX_NAMESPACE(...)
 
+#define UVISOR_BOX_HEAPSIZE(...)
+
 /* uvisor-lib/interrupts.h */
 
 #define vIRQ_SetVector(irqn, vector)        NVIC_SetVector((IRQn_Type) (irqn), (uint32_t) (vector))

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -155,6 +155,8 @@ typedef struct {
     uint32_t index_size;
     /* Contains user provided size of box context without guards of buffers. */
     uint32_t context_size;
+    /* Contains user provided size of box heap without guards of buffers. */
+    uint32_t heap_size;
 
     const char * box_namespace;
     const UvisorBoxAclItem * const acl_list;
@@ -164,6 +166,14 @@ typedef struct {
 typedef struct {
     /* Pointer to the user context */
     void * ctx;
+    /* Pointer to the box heap */
+    void * box_heap;
+    /* Size of the box heap */
+    uint32_t box_heap_size;
+    /* Pointer to the currently active heap.
+     * This is set to `NULL` by uVisor, signalling to the user lib that the
+     * box heap needs to be initialized before use! */
+    void * active_heap;
     /* Pointer to the box config */
     const UvisorBoxConfig * config;
 } UVISOR_PACKED UvisorBoxIndex;

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -147,13 +147,26 @@ typedef struct {
 typedef struct {
     uint32_t magic;
     uint32_t version;
-    uint32_t stack_size;
-    uint32_t context_size;
-    const char * box_namespace;
 
+    /* Box stack size includes stack guards and rounding buffer. */
+    uint32_t stack_size;
+
+    /* Contains the size of the index (must be at least sizeof(UvisorBoxIndex)). */
+    uint32_t index_size;
+    /* Contains user provided size of box context without guards of buffers. */
+    uint32_t context_size;
+
+    const char * box_namespace;
     const UvisorBoxAclItem * const acl_list;
     uint32_t acl_count;
 } UVISOR_PACKED UvisorBoxConfig;
+
+typedef struct {
+    /* Pointer to the user context */
+    void * ctx;
+    /* Pointer to the box config */
+    const UvisorBoxConfig * config;
+} UVISOR_PACKED UvisorBoxIndex;
 
 /*
  * only use this macro for rounding const values during compile time:

--- a/api/src/disabled.c
+++ b/api/src/disabled.c
@@ -31,7 +31,7 @@ UVISOR_EXTERN uint32_t __uvisor_bss_boxes_start;
 
 /* The pointer to the uVisor context is declared by each box separately. Each
  * declaration will have its own type. */
-UVISOR_EXTERN void *uvisor_ctx;
+void * uvisor_ctx;
 
 /* Flag to check that contexts have been initialized */
 static bool g_initialized = false;

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -17,7 +17,7 @@
 .globl uvisor_init
 .globl uvisor_export_table_size
 .globl uvisor_config
-.globl uvisor_ctx
+.globl __uvisor_ps
 .type  uvisor_init, %function
 .weak  __uvisor_mode
 .globl __uvisor_priv_sys_irq_hooks
@@ -107,9 +107,11 @@ __uvisor_page_size:
     /* uvisor default page size is 16kB - user can override weak reference */
     .long 16384
 
-.section .bss
+/* __uvisor_ps is written inside uvisor_init. It must not be
+ * overwritten by libc init and therefore is placed in .uninitialized. */
+.section .uninitialized
 __uvisor_box_context:
-uvisor_ctx:
+__uvisor_ps:
     .long 0
 
 .section .keep.uvisor.bss.main, "awM", @nobits

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -84,6 +84,10 @@ uvisor_config:
     /* pointer to __uvisor_box_context */
     .long __uvisor_box_context
 
+    /* Pointers to beginning and end of main heap for box zero */
+    .long __uvisor_heap_start
+    .long __uvisor_heap_end
+
     /* Pointers to beginning and end of page heap */
     .long __uvisor_page_start
     .long __uvisor_page_end

--- a/core/debug/src/debug.c
+++ b/core/debug/src/debug.c
@@ -222,7 +222,7 @@ static void debug_deprivilege_and_return(void *debug_handler, void *return_handl
     dst_sp[7] = src_sp[7] | (dst_sp_align << 9);
 
     /* Set the context stack pointer for the destination box. */
-    *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[dst_id].context;
+    *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[dst_id].bss;
 
     /* Switch boxes. */
     vmpu_switch(src_id, dst_id);

--- a/core/system/inc/context.h
+++ b/core/system/inc/context.h
@@ -67,8 +67,8 @@ typedef struct {
 
 /** Current state of a box
  *
- * This struct contains the stack pointer and the context pointer for all boxes.
- * The context pointer is not expected to change once a box has been
+ * This struct contains the stack pointer and the bss pointer for all boxes.
+ * The bss pointer is expected not to change once a box has been
  * initialized. Instead, the stack pointer is updated at every context switch.
  *
  * @warning The stack pointer field is not an accurate snapshot of the boxes'
@@ -76,7 +76,7 @@ typedef struct {
  */
 typedef struct {
     uint32_t sp;        /**< Stack pointer */
-    uint32_t context;   /**< Context pointer */
+    uint32_t bss;       /**< Bss pointer */
 } TContextCurrentState;
 
 /** Currently active box */

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -65,6 +65,10 @@ typedef struct {
     /* address of __uvisor_box_context */
     uint32_t **uvisor_box_context;
 
+    /* Heap start and end addresses for box zero */
+    uint32_t * heap_start;
+    uint32_t * heap_end;
+
     /* Page allocator start and end addresses */
     uint32_t * page_start;
     uint32_t * page_end;

--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -140,7 +140,7 @@ extern int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr
 
 uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size);
 
-extern void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size);
+extern void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size);
 extern uint32_t vmpu_acl_static_region(uint8_t region, void* base, uint32_t size, UvisorBoxAcl acl);
 
 extern void vmpu_arch_init(void);

--- a/core/system/src/context.c
+++ b/core/system/src/context.c
@@ -192,7 +192,7 @@ void context_switch_in(TContextSwitchType context_type, uint8_t dst_id, uint32_t
     /* The source/destination box IDs can be the same (for example, in IRQs). */
     if (src_id != dst_id) {
         /* Update the context pointer to the one of the destination box. */
-        *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[dst_id].context;
+        *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[dst_id].bss;
 
         /* Update the ID of the currently active box. */
         g_active_box = dst_id;
@@ -261,7 +261,7 @@ TContextPreviousState * context_switch_out(TContextSwitchType context_type)
         g_active_box = src_id;
 
         /* Update the context pointer to the one of the source box. */
-        *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[src_id].context;
+        *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[src_id].bss;
 
         /* Switch MPU configurations. */
         /* This function halts if it finds an error. */

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -193,6 +193,24 @@ static void vmpu_load_boxes(void)
     const UvisorBoxConfig **box_cfgtbl;
     uint8_t box_id;
 
+    /* Check heap start and end addresses */
+    if (!__uvisor_config.heap_start || !vmpu_sram_addr((uint32_t) __uvisor_config.heap_start)) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "Heap start pointer (0x%08x) is not in SRAM memory.\n",
+            (uint32_t) __uvisor_config.heap_start);
+    }
+    if (!__uvisor_config.heap_end || !vmpu_sram_addr((uint32_t) __uvisor_config.heap_end)) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "Heap end pointer (0x%08x) is not in SRAM memory.\n",
+            (uint32_t) __uvisor_config.heap_end);
+    }
+    if (__uvisor_config.heap_end < __uvisor_config.heap_start) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "Heap end pointer (0x%08x) is smaller than heap start pointer (0x%08x).\n",
+            (uint32_t) __uvisor_config.heap_end,
+            (uint32_t) __uvisor_config.heap_start);
+    }
+
     /* enumerate boxes */
     g_vmpu_box_count = (uint32_t) (__uvisor_config.cfgtbl_ptr_end - __uvisor_config.cfgtbl_ptr_start);
     if (g_vmpu_box_count >= UVISOR_MAX_BOXES) {

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -559,7 +559,7 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
     uint32_t size, block_size;
 
     /* handle main box */
-    if(!box_id)
+    if (box_id == 0)
     {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
@@ -569,7 +569,8 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
         /* assign main box stack pointer to existing
          * unprivileged stack pointer */
         g_context_current_states[0].sp = __get_PSP();
-        g_context_current_states[0].bss = (uint32_t) NULL;
+        /* Box 0 still uses the main heap to be backwards compatible. */
+        g_context_current_states[0].bss = (uint32_t) __uvisor_config.heap_start;
         return;
     }
 

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -171,7 +171,7 @@ void vmpu_acl_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
 void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 {
     /* handle main box */
-    if(!box_id)
+    if (box_id == 0)
     {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
@@ -181,7 +181,8 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
         /* assign main box stack pointer to existing
          * unprivileged stack pointer */
         g_context_current_states[0].sp = __get_PSP();
-        g_context_current_states[0].bss = (uint32_t) NULL;
+        /* Box 0 still uses the main heap to be backwards compatible. */
+        g_context_current_states[0].bss = (uint32_t) __uvisor_config.heap_start;
         return;
     }
 

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -202,36 +202,32 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
     /* add stack protection band */
     g_box_mem_pos += UVISOR_STACK_BAND_SIZE;
 
-    /* add context ACL if needed */
-    if(!bss_size)
-        g_context_current_states[box_id].bss = (uint32_t) NULL;
-    else
-    {
-        bss_size = UVISOR_REGION_ROUND_UP(bss_size);
-        g_context_current_states[box_id].bss = g_box_mem_pos;
+    /* add context ACL */
+    assert(bss_size != 0);
+    bss_size = UVISOR_REGION_ROUND_UP(bss_size);
+    g_context_current_states[box_id].bss = g_box_mem_pos;
 
-        DPRINTF("erasing box context at 0x%08X (%u bytes)\n",
-            g_box_mem_pos,
-            bss_size
-        );
+    DPRINTF("erasing box context at 0x%08X (%u bytes)\n",
+        g_box_mem_pos,
+        bss_size
+    );
 
-        /* reset uninitialized secured box context */
-        memset(
-            (void *) g_box_mem_pos,
-            0,
-            bss_size
-        );
+    /* reset uninitialized secured box context */
+    memset(
+        (void *) g_box_mem_pos,
+        0,
+        bss_size
+    );
 
-        /* add context ACL */
-        vmpu_acl_add(
-            box_id,
-            (void*)g_box_mem_pos,
-            bss_size,
-            UVISOR_TACLDEF_DATA
-        );
+    /* add context ACL */
+    vmpu_acl_add(
+        box_id,
+        (void*)g_box_mem_pos,
+        bss_size,
+        UVISOR_TACLDEF_DATA
+    );
 
-        g_box_mem_pos += bss_size + UVISOR_STACK_BAND_SIZE;
-    }
+    g_box_mem_pos += bss_size + UVISOR_STACK_BAND_SIZE;
 }
 
 void vmpu_switch(uint8_t src_box, uint8_t dst_box)

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -168,20 +168,20 @@ void vmpu_acl_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
             HALT_ERROR(SANITY_CHECK_FAILED, "ACL sanity check failed [%i]\n", res);
 }
 
-void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size)
+void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 {
     /* handle main box */
     if(!box_id)
     {
-        DPRINTF("ctx=%i stack=%i\n\r", context_size, stack_size);
+        DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
-        assert(context_size == 0);
+        assert(bss_size == 0);
         assert(stack_size == 0);
 
         /* assign main box stack pointer to existing
          * unprivileged stack pointer */
         g_context_current_states[0].sp = __get_PSP();
-        g_context_current_states[0].context = (uint32_t) NULL;
+        g_context_current_states[0].bss = (uint32_t) NULL;
         return;
     }
 
@@ -203,34 +203,34 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t context_size, uint32_t stack_size)
     g_box_mem_pos += UVISOR_STACK_BAND_SIZE;
 
     /* add context ACL if needed */
-    if(!context_size)
-        g_context_current_states[box_id].context = (uint32_t) NULL;
+    if(!bss_size)
+        g_context_current_states[box_id].bss = (uint32_t) NULL;
     else
     {
-        context_size = UVISOR_REGION_ROUND_UP(context_size);
-        g_context_current_states[box_id].context = g_box_mem_pos;
+        bss_size = UVISOR_REGION_ROUND_UP(bss_size);
+        g_context_current_states[box_id].bss = g_box_mem_pos;
 
         DPRINTF("erasing box context at 0x%08X (%u bytes)\n",
             g_box_mem_pos,
-            context_size
+            bss_size
         );
 
         /* reset uninitialized secured box context */
         memset(
             (void *) g_box_mem_pos,
             0,
-            context_size
+            bss_size
         );
 
         /* add context ACL */
         vmpu_acl_add(
             box_id,
             (void*)g_box_mem_pos,
-            context_size,
+            bss_size,
             UVISOR_TACLDEF_DATA
         );
 
-        g_box_mem_pos += context_size + UVISOR_STACK_BAND_SIZE;
+        g_box_mem_pos += bss_size + UVISOR_STACK_BAND_SIZE;
     }
 }
 


### PR DESCRIPTION
This introduces a box index in box bss memory, augmenting the concept of the ctx pointer with additional information such the box config, heaps, box id.
uVisor initializes the box index and allows for the user to declare additional reserved box index space by overwriting the __uvisor_box_index_size constant.

Note: This builds directly on top of #227, but does not directly depend on it.

cc @Patater @AlessandroA @meriac