### PR TITLE
3. Add tier-2 allocator and initialization

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -42,7 +42,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         0, \
-        sizeof(UvisorBoxIndex), \
+        sizeof(RtxBoxIndex), \
         0, \
         0, \
         NULL, \
@@ -64,7 +64,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
                     (UVISOR_MIN_STACK(stack_size) + \
                     (context_size) + \
                     (__uvisor_box_heapsize) + \
-                    sizeof(UvisorBoxIndex) \
+                    sizeof(RtxBoxIndex) \
                 ) \
             * 8) \
         / 6)]; \
@@ -73,7 +73,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         UVISOR_MIN_STACK(stack_size), \
-        sizeof(UvisorBoxIndex), \
+        sizeof(RtxBoxIndex), \
         context_size, \
         __uvisor_box_heapsize, \
         __uvisor_box_namespace, \

--- a/api/rtx/inc/process_malloc.h
+++ b/api/rtx/inc/process_malloc.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __RTX_PROCESS_MALLOC_H__
+#define __RTX_PROCESS_MALLOC_H__
+
+#include "secure_allocator.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Allocate memory on the process heap. */
+void * malloc_p(size_t size);
+/* Reallocate memory on the process heap. */
+void * realloc_p(void * ptr, size_t size);
+/* Free memory on the process heap. */
+void free_p(void * ptr);
+
+#ifdef __cplusplus
+}   /* extern "C" */
+#endif
+
+#endif  /* __RTX_PROCESS_MALLOC_H__ */

--- a/api/rtx/inc/rtx_box_index.h
+++ b/api/rtx/inc/rtx_box_index.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __RTX_BOX_INDEX_H__
+#define __RTX_BOX_INDEX_H__
+
+#include "cmsis_os.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    /* The uvisor box index must be placed at the beginning */
+    UvisorBoxIndex index;
+
+    /* Id of the mutex */
+    osMutexId mutex_id;
+    /* Pointer to the data of the mutex */
+    osMutexDef_t mutex;
+    /* Internal data of the mutex */
+    int32_t mutex_data[4];
+} RtxBoxIndex;
+
+#ifdef __cplusplus
+}   /* extern "C" */
+#endif
+
+#endif  /* __RTX_BOX_INDEX_H__ */

--- a/api/rtx/inc/secure_allocator.h
+++ b/api/rtx/inc/secure_allocator.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __SECURE_ALLOCATOR_H__
+#define __SECURE_ALLOCATOR_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Contains the allocator data and backing page table. */
+typedef void * SecureAllocator;
+
+/** Create an allocator in-place in an existing pool without using pages.
+ * Use this to turn statically allocated memory into a heap.
+ * Or allocate a large piece of memory and then turn that into a heap.
+ *
+ * @param mem   Pointer to the origin of the memory pool
+ * @param bytes Length of the memory pool in bytes
+ * @returns the allocator or `NULL` on failure
+ */
+SecureAllocator secure_allocator_create_with_pool(
+    void * mem,
+    size_t bytes);
+
+/** Create an allocator using pages from the page heap.
+ * Use this to request secure dynamic memory for your process.
+ * Note that this memory is not guaranteed to be consecutive, therefore you
+ * must specify the maximum allocation size that you plan to use in this
+ * allocator. This function will then compute the number and size of required
+ * pages and request them from the secure page heap.
+ *
+ * @param total_size          The minimal total size of the heap
+ * @param maximum_malloc_size The largest size to be allocated in one chunk
+ * @returns the allocator or `NULL` on failure (out of memory,
+ *          maximum malloc size cannot be fulfilled)
+ */
+SecureAllocator secure_allocator_create_with_pages(
+    size_t total_size,
+    size_t maximum_malloc_size);
+
+/** Destroy the allocator and free the backing pages.
+ * An attempt to destroy a memory-pool backed allocator will fail and return
+ * with an error code.
+ *
+ * @retval 0  Allocator successfully destroyed.
+ * @retval -1 Allocator is static (memory-pool), or freeing memory pages failed.
+ */
+int secure_allocator_destroy(
+    SecureAllocator allocator);
+
+/** Drop-in for `malloc`. */
+void * secure_malloc(
+    SecureAllocator allocator,
+    size_t size);
+
+/** Drop-in for `realloc`. */
+void * secure_realloc(
+    SecureAllocator allocator,
+    void * ptr,
+    size_t size);
+
+/** Drop-in for `free`. */
+void secure_free(
+    SecureAllocator allocator,
+    void * ptr);
+
+#ifdef __cplusplus
+}   /* extern "C" */
+#endif
+
+#endif  /* __SECURE_ALLOCATOR_H__ */

--- a/api/rtx/src/rtx_malloc_wrapper.c
+++ b/api/rtx/src/rtx_malloc_wrapper.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cmsis_os.h"
+#include "uvisor-lib/uvisor-lib.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <reent.h>
+
+#define OP_MALLOC  0
+#define OP_REALLOC 1
+#define OP_FREE    2
+
+#define HEAP_ACTIVE  0
+#define HEAP_PROCESS 1
+
+/* Use printf with caution inside malloc: printf may allocate memory itself,
+   so using printf in malloc may lead to recursive calls! */
+#define DPRINTF(...) {};
+
+extern RtxBoxIndex * const __uvisor_ps;
+
+/** @retval 0 The kernel is not initialized.
+ *  @retval 1 The kernel is initialized.. */
+static int is_kernel_initialized()
+{
+    static uint8_t kernel_running = 0;
+    if (kernel_running) {
+        return 1;
+    }
+    if (osKernelRunning()) {
+        kernel_running = 1;
+        return 1;
+    }
+    return 0;
+}
+
+static int init_allocator()
+{
+    int ret = 0;
+    if (__uvisor_ps == NULL) {
+        return -1;
+    }
+
+    if ((__uvisor_ps->mutex_id == NULL) && is_kernel_initialized()) {
+        /* Point the mutex pointer to the data. */
+        __uvisor_ps->mutex.mutex = &(__uvisor_ps->mutex_data);
+        /* Create mutex if not already done. */
+        __uvisor_ps->mutex_id = osMutexCreate(&(__uvisor_ps->mutex));
+        /* Mutex failed to be created. */
+        if (__uvisor_ps->mutex_id == NULL) {
+            return -1;
+        }
+    }
+
+    if (__uvisor_ps->index.active_heap == NULL) {
+        /* We need to initialize the process heap. */
+        if (__uvisor_ps->index.box_heap != NULL) {
+            /* Lock the mutex during initialization. */
+            int kernel_initialized = is_kernel_initialized();
+            if (kernel_initialized) {
+                osMutexWait(__uvisor_ps->mutex_id, osWaitForever);
+            }
+            /* Initialize the process heap. */
+            SecureAllocator allocator = secure_allocator_create_with_pool(
+                __uvisor_ps->index.box_heap,
+                __uvisor_ps->index.box_heap_size);
+            /* Set the allocator. */
+            ret = allocator ? 0 : -1;
+            __uvisor_ps->index.active_heap = allocator;
+            /* Release the mutex. */
+            if (kernel_initialized) {
+                osMutexRelease(__uvisor_ps->mutex_id);
+            }
+        }
+        else {
+            DPRINTF("uvisor_allocator: No process heap available!\n");
+            ret = -1;
+        }
+    }
+    return ret;
+}
+
+static void * memory(void * ptr, size_t size, int heap, int operation)
+{
+    /* Buffer the return value. */
+    void * ret = NULL;
+    /* Initialize allocator. */
+    if (init_allocator()) {
+        return NULL;
+    }
+    /* Check if we need to aquire the mutex. */
+    int mutexed = (is_kernel_initialized() && (heap == HEAP_PROCESS));
+    void * allocator = (heap == HEAP_PROCESS) ?
+                       (__uvisor_ps->index.box_heap) :
+                       (__uvisor_ps->index.active_heap);
+
+    /* Aquire the mutex if required.
+     * TODO: Mutex use is very coarse here. It may be sufficient to guard
+     * the `rt_alloc_mem` and `rt_free_mem` functions in `uvisor_allocator.c`.
+     * However, it is simpler to do it here for now. */
+    if (mutexed) {
+        osMutexWait(__uvisor_ps->mutex_id, osWaitForever);
+    }
+    /* Perform the required operation. */
+    switch(operation)
+    {
+        case OP_MALLOC:
+            ret = secure_malloc(allocator, size);
+            break;
+        case OP_REALLOC:
+            ret = secure_realloc(allocator, ptr, size);
+            break;
+        case OP_FREE:
+            secure_free(allocator, ptr);
+            break;
+        default:
+            break;
+    }
+    /* Release the mutex if required. */
+    if (mutexed) {
+        osMutexRelease(__uvisor_ps->mutex_id);
+    }
+    return ret;
+}
+
+/* Wrapped memory management functions. */
+#if defined (__CC_ARM)
+void * $Sub$$_malloc_r(struct _reent * r, size_t size) {
+    return memory(r, size, HEAP_ACTIVE, OP_MALLOC);
+}
+void * $Sub$$_realloc_r(struct _reent * r, void * ptr, size_t size) {
+    (void)r;
+    return memory(ptr, size, HEAP_ACTIVE, OP_REALLOC);
+}
+void $Sub$$_free_r(struct _reent * r, void * ptr) {
+    (void)r;
+    memory(ptr, 0, HEAP_ACTIVE, OP_FREE);
+}
+#elif defined (__GNUC__)
+void * __wrap__malloc_r(struct _reent * r, size_t size) {
+    return memory(r, size, HEAP_ACTIVE, OP_MALLOC);
+}
+void * __wrap__realloc_r(struct _reent * r, void * ptr, size_t size) {
+    (void)r;
+    return memory(ptr, size, HEAP_ACTIVE, OP_REALLOC);
+}
+void __wrap__free_r(struct _reent * r, void * ptr) {
+    (void)r;
+    memory(ptr, 0, HEAP_ACTIVE, OP_FREE);
+}
+#elif defined (__ICCARM__)
+/* TODO: Find out how to do function wrapping for IARCC. */
+/* TODO: newlib allocator is not thread-safe! */
+#   warning "Using uVisor allocator is not available for IARCC. Falling back to newlib allocator."
+#endif

--- a/api/rtx/src/rtx_malloc_wrapper.c
+++ b/api/rtx/src/rtx_malloc_wrapper.c
@@ -170,3 +170,13 @@ void __wrap__free_r(struct _reent * r, void * ptr) {
 /* TODO: newlib allocator is not thread-safe! */
 #   warning "Using uVisor allocator is not available for IARCC. Falling back to newlib allocator."
 #endif
+
+void * malloc_p(size_t size) {
+    return memory(NULL, size, HEAP_PROCESS, OP_MALLOC);
+}
+void * realloc_p(void * ptr, size_t size) {
+    return memory(ptr, size, HEAP_PROCESS, OP_REALLOC);
+}
+void free_p(void * ptr) {
+    memory(ptr, 0, HEAP_PROCESS, OP_FREE);
+}

--- a/api/rtx/src/secure_allocator.c
+++ b/api/rtx/src/secure_allocator.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rt_TypeDef.h"
+#include "rt_Memory.h"
+
+#include "secure_allocator.h"
+#include "uvisor-lib/uvisor-lib.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Use printf with caution inside malloc: printf may allocate memory itself,
+   so using printf in malloc may lead to recursive calls! */
+#define DPRINTF(...) {}
+
+/* offsetof is a gcc built-in function, this is the manual implementation */
+#define OFFSETOF(type, member) ((uint32_t) (&(((type *)(0))->member)))
+
+/* Declare this variable here, so the tier-2 allocator _always_ uses the
+ * page size that the tier-1 allocator expects! */
+const uint32_t __uvisor_page_size = UVISOR_PAGE_SIZE;
+
+/* Internal structure currently only contains the page table. */
+typedef struct {
+    UvisorPageTable table;
+} SecureAllocatorInternal;
+
+static inline UvisorPageTable * table(SecureAllocator allocator) {
+    return &(((SecureAllocatorInternal *) allocator)->table);
+}
+
+SecureAllocator secure_allocator_create_with_pool(
+    void * mem,
+    size_t bytes)
+{
+    SecureAllocatorInternal * allocator = mem;
+    /* Signal that this is non-page allocated memory. */
+    allocator->table.page_size = bytes;
+    allocator->table.page_count = 0;
+    /* The internal rt_Memory MEMP structure must be placed AFTER table.page_origins[0] !!! */
+    size_t offset = OFFSETOF(SecureAllocatorInternal, table.page_origins) + sizeof(((UvisorPageTable) {0}).page_origins);
+    /* Create MEMP structure inside the memory. */
+    if (rt_init_mem(mem + offset, bytes - offset)) {
+        /* Abort if failed. */
+        DPRINTF("secure_allocator_create_with_pool: MEMP allocator creation failed\n\n");
+        return NULL;
+    }
+    /* Remember the MEMP pointer though. */
+    allocator->table.page_origins[0] = mem + offset;
+    DPRINTF("secure_allocator_create_with_pool: Created MEMP allocator %p with offset %d\n\n", mem + offset, offset);
+    return allocator;
+}
+
+SecureAllocator secure_allocator_create_with_pages(
+    size_t size,
+    size_t maximum_malloc_size)
+{
+    /* The rt_Memory allocator puts one MEMP structure at both the
+     * beginning and end of the memory pool. */
+    const size_t block_overhead = 2 * sizeof(MEMP);
+    const size_t page_size_with_overhead = UVISOR_PAGE_SIZE + block_overhead;
+    /* Calculate the integer part of required the page count. */
+    size_t page_count = size / page_size_with_overhead;
+    /* Add another page if the remainder is not zero. */
+    if (size - page_count * page_size_with_overhead) {
+        page_count++;
+    }
+    DPRINTF("secure_allocator_create_with_pages: Requesting %u pages for at least %uB\n", page_count, size);
+
+    /* Compute the maximum allocation within our blocks. */
+    size_t maximum_allocation_size = UVISOR_PAGE_SIZE - block_overhead;
+    /* If the required maximum allocation is larger than we can provide, abort. */
+    if (maximum_malloc_size > maximum_allocation_size) {
+        DPRINTF("secure_allocator_create_with_pages: Maximum allocation request %uB is larger then available %uB\n\n", maximum_malloc_size, maximum_allocation_size);
+        return NULL;
+    }
+
+    /* Compute the required memory size for the page table. */
+    size_t allocator_type_size = sizeof(SecureAllocatorInternal);
+    /* Add size for each additional page. */
+    allocator_type_size += (page_count - 1) * sizeof(((UvisorPageTable) {0}).page_origins);
+    /* Allocate this much memory. */
+    SecureAllocatorInternal * const allocator = malloc(allocator_type_size);
+    /* If malloc failed, abort. */
+    if (allocator == NULL) {
+        DPRINTF("secure_allocator_create_with_pages: SecureAllocatorInternal failed to be allocated!\n\n");
+        return NULL;
+    }
+
+    /* Prepare the page table. */
+    allocator->table.page_size = UVISOR_PAGE_SIZE;
+    allocator->table.page_count = page_count;
+    /* Get me some pages. */
+    if (uvisor_page_malloc((UvisorPageTable *) &(allocator->table))) {
+        free(allocator);
+        DPRINTF("secure_allocator_create_with_pages: Not enough free pages available!\n\n");
+        return NULL;
+    }
+
+    /* Initialize a MEMP structure in all pages. */
+    for(size_t ii = 0; ii < page_count; ii++) {
+        /* Add each page as a pool. */
+        rt_init_mem(allocator->table.page_origins[ii], UVISOR_PAGE_SIZE);
+        DPRINTF("secure_allocator_create_with_pages: Created MEMP allocator %p with offset %d\n", allocator->table.page_origins[ii], 0);
+    }
+    DPRINTF("\n");
+    /* Aaaand across the line. */
+    return (SecureAllocator) allocator;
+}
+
+int secure_allocator_destroy(
+    SecureAllocator allocator)
+{
+    DPRINTF("secure_allocator_destroy: Destroying MEMP allocator at %p\n", table(allocator)->page_origins[0]);
+
+    /* Check if we are working on statically allocated memory. */
+    SecureAllocatorInternal * alloc = (SecureAllocatorInternal * const) allocator;
+    if (alloc->table.page_count == 0) {
+        DPRINTF("secure_allocator_destroy: %p is not page-backed memory, not freeing!\n", allocator);
+        return -1;
+    }
+
+    /* Free all pages. */
+    if (uvisor_page_free(&(alloc->table))) {
+        DPRINTF("secure_allocator_destroy: Unable to free pages!\n\n");
+        return -1;
+    }
+
+    /* Free the allocator structure. */
+    free(allocator);
+
+    DPRINTF("\n");
+    return 0;
+}
+
+void * secure_malloc(
+    SecureAllocator allocator,
+    size_t size)
+{
+    size_t index = 0;
+    do {
+        /* Search in this page. */
+        void * mem = rt_alloc_mem(table(allocator)->page_origins[index], size);
+        /* Return if we found something. */
+        if (mem) {
+            DPRINTF("secure_malloc: Found %4uB in page %u at %p\n", size, index, mem);
+            return mem;
+        }
+        /* Otherwise, go to the next page. */
+        index++;
+    } /* Continue search if more pages are available. */
+    while (index < table(allocator)->page_count);
+
+    DPRINTF("secure_malloc: Out of memory in allocator %p \n", allocator);
+    /* We found nothing. */
+    return NULL;
+}
+
+void * secure_realloc(
+    SecureAllocator allocator,
+    void * ptr,
+    size_t new_size)
+{
+    /* TODO: THIS IS A NAIVE IMPLEMENTATION, which always allocates new
+       memory, and copies the memory, then frees the old memory. */
+
+    /* Allocate new memory. */
+    void * new_ptr = secure_malloc(allocator, new_size);
+    /* If memory allocation failed, abort. */
+    if (new_ptr == NULL) {
+        return NULL;
+    }
+
+    /* Passing NULL as ptr is legal, realloc acts as malloc then. */
+    if (ptr) {
+        /* Get the size of the ptr memory. */
+        size_t size = ((MEMP *) ((uint32_t) ptr - sizeof(MEMP)))->len;
+        /* Copy the memory to the new location, min(new_size, size). */
+        memcpy(new_ptr, ptr, new_size < size ? new_size : size);
+        /* Free the previous memory. */
+        secure_free(allocator, ptr);
+    }
+    return new_ptr;
+}
+
+void secure_free(
+    SecureAllocator allocator,
+    void * ptr)
+{
+    size_t index = 0;
+    do {
+        /* Search in this page. */
+        int ret = rt_free_mem(table(allocator)->page_origins[index], ptr);
+        /* Return if free was successful. */
+        if (ret == 0) {
+            DPRINTF("secure_free: Freed %p in page %u.\n", ptr, index);
+            return;
+        }
+        /* Otherwise, go to the next page. */
+        index++;
+    } /* Continue search if more pages are available. */
+    while (index < table(allocator)->page_count);
+
+    DPRINTF("secure_free: %p not found in allocator %p!\n", ptr, allocator);
+    /* We found nothing. */
+    return;
+}


### PR DESCRIPTION
This adds the required glue code for connecting the tier-2 with the tier-1 allocator incl. initialization of heaps on first allocation.
Also adds mutex protection to process heap via extended box index.

Note: This builds directly on top of #230 and depends on it!

cc @Patater @AlessandroA @meriac