### PR TITLE
4. Add initialization of box index and page allocator for unsupported targets

### DIFF
--- a/api/rtx/src/rtx_malloc_wrapper.c
+++ b/api/rtx/src/rtx_malloc_wrapper.c
@@ -55,7 +55,12 @@ static int init_allocator()
 {
     int ret = 0;
     if (__uvisor_ps == NULL) {
+#if defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1)
         return -1;
+#else
+        extern void secure_malloc_init(void);
+        secure_malloc_init();
+#endif
     }
 
     if ((__uvisor_ps->mutex_id == NULL) && is_kernel_initialized()) {

--- a/api/rtx/src/unsupported_malloc.c
+++ b/api/rtx/src/unsupported_malloc.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "uvisor-lib/uvisor-lib.h"
+
+#if !(defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1))
+
+#include <string.h> /* for memset */
+
+/* Forward declaration of the page allocator API. */
+extern void page_allocator_init(void * const heap_start, void * const heap_end, const uint32_t * const page_size);
+
+extern uint32_t __end__[];      /* __heap_start */
+extern uint32_t __HeapLimit[];  /* __heap_end   */
+
+extern uint32_t __StackLimit[];   /* bottom of stack */
+
+/* There is only one box index for box 0. */
+RtxBoxIndex * __uvisor_ps;
+
+static void box_index_init(void *box_bss, uint32_t heap_size)
+{
+    const uint32_t index_size = sizeof(RtxBoxIndex);
+    /* Adjust size for overhead of box index */
+    heap_size -= index_size;
+
+    /* The box index is at the beginning of the bss section */
+    RtxBoxIndex *const indexOS = box_bss;
+    /* Zero the _entire_ index, so that we know to initialize the mutex on
+     * first use! */
+    memset(box_bss, 0, index_size);
+    /* Initialize user context */
+    indexOS->index.ctx = NULL;
+    /* Initialize box heap */
+    indexOS->index.box_heap = box_bss + index_size;
+    indexOS->index.box_heap_size = heap_size;
+    /* Active heap pointer is NULL */
+    indexOS->index.active_heap = NULL;
+
+    /* There is no box config for unsupported! */
+    indexOS->index.config = NULL;
+
+    /* Set the index */
+    __uvisor_ps = indexOS;
+}
+
+void secure_malloc_init(void)
+{
+    /* get the main heap size from the linker script */
+    uint32_t heap_size = ((uint32_t) __HeapLimit -
+                          (uint32_t) __end__);
+    /* Main heap size is aligned to page boundaries n*UVISOR_PAGE_SIZE */
+    uint32_t heap_start = (uint32_t) __StackLimit - heap_size;
+    /* align the start address of the main heap to a page boundary */
+    heap_start &= ~(UVISOR_PAGE_SIZE - 1);
+    /* adjust the heap size to the new heap start address */
+    heap_size = (uint32_t) __StackLimit - heap_start;
+
+    /* page heap now extends from the previous main heap start address
+     * to the new main heap start address */
+    extern uint32_t __uvisor_page_size;
+    page_allocator_init(__end__, (void *) heap_start, &__uvisor_page_size);
+    box_index_init((void *) heap_start, heap_size);
+}
+
+#endif

--- a/api/rtx/src/unsupported_page_allocator.c
+++ b/api/rtx/src/unsupported_page_allocator.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "uvisor-lib/uvisor-lib.h"
+
+#if !(defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1))
+
+#include "cmsis.h"
+
+/* This is the fallback implementation for using the page allocator from uVisor
+ * inside an OS as a normal function.
+ * Be aware that the page allocator is not re-entrant, so the OS must provide a
+ * mutex implementation to enable thread-safety!
+ */
+#define DPRINTF(...) {}
+#define g_active_box 0
+#define vmpu_is_box_id_valid(...) 0
+#define vmpu_public_flash_addr(...) 1
+#define vmpu_sram_addr(...) 1
+#define HALT_ERROR(id, ...) {}
+#define UVISOR_PAGE_ALLOCATOR_MUTEX_AQUIRE  page_allocator_mutex_aquire()
+#define UVISOR_PAGE_ALLOCATOR_MUTEX_RELEASE osMutexRelease(g_page_allocator_mutex_id)
+
+/* Forward declaration of the page allocator API. */
+int page_allocator_malloc(UvisorPageTable * const table);
+int page_allocator_free(const UvisorPageTable * const table);
+
+int uvisor_page_malloc(UvisorPageTable *const table)
+{
+    return page_allocator_malloc(table);
+}
+
+int uvisor_page_free(const UvisorPageTable *const table)
+{
+    return page_allocator_free(table);
+}
+
+/* Implement mutex for page allocator. */
+static osMutexId g_page_allocator_mutex_id = NULL;
+static int32_t g_page_allocator_mutex_data[4];
+static const osMutexDef_t g_page_allocator_mutex = { g_page_allocator_mutex_data };
+
+static void page_allocator_mutex_aquire()
+{
+    if (g_page_allocator_mutex_id == NULL) {
+        /* Create mutex if not already done. */
+        g_page_allocator_mutex_id = osMutexCreate(&g_page_allocator_mutex);
+        if (g_page_allocator_mutex_id == NULL) {
+            /* Mutex failed to be created. */
+            return;
+        }
+    }
+
+    osMutexWait(g_page_allocator_mutex_id, osWaitForever);
+}
+
+/* Alignment of MPU regions is not required anymore, however we still require
+ * a 32B alignment, to have some page size granularity. */
+static inline int vmpu_is_region_size_valid(uint32_t size)
+{
+    return ((size & ~31) == size);
+}
+static inline uint32_t vmpu_round_up_region(uint32_t addr, uint32_t size)
+{
+    if (!vmpu_is_region_size_valid(size)) {
+        return 0;
+    }
+    const uint32_t mask = size - 1;
+    /* Adding the mask can overflow. */
+    const uint32_t rounded_addr = addr + mask;
+    /* Check for overflow. */
+    if (rounded_addr < addr) {
+        /* This means the address was too large to align. */
+        return 0;
+    }
+    /* Mask the rounded address to get the aligned address. */
+    return (rounded_addr & ~mask);
+}
+static inline uint32_t page_table_read(uint32_t addr)
+{
+    return *((uint32_t *) addr);
+}
+static inline void page_table_write(uint32_t addr, uint32_t data)
+{
+    *((uint32_t *) addr) = data;
+}
+
+/* Include the original page allocator source directly. */
+#include "source/page_allocator.c_inc"
+
+#endif


### PR DESCRIPTION
This adds initialization for unsupported targets, where the page heap is placed inside the main heap, while leaving the main heap intact, which means this is compatible with existing CMSIS linker scripts.

Note: This builds on #231 and depends on it!

Actual diff:
- Move unsupported.c into rtx/src folder.
- Add uvisor_malloc_init for unsupported targets

cc @Patater @AlessandroA @meriac 