### PR TITLE
Register level gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ SOURCES:=\
          $(CORE_SYSTEM_DIR)/src/halt.c \
          $(CORE_SYSTEM_DIR)/src/main.c \
          $(CORE_SYSTEM_DIR)/src/page_allocator.c \
+         $(CORE_SYSTEM_DIR)/src/register_gateway.c \
          $(CORE_SYSTEM_DIR)/src/stdlib.c \
          $(CORE_SYSTEM_DIR)/src/svc.c \
          $(CORE_SYSTEM_DIR)/src/unvic.c \

--- a/api/inc/context_exports.h
+++ b/api/inc/context_exports.h
@@ -17,9 +17,10 @@
 #ifndef __UVISOR_CONTEX_EXPORTS_H__
 #define __UVISOR_CONTEX_EXPORTS_H__
 
-/** Maximum number of nested context switches. The same state stack is kept for
- * all kinds of context switches, which includes secure gateways, interrupts,
- * and task switching. */
+/** Maximum number of nested context switches.
+ *
+ * The same state stack is kept for all kinds of context switches that are bound
+ * to a function, for which uVisor keeps an internal state. */
 #define UVISOR_CONTEXT_MAX_DEPTH 16
 
 #endif /* __UVISOR_CONTEX_EXPORTS_H__ */

--- a/api/inc/register_gateway.h
+++ b/api/inc/register_gateway.h
@@ -32,8 +32,8 @@
 #error "Unsupported instruction set. The ARM Thumb-2 instruction set must be supported."
 #endif /* __thumb__ && __thumb2__ */
 
-/* register gateway operations */
-/* note: do not use special characters as these numbers will be stringified */
+/* Register gateway operations */
+/* Note: Do not use special characters as these numbers will be stringified. */
 #define UVISOR_OP_READ(op)  (op)
 #define UVISOR_OP_WRITE(op) ((1 << 4) | (op))
 #define UVISOR_OP_NOP       0x0
@@ -41,17 +41,17 @@
 #define UVISOR_OP_OR        0x2
 #define UVISOR_OP_XOR       0x3
 
-/* default mask for whole register operatins */
+/* Default mask for whole register operatins. */
 #define __UVISOR_OP_DEFAULT_MASK 0x0
 
-/* register gateway metadata */
+/* Register gateway metadata */
 #if defined(__CC_ARM)
 
 /* TODO/FIXME */
 
 #elif defined(__GNUC__)
 
-/* 1 argument: simple read, no mask */
+/* 1 argument: Simple read, no mask */
 #define __UVISOR_REGISTER_GATEWAY_METADATA1(src_box, addr) \
     "b.n skip_args%=\n" \
     ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
@@ -61,7 +61,7 @@
     ".word " UVISOR_TO_STRING(__UVISOR_OP_DEFAULT_MASK) "\n" \
     "skip_args%=:\n"
 
-/* 2 arguments: simple write, no mask */
+/* 2 arguments: Simple write, no mask */
 #define __UVISOR_REGISTER_GATEWAY_METADATA2(src_box, addr, val) \
     "b.n skip_args%=\n" \
     ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
@@ -71,7 +71,7 @@
     ".word " UVISOR_TO_STRING(__UVISOR_OP_DEFAULT_MASK) "\n" \
     "skip_args%=:\n"
 
-/* 3 arguments: masked read */
+/* 3 arguments: Masked read */
 #define __UVISOR_REGISTER_GATEWAY_METADATA3(src_box, addr, op, mask) \
     "b.n skip_args%=\n" \
     ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
@@ -81,7 +81,7 @@
     ".word " UVISOR_TO_STRING(mask) "\n" \
     "skip_args%=:\n"
 
-/* 4 arguments: masked write */
+/* 4 arguments: Masked write */
 #define __UVISOR_REGISTER_GATEWAY_METADATA4(src_box, addr, val, op, mask) \
     "b.n skip_args%=\n" \
     ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
@@ -98,10 +98,11 @@
                                               __UVISOR_REGISTER_GATEWAY_METADATA3, \
                                               __UVISOR_REGISTER_GATEWAY_METADATA2, \
                                               __UVISOR_REGISTER_GATEWAY_METADATA1, \
-                                              /* no macro for 0 args */          )(src_box, ##__VA_ARGS__)
+                                              /* No macro for 0 args */          )(src_box, ##__VA_ARGS__)
 
-/* register-level gateway - read */
-/* FIXME currently only a hardcoded 32bit constant can be used for the addr field */
+/* Rregister-level gateway - Read */
+/* FIXME: Currently only a hardcoded 32bit constant can be used for the addr
+ *        field. */
 #define uvisor_read(src_box, ...) \
     ({ \
         uint32_t res = UVISOR_SVC(UVISOR_SVC_ID_REGISTER_GATEWAY, \
@@ -109,7 +110,7 @@
         res; \
     })
 
-/* register-level gateway - write */
+/* Register-level gateway - Write */
 #define uvisor_write(src_box, addr, val, ...) \
     ({ \
         UVISOR_SVC(UVISOR_SVC_ID_REGISTER_GATEWAY, \

--- a/api/inc/register_gateway.h
+++ b/api/inc/register_gateway.h
@@ -17,105 +17,212 @@
 #ifndef __UVISOR_API_REGISTER_GATEWAY_H__
 #define __UVISOR_API_REGISTER_GATEWAY_H__
 
+#include "api/inc/register_gateway_exports.h"
 #include "api/inc/uvisor_exports.h"
 #include <stdint.h>
 
-/* The following magic is used to verify that a register gateway structure. It
- * has been generated starting from the ARM Thumb/Thumb-2 invalid opcode.
- * ARM Thumb (w/o the Thumb-2 extension): 0xF7FxAxxx (32 bits)
- * The 'x's can be freely chosen (they have been chosen randomly here).
- * This requires the Thumb-2 extensions because otherwise only 16 bits opcodes
- * are accepted.*/
-#if defined(__thumb__) && defined(__thumb2__)
-#define UVISOR_REGISTER_GATEWAY_MAGIC 0xF7F3A89E
-#else
-#error "Unsupported instruction set. The ARM Thumb-2 instruction set must be supported."
-#endif /* __thumb__ && __thumb2__ */
+/** Get the offset of a struct member.
+ * @internal
+ */
+#define __UVISOR_OFFSETOF(type, member) ((uint32_t) (&(((type *)(0))->member)))
 
-/* Register gateway operations */
-/* Note: Do not use special characters as these numbers will be stringified. */
-#define UVISOR_OP_READ(op)  (op)
-#define UVISOR_OP_WRITE(op) ((1 << 4) | (op))
-#define UVISOR_OP_NOP       0x0
-#define UVISOR_OP_AND       0x1
-#define UVISOR_OP_OR        0x2
-#define UVISOR_OP_XOR       0x3
+/** Generate the opcode of the 16-bit Thumb-2 16-bit T2 encoding of the branch
+ *  instruction.
+ * @internal
+ * @note The branch instruction is encoded according to the Thumb-2 immediate
+ * encoding rules:
+ *     <instr_addr>: B.N <label>
+ *     imm = (<label>_addr - PC) / 2
+ * Where:
+ *     PC = <instr>_addr + 4
+ * The +4 is to account for the pipelined PC at the time of the branch
+ * instruction. See ARM DDI 0403E.b page A4-102 for more details.
+ * @param instr[in] Address of the branch instruction
+ * @param label[in] Address of the label
+ * @returns the 16-bit encoding of the B.N <label> instruction.
+ */
+#define BRANCH_OPCODE(instr, label) \
+    (uint16_t) (0xE000 | (uint8_t) ((((uint32_t) (label) - ((uint32_t) (instr) + 4)) / 2) & 0xFF))
 
-/* Default mask for whole register operatins. */
-#define __UVISOR_OP_DEFAULT_MASK 0x0
+/** `BX LR` encoding
+ * @internal
+ */
+#define BXLR                           ((uint16_t) 0x4770)
 
-/* Register gateway metadata */
-#if defined(__CC_ARM)
-
-/* TODO/FIXME */
-
-#elif defined(__GNUC__)
-
-/* 1 argument: Simple read, no mask */
-#define __UVISOR_REGISTER_GATEWAY_METADATA1(src_box, addr) \
-    "b.n skip_args%=\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
-    ".word " UVISOR_TO_STRING(addr) "\n" \
-    ".word " UVISOR_TO_STRING(src_box) "_cfg_ptr\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_OP_READ(UVISOR_OP_NOP)) "\n" \
-    ".word " UVISOR_TO_STRING(__UVISOR_OP_DEFAULT_MASK) "\n" \
-    "skip_args%=:\n"
-
-/* 2 arguments: Simple write, no mask */
-#define __UVISOR_REGISTER_GATEWAY_METADATA2(src_box, addr, val) \
-    "b.n skip_args%=\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
-    ".word " UVISOR_TO_STRING(addr) "\n" \
-    ".word " UVISOR_TO_STRING(src_box) "_cfg_ptr\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_OP_WRITE(UVISOR_OP_NOP)) "\n" \
-    ".word " UVISOR_TO_STRING(__UVISOR_OP_DEFAULT_MASK) "\n" \
-    "skip_args%=:\n"
-
-/* 3 arguments: Masked read */
-#define __UVISOR_REGISTER_GATEWAY_METADATA3(src_box, addr, op, mask) \
-    "b.n skip_args%=\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
-    ".word " UVISOR_TO_STRING(addr) "\n" \
-    ".word " UVISOR_TO_STRING(src_box) "_cfg_ptr\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_OP_READ(op)) "\n" \
-    ".word " UVISOR_TO_STRING(mask) "\n" \
-    "skip_args%=:\n"
-
-/* 4 arguments: Masked write */
-#define __UVISOR_REGISTER_GATEWAY_METADATA4(src_box, addr, val, op, mask) \
-    "b.n skip_args%=\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_REGISTER_GATEWAY_MAGIC) "\n" \
-    ".word " UVISOR_TO_STRING(addr) "\n" \
-    ".word " UVISOR_TO_STRING(src_box) "_cfg_ptr\n" \
-    ".word " UVISOR_TO_STRING(UVISOR_OP_WRITE(op)) "\n" \
-    ".word " UVISOR_TO_STRING(mask) "\n" \
-    "skip_args%=:\n"
-
-#endif /* __CC_ARM or __GNUC__ */
-
-#define __UVISOR_REGISTER_GATEWAY_METADATA(src_box, ...) \
-     __UVISOR_MACRO_SELECT(_0, ##__VA_ARGS__, __UVISOR_REGISTER_GATEWAY_METADATA4, \
-                                              __UVISOR_REGISTER_GATEWAY_METADATA3, \
-                                              __UVISOR_REGISTER_GATEWAY_METADATA2, \
-                                              __UVISOR_REGISTER_GATEWAY_METADATA1, \
-                                              /* No macro for 0 args */          )(src_box, ##__VA_ARGS__)
-
-/* Rregister-level gateway - Read */
-/* FIXME: Currently only a hardcoded 32bit constant can be used for the addr
- *        field. */
-#define uvisor_read(src_box, ...) \
+/** Register Gateway - Read operation
+ *
+ * This macro provides an API to perform 32-bit read operations on restricted
+ * registers. Such accesses are assembled into a read-only flash structure that
+ * is read and validated by uVisor before performing the operation.
+ *
+ * @warning These APIs currently only support link-time known values. This means
+ * that an access of this type is not supported:
+ * ```
+ * static uint32_t const const_mask = 0x0000F000;
+ * a = uvisor_read(&SYSCFG->CTRL, UVISOR_RGW_OP_READ, const_mask); // Yes
+ * uint32_t var_mask = rand();
+ * a = uvisor_read(&SYSCFG->CTRL, UVISOR_RGW_OP_READ, var_mask); // No
+ * ```
+ *
+ * @param box_name[in]  The name of the source box as decalred in
+ *                      `UVISOR_BOX_CONFIG`.
+ * @param addr[in]      The address for the data access.
+ * @param operation[in] The operation to perform at the address for the read. It
+ *                      is chosen among the `UVISOR_RGW_OP_*` macros.
+ * @param mask[in]      The mask to apply for the read operation.
+ * @returns The value read from address using the operation and mask provided
+ * (or their respective defaults if they have not been provided).
+ */
+#define uvisor_read(box_name, addr, op, msk) \
     ({ \
-        uint32_t res = UVISOR_SVC(UVISOR_SVC_ID_REGISTER_GATEWAY, \
-                                  __UVISOR_REGISTER_GATEWAY_METADATA(src_box, ##__VA_ARGS__)); \
-        res; \
+        /* Instanstiate the gateway. This gets resolved at link-time. */ \
+        __attribute__((aligned(4))) static TRegisterGateway const register_gateway = { \
+            .svc_opcode = UVISOR_SVC_OPCODE(UVISOR_SVC_ID_REGISTER_GATEWAY), \
+            .branch     = BRANCH_OPCODE(__UVISOR_OFFSETOF(TRegisterGateway, branch), \
+                                        __UVISOR_OFFSETOF(TRegisterGateway, bxlr)), \
+            .magic      = UVISOR_REGISTER_GATEWAY_MAGIC, \
+            .box_ptr    = (uint32_t) & box_name ## _cfg_ptr, \
+            .address    = (uint32_t) addr, \
+            .value      = 0, \
+            .mask       = msk, \
+            .operation  = op, \
+            .bxlr       = BXLR  \
+        }; \
+        \
+        /* Pointer to the register gateway we just created. The pointer is
+         * located in a discoverable linker section. */ \
+        __attribute__((section(".keep.uvisor.register_gateway_ptr"))) \
+        static uint32_t const register_gateway_ptr = (uint32_t) &register_gateway; \
+        (void) register_gateway_ptr; \
+        \
+        /* Call the actual gateway. */ \
+        uint32_t result = ((uint32_t (*)(void)) ((uint32_t) &register_gateway | 1))(); \
+        result; \
     })
 
-/* Register-level gateway - Write */
-#define uvisor_write(src_box, addr, val, ...) \
-    ({ \
-        UVISOR_SVC(UVISOR_SVC_ID_REGISTER_GATEWAY, \
-                   __UVISOR_REGISTER_GATEWAY_METADATA(src_box, addr, val, ##__VA_ARGS__), \
-                   val); \
-    })
+/** Register Gateway - Write operation
+ *
+ * This macro provides an API to perform 32-bit write operations on restricted
+ * registers. Such accesses are assembled into a read-only flash structure that
+ * is read and validated by uVisor before performing the operation.
+ *
+ * @warning These APIs currently only support link-time known values. This means
+ * that an access of this type is not supported:
+ * ```C
+ * static uint32_t const const_value = 1;
+ * uvisor_write(&SYSCFG->CTRL, const_value, UVISOR_RGW_OP_WRITE, 0xF); // Yes
+ * uint32_t var_value = rand();
+ * uvisor_write(&SYSCFG->CTRL, var_value, UVISOR_RGW_OP_WRITE, 0xF); // No
+ * ```
+ *
+ * @param box_name[in]  The name of the source box as decalred in
+ *                      `UVISOR_BOX_CONFIG`.
+ * @param addr[in]      The address for the data access.
+ * @param val[in]       The value to write at address.
+ * @param operation[in] The operation to perform at the address for the read. It
+ *                      is chosen among the `UVISOR_RGW_OP_*` macros.
+ * @param mask[in]      The mask to apply for the write operation.
+ */
+#define uvisor_write(box_name, addr, val, op, msk) \
+    { \
+        /* Instanstiate the gateway. This gets resolved at link-time. */ \
+        __attribute__((aligned(4))) static TRegisterGateway const register_gateway = { \
+            .svc_opcode = UVISOR_SVC_OPCODE(UVISOR_SVC_ID_REGISTER_GATEWAY), \
+            .branch     = BRANCH_OPCODE(__UVISOR_OFFSETOF(TRegisterGateway, branch), \
+                                        __UVISOR_OFFSETOF(TRegisterGateway, bxlr)), \
+            .magic      = UVISOR_REGISTER_GATEWAY_MAGIC, \
+            .box_ptr    = (uint32_t) & box_name ## _cfg_ptr, \
+            .address    = (uint32_t) addr, \
+            .value      = val, \
+            .mask       = msk, \
+            .operation  = op, \
+            .bxlr       = BXLR  \
+        }; \
+        \
+        /* Pointer to the register gateway we just created. The pointer is
+         * located in a discoverable linker section. */ \
+        __attribute__((section(".keep.uvisor.register_gateway_ptr"))) \
+        static uint32_t const register_gateway_ptr = (uint32_t) &register_gateway; \
+        (void) register_gateway_ptr; \
+        \
+        /* Call the actual gateway. */ \
+        ((void (*)(void)) ((uint32_t) ((uint32_t) &register_gateway | 1)))(); \
+    }
+
+/** Get the selected bits at the target address.
+ * @param box_name[in] Box name as defined by the uVisor box configuration
+ *                     macro `UVISOR_BOX_CONFIG`
+ * @param address[in]  Target address
+ * @param mask[in]     Bits to select out of the target address
+ * @returns The value `*address & mask`.
+ */
+#define UVISOR_BITS_GET(box_name, address, mask) \
+    /* Register gateway implementation:
+     * *address & mask */ \
+    uvisor_read(box_name, address, UVISOR_RGW_OP_READ_AND, mask)
+
+/** Check the selected bits at the target address.
+ * @param box_name[in] Box name as defined by the uVisor box configuration
+ *                     macro `UVISOR_BOX_CONFIG`
+ * @param address[in]  Address at which to check the bits
+ * @param mask[in]     Bits to select out of the target address
+ * @returns The value `(bool) (*address & mask) == mask)`.
+ */
+#define UVISOR_BITS_CHECK(box_name, address, mask) \
+    ((bool) (UVISOR_BITS_GET(box_name, address, mask) == mask))
+
+/** Set the selected bits to 1 at the target address.
+ *
+ * Equivalent to: `*address |= mask`.
+ * @param box_name[in] Box name as defined by the uVisor box configuration
+ *                     macro `UVISOR_BOX_CONFIG`
+ * @param address[in]  Target address
+ * @param mask[in]     Bits to select out of the target address
+ */
+#define UVISOR_BITS_SET(box_name, address, mask) \
+    /* Register gateway implementation:
+     * *address |= (mask & mask) */ \
+    uvisor_write(box_name, address, mask, UVISOR_RGW_OP_WRITE_OR, mask)
+
+/** Clear the selected bits at the target address.
+ *
+ * Equivalent to: `*address &= ~mask`.
+ * @param box_name[in] Box name as defined by the uVisor box configuration
+ *                     macro `UVISOR_BOX_CONFIG`
+ * @param address[in]  Target address
+ * @param mask[in]     Bits to select out of the target address
+ */
+#define UVISOR_BITS_CLEAR(box_name, address, mask) \
+    /* Register gateway implementation:
+     * *address &= (0x00000000 | ~mask) */ \
+    uvisor_write(box_name, address, 0x00000000, UVISOR_RGW_OP_WRITE_AND, mask)
+
+/** Set the selected bits at the target address to the given value.
+ *
+ * Equivalent to: `*address = (*address & ~mask) | (value & mask)`.
+ * @param box_name[in] Box name as defined by the uVisor box configuration
+ *                     macro `UVISOR_BOX_CONFIG`
+ * @param address[in]  Target address
+ * @param mask[in]     Bits to select out of the target address
+ * @param value[in]    Value to write at the address location. Note: The value
+ *                     must be already shifted to the correct bit position
+ */
+#define UVISOR_BITS_SET_VALUE(box_name, address, mask, value) \
+    /* Register gateway implementation:
+     * *address = (*address & ~mask) | (value & mask) */ \
+    uvisor_write(box_name, address, value, UVISOR_RGW_OP_WRITE_REPLACE, mask)
+
+/** Toggle the selected bits at the target address.
+ *
+ * Equivalent to: `*address ^= mask`.
+ * @param box_name[in] Box name as defined by the uVisor box configuration
+ *                     macro `UVISOR_BOX_CONFIG`
+ * @param address[in]  Target address
+ * @param mask[in]     Bits to select out of the target address
+ */
+#define UVISOR_BITS_TOGGLE(box_name, address, mask) \
+    /* Register gateway implementation:
+     * *address ^= (0xFFFFFFFF & mask) */ \
+    uvisor_write(box_name, address, 0xFFFFFFFF, UVISOR_RGW_OP_WRITE_XOR, mask)
 
 #endif /* __UVISOR_API_REGISTER_GATEWAY_H__ */

--- a/api/inc/register_gateway_exports.h
+++ b/api/inc/register_gateway_exports.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_API_REGISTER_GATEWAY_EXPORTS_H__
+#define __UVISOR_API_REGISTER_GATEWAY_EXPORTS_H__
+
+/** Register gateway magic
+ *
+ * The following magic is used to verify a register gateway structure. It has
+ * been generated starting from the ARM Thumb/Thumb-2 invalid opcode.
+ * ARM Thumb (with the Thumb-2 extension): 0xF7FxAxxx (32 bits)
+ * The 'x's can be freely chosen (they have been chosen randomly here). This
+ * requires the Thumb-2 extensions because otherwise only 16 bits opcodes are
+ * accepted.
+ */
+#if defined(__thumb__) && defined(__thumb2__)
+#define UVISOR_REGISTER_GATEWAY_MAGIC 0xF7F3A89E
+#else
+#error "Unsupported instruction set. The ARM Thumb-2 instruction set must be supported."
+#endif /* __thumb__ && __thumb2__ */
+
+/** Register gateway structure
+ *
+ * This struct is packed because we must ensure that the `svc_opcode` field has
+ * no padding before itself, and that the `bxlr` field is at a pre-determined
+ * offset from the `branch` field.
+ */
+typedef struct {
+    uint16_t svc_opcode;
+    uint16_t branch;
+    uint32_t magic;
+    uint32_t box_ptr;
+    uint32_t address;
+    uint32_t value;
+    uint32_t mask;
+    uint16_t operation;
+    uint16_t bxlr;
+} UVISOR_PACKED __attribute__((aligned(4))) TRegisterGateway;
+
+/** Register gateway operations
+ * @warning The operation value must be hardcoded. */
+#define UVISOR_RGW_OP_READ          0 /**< value = *address */
+#define UVISOR_RGW_OP_READ_AND      1 /**< value = *address & mask */
+#define UVISOR_RGW_OP_WRITE         2 /**< *address = value */
+#define UVISOR_RGW_OP_WRITE_AND     3 /**< *address &= value | mask */
+#define UVISOR_RGW_OP_WRITE_OR      4 /**< *address |= value & ~mask */
+#define UVISOR_RGW_OP_WRITE_XOR     5 /**< *address ^= value & mask */
+#define UVISOR_RGW_OP_WRITE_REPLACE 6 /**< *address = (*address & ~mask) | (value & mask) */
+
+#endif /* __UVISOR_API_REGISTER_GATEWAY_EXPORTS_H__ */

--- a/api/inc/svc_exports.h
+++ b/api/inc/svc_exports.h
@@ -20,11 +20,6 @@
 #include "api/inc/uvisor_exports.h"
 #include <stdint.h>
 
-/* maximum depth of nested context switches
- * this includes both IRQn and secure gateways, as they use the same state stack
- * for their context switches */
-#define UVISOR_SVC_CONTEXT_MAX_DEPTH 0x10
-
 /* An SVCall takes a 8bit immediate, which is used as follows:
  *
  * For fast APIs:
@@ -120,15 +115,10 @@
 
 /* SVC immediate values for hardcoded table (call from unprivileged) */
 #define UVISOR_SVC_ID_UNVIC_OUT        UVISOR_SVC_FIXED_TABLE(0, 0)
-#define UVISOR_SVC_ID_CX_IN(nargs)     UVISOR_SVC_FIXED_TABLE(1, nargs)
-#define UVISOR_SVC_ID_CX_OUT           UVISOR_SVC_FIXED_TABLE(2, 0)
 #define UVISOR_SVC_ID_REGISTER_GATEWAY UVISOR_SVC_FIXED_TABLE(3, 0)
 
 /* SVC immediate values for hardcoded table (call from privileged) */
 #define UVISOR_SVC_ID_UNVIC_IN         UVISOR_SVC_FIXED_TABLE(0, 0)
-
-/* unprivileged code uses a secure gateway to switch context */
-#define UVISOR_SVC_ID_SECURE_GATEWAY(nargs) UVISOR_SVC_ID_CX_IN(nargs)
 
 /* macro to execute an SVCall; additional metadata can be provided, which will
  * be appended right after the svc instruction */

--- a/api/inc/svc_exports.h
+++ b/api/inc/svc_exports.h
@@ -120,6 +120,9 @@
 /* SVC immediate values for hardcoded table (call from privileged) */
 #define UVISOR_SVC_ID_UNVIC_IN         UVISOR_SVC_FIXED_TABLE(0, 0)
 
+/** Generate the SVCall opcode from the SVC ID. */
+#define UVISOR_SVC_OPCODE(id) ((uint16_t) 0xDF00 | (uint8_t) ((id) & 0xFF))
+
 /* macro to execute an SVCall; additional metadata can be provided, which will
  * be appended right after the svc instruction */
 /* note: the macro is implicitly overloaded to allow 0 to 4 32bits arguments */

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -54,6 +54,7 @@ UVISOR_EXTERN int uvisor_lib_init(void);
 #include "api/inc/context_exports.h"
 #include "api/inc/export_table_exports.h"
 #include "api/inc/halt_exports.h"
+#include "api/inc/register_gateway_exports.h"
 #include "api/inc/svc_exports.h"
 #include "api/inc/priv_sys_irq_hook_exports.h"
 #include "api/inc/unvic_exports.h"

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -51,6 +51,7 @@ UVISOR_EXTERN int uvisor_lib_init(void);
  * These are included independently on whether uVisor is supported or not by the
  * target platform. */
 #include "api/inc/debug_exports.h"
+#include "api/inc/context_exports.h"
 #include "api/inc/export_table_exports.h"
 #include "api/inc/halt_exports.h"
 #include "api/inc/svc_exports.h"

--- a/api/src/disabled.c
+++ b/api/src/disabled.c
@@ -42,7 +42,7 @@ static void *g_uvisor_ctx_array[UVISOR_MAX_BOXES] = {0};
 /* Call stack
  * We must keep the full call stack as otherwise it's not possible to restore a
  * box context after a nested call. */
-static uint8_t g_call_stack[UVISOR_SVC_CONTEXT_MAX_DEPTH];
+static uint8_t g_call_stack[UVISOR_CONTEXT_MAX_DEPTH];
 static int g_call_sp;
 
 /* Memory position pointer
@@ -133,7 +133,7 @@ void uvisor_disabled_switch_in(const uint32_t *dst_box_cfgtbl_ptr)
     uvisor_ctx = g_uvisor_ctx_array[dst_box_id];
 
     /* Push state. */
-    if (g_call_sp >= UVISOR_SVC_CONTEXT_MAX_DEPTH - 1) {
+    if (g_call_sp >= UVISOR_CONTEXT_MAX_DEPTH - 1) {
         uvisor_error(USER_NOT_ALLOWED);
     }
     g_call_stack[++g_call_sp] = dst_box_id;

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -79,6 +79,10 @@ uvisor_config:
     .long __uvisor_cfgtbl_ptr_start
     .long __uvisor_cfgtbl_ptr_end
 
+    /* Pointers to the secure boxes register gateways */
+    .long __uvisor_register_gateway_ptr_start
+    .long __uvisor_register_gateway_ptr_end
+
     /* Address of __uvisor_box_context */
     .long __uvisor_box_context
 

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -26,8 +26,11 @@
     .thumb
     .thumb_func
 
+/* This is the unique uVisor entry point from the point of view of the host OS.
+ * This symbol corresponds to:
+ *      extern "C" void uvisor_init(void); */
 uvisor_init:
-    /* uvisor - precompiled blob */
+    /* uVisor pre-compiled binary blob */
     .incbin UVISOR_BIN
 
 /* The size of the uVisor export table is a uint32_t located at the end of the
@@ -37,64 +40,60 @@ uvisor_init:
 .set uvisor_export_table_size, uvisor_config - 4
 
 uvisor_config:
-    /* uvisor expects its configuration section right
-       after itself in flash. If the configuration magic is not found,
-       uvisor will intentionally freeze to avoid accidentally
-       unprotect systems */
+    /* uVisor expects its configuration section right after itself in flash. If
+     * the configuration magic is not found, uVisor will intentionally freeze to
+     * avoid accidentally unprotect systems. */
     .long UVISOR_MAGIC
 
-    /* MBED_VERSION */
+    /* Host OS version */
     .long 0
 
-    /* uvisor mode
-       0: disabled
-       1: permissive
-       2: enabled */
+    /* uVisor mode of operation */
     .long __uvisor_mode
 
-    /* start and end address of protected bss */
+    /* Protected BSS section */
     .long __uvisor_bss_start
     .long __uvisor_bss_end
 
-    /* start and end address of uvisor main bss */
+    /* uVisor own BSS section */
     .long __uvisor_bss_main_start
     .long __uvisor_bss_main_end
 
-    /* start and end address of uvisor secure boxes bss */
+    /* Seecure boxes BSS section */
     .long __uvisor_bss_boxes_start
     .long __uvisor_bss_boxes_end
 
-    /* start and end address of uvisor code and data */
+    /* uVisor own code and data */
     .long __uvisor_main_start
     .long __uvisor_main_end
 
-    /* start and end address of protected flash region
-    /* note: remaining flash size is available for configuration storage */
+    /* Protected flash memory region */
     .long __uvisor_secure_start
     .long __uvisor_secure_end
 
-     /* start and end address of boxes configuration tables */
+    /* Secure boxes configuration tables */
     .long __uvisor_cfgtbl_start
     .long __uvisor_cfgtbl_end
 
-    /* start and end address of list of pointers to boxes configuration tables */
+    /* Pointers to the secure boxes configuration tables */
     .long __uvisor_cfgtbl_ptr_start
     .long __uvisor_cfgtbl_ptr_end
 
-    /* pointer to __uvisor_box_context */
+    /* Address of __uvisor_box_context */
     .long __uvisor_box_context
 
-    /* Pointers to beginning and end of main heap for box zero */
+    /* Main heap for box 0 */
     .long __uvisor_heap_start
     .long __uvisor_heap_end
 
-    /* Pointers to beginning and end of page heap */
+    /* Page allocator region */
     .long __uvisor_page_start
     .long __uvisor_page_end
-    /* Pointer to the requested page size for page heap */
+
+    /* Page size for the page allocator */
     .long __uvisor_page_size
 
-    /* Physical memories' boundaries */
+    /* Physical memory boundaries */
     .long __uvisor_flash_start;
     .long __uvisor_flash_end;
     .long __uvisor_sram_start;
@@ -103,12 +102,16 @@ uvisor_config:
     /* Privileged system IRQ hooks */
     .long __uvisor_priv_sys_irq_hooks
 
+/* uVisor mode of operation
+ * Modes available: UVISOR_ENABLED, UVISOR_DISABLED, UVISOR_PERMISSIVE. */
 __uvisor_mode:
-    /* uvisor default mode - user can override weak reference */
+    /* uVisor default mode: Disabled.
+     * The user can override this weak reference. */
     .long 0
 
 __uvisor_page_size:
-    /* uvisor default page size is 16kB - user can override weak reference */
+    /* uVisor default page size: 16kB.
+     * The user can override this weak reference. */
     .long 16384
 
 /* __uvisor_ps is written inside uvisor_init. It must not be
@@ -118,5 +121,7 @@ __uvisor_box_context:
 __uvisor_ps:
     .long 0
 
+/* Reserve space for the uVisor BSS section. This section is zeroed by uVisor at
+ * boot time. */
 .section .keep.uvisor.bss.main, "awM", @nobits
     .space UVISOR_SRAM_LENGTH

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -69,6 +69,10 @@ typedef struct {
     uint32_t * cfgtbl_ptr_start;
     uint32_t * cfgtbl_ptr_end;
 
+    /* Pointers to the secure boxes register gateways */
+    uint32_t * register_gateway_ptr_start;
+    uint32_t * register_gateway_ptr_end;
+
     /* Address of __uvisor_box_context */
     uint32_t * * uvisor_box_context;
 

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -19,72 +19,80 @@
 
 #include "api/inc/priv_sys_irq_hook_exports.h"
 
-UVISOR_EXTERN const uint32_t __code_end__;
-UVISOR_EXTERN const uint32_t __stack_start__;
-UVISOR_EXTERN const uint32_t __stack_top__;
-UVISOR_EXTERN const uint32_t __stack_end__;
+extern uint32_t const __code_end__;
+extern uint32_t const __stack_start__;
+extern uint32_t const __stack_top__;
+extern uint32_t const __stack_end__;
 
-UVISOR_EXTERN uint32_t __bss_start__;
-UVISOR_EXTERN uint32_t __bss_end__;
+extern uint32_t __bss_start__;
+extern uint32_t __bss_end__;
 
-UVISOR_EXTERN uint32_t __data_start__;
-UVISOR_EXTERN uint32_t __data_end__;
-UVISOR_EXTERN const uint32_t __data_start_src__;
+extern uint32_t __data_start__;
+extern uint32_t __data_end__;
+extern uint32_t const __data_start_src__;
 
-UVISOR_EXTERN void main_entry(void);
-UVISOR_EXTERN void isr_default_sys_handler(void);
-UVISOR_EXTERN void isr_default_handler(void);
-UVISOR_EXTERN int isr_default(uint32_t isr_id);
+extern void main_entry(void);
+extern void isr_default_sys_handler(void);
+extern void isr_default_handler(void);
+extern int isr_default(uint32_t isr_id);
 
 typedef struct {
     uint32_t magic;
     uint32_t version;
-    uint32_t *mode;
+    uint32_t * mode;
 
-    /* protected bss */
-    uint32_t *bss_start, *bss_end;
+    /* Protected BSS section */
+    uint32_t * bss_start;
+    uint32_t * bss_end;
 
-        /* uvisor main bss */
-    uint32_t *bss_main_start, *bss_main_end;
+    /* uVisor own BSS section */
+    uint32_t * bss_main_start;
+    uint32_t * bss_main_end;
 
-        /* secure boxes bss */
-    uint32_t *bss_boxes_start, *bss_boxes_end;
+    /* Seecure boxes BSS section */
+    uint32_t * bss_boxes_start;
+    uint32_t * bss_boxes_end;
 
-    /* uvisor code and data */
-    uint32_t *main_start, *main_end;
+    /* uVisor own code and data */
+    uint32_t * main_start;
+    uint32_t * main_end;
 
-    /* protected flash memory region */
-    uint32_t *secure_start, *secure_end;
+    /* Protected flash memory region */
+    uint32_t * secure_start;
+    uint32_t * secure_end;
 
-        /* boxes configuration tables */
-    uint32_t *cfgtbl_start, *cfgtbl_end;
+    /* Secure boxes configuration tables */
+    uint32_t * cfgtbl_start;
+    uint32_t * cfgtbl_end;
 
-        /* pointers to boxes configuration tables */
-    uint32_t *cfgtbl_ptr_start, *cfgtbl_ptr_end;
+    /* Pointers to the secure boxes configuration tables */
+    uint32_t * cfgtbl_ptr_start;
+    uint32_t * cfgtbl_ptr_end;
 
-    /* address of __uvisor_box_context */
-    uint32_t **uvisor_box_context;
+    /* Address of __uvisor_box_context */
+    uint32_t * * uvisor_box_context;
 
-    /* Heap start and end addresses for box zero */
+    /* Main heap for box 0 */
     uint32_t * heap_start;
     uint32_t * heap_end;
 
-    /* Page allocator start and end addresses */
+    /* Page allocator region */
     uint32_t * page_start;
     uint32_t * page_end;
-    /* Pointer to page size used for page allocator */
+
+    /* Page size for the page allocator */
     uint32_t * page_size;
 
-    /* Physical memories' boundaries */
-    uint32_t *flash_start;
-    uint32_t *flash_end;
-    uint32_t *sram_start;
-    uint32_t *sram_end;
+    /* Physical memory boundaries */
+    uint32_t * flash_start;
+    uint32_t * flash_end;
+    uint32_t * sram_start;
+    uint32_t * sram_end;
 
     /* Privileged system IRQ hooks */
-    const UvisorPrivSystemIRQHooks * const priv_sys_irq_hooks;
+    UvisorPrivSystemIRQHooks const * const priv_sys_irq_hooks;
 } UVISOR_PACKED UvisorConfig;
 
-UVISOR_EXTERN const UvisorConfig __uvisor_config;
+extern UvisorConfig const __uvisor_config;
 
-#endif/*__LINKER_H__*/
+#endif /* __LINKER_H__ */

--- a/core/system/inc/mpu/vmpu.h
+++ b/core/system/inc/mpu/vmpu.h
@@ -101,8 +101,15 @@ static UVISOR_FORCEINLINE int vmpu_sram_addr(uint32_t addr)
 #define VMPU_SRAM_BITBAND_START   0x22000000
 #define VMPU_SRAM_BITBAND_END     0x23FFFFFF
 #define VMPU_PERIPH_START         0x40000000
+#define VMPU_PERIPH_MASK          0xFFF00000
 #define VMPU_PERIPH_BITBAND_START 0x42000000
 #define VMPU_PERIPH_BITBAND_END   0x43FFFFFF
+#define VMPU_PERIPH_BITBAND_MASK  0xFE000000
+#define VMPU_PERIPH_FULL_MASK     0xFC000000
+
+/* ROM Table region boundaries */
+#define VMPU_ROMTABLE_START 0xE00FF000UL
+#define VMPU_ROMTABLE_MASK  0xFFFFF000UL
 
 /* bit-banding aliases macros
  * physical address ---> bit-banded alias
@@ -155,8 +162,6 @@ extern void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp);
  * condition must hold: g_vmpu_box_count < UVISOR_MAX_BOXES */
 extern uint32_t  g_vmpu_box_count;
 bool g_vmpu_boxes_counted;
-
-extern uint32_t vmpu_register_gateway(uint32_t addr, uint32_t val);
 
 extern int vmpu_box_id_self(void);
 extern int vmpu_box_id_caller(void);

--- a/core/system/inc/register_gateway.h
+++ b/core/system/inc/register_gateway.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __REGISTER_GATEWAY_H__
+#define __REGISTER_GATEWAY_H__
+
+#include "api/inc/register_gateway_exports.h"
+#include <stdint.h>
+
+/** Perform a register gateway operation.
+ * @param svc_sp[in]    Unprivileged stack pointer at the time of the register
+ *                      gateway
+ * @param svc_pc[in]    Program counter at the time of the register gateway
+ */
+void register_gateway_perform_operation(uint32_t svc_sp, uint32_t svc_pc);
+
+#endif /* __REGISTER_GATEWAY_H__ */

--- a/core/system/inc/unvic.h
+++ b/core/system/inc/unvic.h
@@ -63,9 +63,8 @@ extern void unvic_init(void);
  *
  * @warning This function trusts the SVCall parameters that are passed to it.
  *
- * @param svc_sp[in]    Unprivileged stack pointer at the time of the secure
- *                      gateway
- * @param svc_pc[in]    Program counter at the time of the secure gateway */
+ * @param svc_sp[in]    Unprivileged stack pointer at the time of the interrupt
+ * @param svc_pc[in]    Program counter at the time of the interrupt */
 void UVISOR_NAKED unvic_gateway_in(uint32_t svc_sp, uint32_t svc_pc);
 
 /** Perform a context switch-out as a result of an interrupt request.
@@ -77,8 +76,8 @@ void UVISOR_NAKED unvic_gateway_in(uint32_t svc_sp, uint32_t svc_pc);
  *
  * @warning This function trusts the SVCall parameters that are passed to it.
  *
- * @param svc_sp[in]    Unprivileged stack pointer at the time of the secure
- *                      gateway return handler (thunk) */
+ * @param svc_sp[in]    Unprivileged stack pointer at the time of the interrupt
+ *                      return handler (thunk) */
 void UVISOR_NAKED unvic_gateway_out(uint32_t svc_sp);
 
 /** Disable all interrupts for the currently active box.

--- a/core/system/src/register_gateway.c
+++ b/core/system/src/register_gateway.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <uvisor.h>
+#include "context.h"
+#include "halt.h"
+#include "register_gateway.h"
+#include "vmpu.h"
+
+#define REGISTER_GATEWAY_STATUS_OK            (0)
+#define REGISTER_GATEWAY_STATUS_ERROR_FLASH   (-1)
+#define REGISTER_GATEWAY_STATUS_ERROR_MAGIC   (-2)
+#define REGISTER_GATEWAY_STATUS_ERROR_BOX_PTR (-3)
+#define REGISTER_GATEWAY_STATUS_ERROR_BOX_ID  (-4)
+#define REGISTER_GATEWAY_STATUS_ERROR_ADDRESS (-5)
+
+/** Perform the validation of a register gateway.
+ * @internal
+ * @warning This function does not verify that the operation, value and mask
+ * make sense together. The code that performs the operation should check for
+ * this and return an error accordingly.
+ * @param register_gateway[in]  Pointer to the register gateway structure in
+ *                              flash.
+ * @returns the status of the check. A negative number indicates an error.
+ */
+static int register_gateway_check(TRegisterGateway const * const register_gateway)
+{
+    /* Verify that the register gateway is in public flash. */
+    /* Note: We only check that the start and end addresses of the gateway are
+     * in public flash. Since the gateway is fairly small, we can safely assume
+     * that all of it is in public flash. */
+    if (!vmpu_public_flash_addr((uint32_t) register_gateway) ||
+        !vmpu_public_flash_addr((uint32_t) ((void *) register_gateway + sizeof(TRegisterGateway) - 1))) {
+        DPRINTF("Register gateway 0x%08X is not in public flash.\r\n", (uint32_t) register_gateway);
+        return REGISTER_GATEWAY_STATUS_ERROR_FLASH;
+    }
+
+    /* Verify that the register gateway magic is present. */
+    if (register_gateway->magic != UVISOR_REGISTER_GATEWAY_MAGIC) {
+        DPRINTF("Register gateway 0x%08X does not contain a valid magic (0x%08X).\r\n",
+                (uint32_t) register_gateway, register_gateway->magic);
+        return REGISTER_GATEWAY_STATUS_ERROR_MAGIC;
+    }
+
+    /* Verify that the box configuration pointer is in the dedicated flash
+     * region and that it corresponds to the currently active box. */
+    /* Note: We only check that the box pointer is larger than the start of the
+     * pointer region. The subsequent substraction that we do to calculate the
+     * box ID is then guaranteed to be sane. */
+    if (register_gateway->box_ptr < (uint32_t) __uvisor_config.cfgtbl_ptr_start) {
+        DPRINTF("The pointer (0x%08X) in the register gateway 0x%08X is not a valid box configuration pointer.\r\n",
+                register_gateway->box_ptr, (uint32_t) register_gateway);
+        return REGISTER_GATEWAY_STATUS_ERROR_BOX_PTR;
+    }
+    uint8_t box_id = (uint8_t) ((uint32_t *) register_gateway->box_ptr - __uvisor_config.cfgtbl_ptr_start);
+    if (box_id != g_active_box) {
+        DPRINTF("Register gateway is owned by box %d, while the active box is %d.\r\n", box_id, g_active_box);
+        return REGISTER_GATEWAY_STATUS_ERROR_BOX_ID;
+    }
+
+    /* Verify that the address is in one of the allowed memory sections:
+     *   0x40000000 - 0x43FFFFFF: Peripheral + Peripheral alias
+     *   0xE00FF000 - 0xE00FFFFF: Custom ROM Table */
+    uint32_t address = register_gateway->address;
+    if (((address & VMPU_PERIPH_FULL_MASK) != VMPU_PERIPH_START) &&
+        ((address & VMPU_ROMTABLE_MASK) != VMPU_ROMTABLE_START)) {
+        DPRINTF("Register gateways can only target the peripheral or ROM Table memory regions. "
+                "Address 0x%08X not allowed.\r\n", address);
+        return REGISTER_GATEWAY_STATUS_ERROR_ADDRESS;
+    }
+
+    /* If the code got here, then everything is fine. */
+    return REGISTER_GATEWAY_STATUS_OK;
+}
+
+/* Perform a register gateway operation. */
+void register_gateway_perform_operation(uint32_t svc_sp, uint32_t svc_pc)
+{
+    /* Check if the SVCall points to a register gateway. */
+    TRegisterGateway const * const register_gateway = (TRegisterGateway const * const) svc_pc;
+    int status = register_gateway_check(register_gateway);
+    if (status != REGISTER_GATEWAY_STATUS_OK) {
+        HALT_ERROR(PERMISSION_DENIED, "Register gateway 0x%08X not allowed. Error: %d.",
+                   (uint32_t) register_gateway, status);
+    }
+
+    /* From now on we can assume the register_gateway structure and the address
+     * are valid. */
+
+    /* Perform the actual operation. */
+    uint32_t * address = (uint32_t *) register_gateway->address;
+    uint32_t result = 0;
+    switch (register_gateway->operation) {
+    case UVISOR_RGW_OP_READ:
+        result = *address;
+        break;
+    case UVISOR_RGW_OP_READ_AND:
+        result = *address & register_gateway->mask;
+        break;
+    case UVISOR_RGW_OP_WRITE:
+        *address = register_gateway->value;
+        break;
+    case UVISOR_RGW_OP_WRITE_AND:
+        *address &= (register_gateway->value | ~(register_gateway->mask));
+        break;
+    case UVISOR_RGW_OP_WRITE_OR:
+        *address |= (register_gateway->value & register_gateway->mask);
+        break;
+    case UVISOR_RGW_OP_WRITE_XOR:
+        *address ^= (register_gateway->value & register_gateway->mask);
+        break;
+    case UVISOR_RGW_OP_WRITE_REPLACE:
+        *address = (*address & ~(register_gateway->mask)) | (register_gateway->value & register_gateway->mask);
+        break;
+    default:
+        HALT_ERROR(NOT_ALLOWED, "Register level gateway: Operation 0x%08X not recognised.",
+                   register_gateway->operation);
+        break;
+    }
+
+    /* Store the return value in the caller stack.
+     * The return value is 0 if the gateway contained a write operation. */
+    vmpu_unpriv_uint32_write(svc_sp, result);
+}

--- a/core/system/src/svc.c
+++ b/core/system/src/svc.c
@@ -135,7 +135,7 @@ void UVISOR_NAKED SVCall_IRQn_Handler(void)
         ".word  unvic_gateway_out\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"
-        ".word  vmpu_register_gateway\n"
+        ".word  register_gateway_perform_operation\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"

--- a/core/system/src/unvic.c
+++ b/core/system/src/unvic.c
@@ -441,9 +441,8 @@ void UVISOR_NAKED unvic_gateway_in(uint32_t svc_sp, uint32_t svc_pc)
  *
  * @warning This function trusts the SVCall parameters that are passed to it.
  *
- * @param svc_sp[in]    Unprivileged stack pointer at the time of the secure
- *                      gateway
- * @param svc_pc[in]    Program counter at the time of the secure gateway */
+ * @param svc_sp[in]    Unprivileged stack pointer at the time of the interrupt
+ * @param svc_pc[in]    Program counter at the time of the interrupt */
 uint32_t unvic_gateway_context_switch_in(uint32_t svc_sp, uint32_t svc_pc)
 {
     uint8_t dst_id;
@@ -538,8 +537,8 @@ void UVISOR_NAKED unvic_gateway_out(uint32_t svc_sp)
  *
  * @warning This function trusts the SVCall parameters that are passed to it.
  *
- * @param svc_sp[in]    Unprivileged stack pointer at the time of the secure
- *                      gateway return handler (thunk)
+ * @param svc_sp[in]    Unprivileged stack pointer at the time of the interrupt
+ *                      return handler (thunk)
  * @param msp[in]       Value of the MSP register at the time of the SVcall */
 void unvic_gateway_context_switch_out(uint32_t svc_sp, uint32_t msp)
 {


### PR DESCRIPTION
This PR introduces the Register Gateway implementation.
- Added the issue #241 to track the runtime OR operation on the gateway function pointer independently of this pull request.

Done so far:

* Remove `uvisor_{read,write}` APIs restrictions (see #90) by using  a `struct` instead of SVCall metadata.
* All operations implemented.
* Added APIs for common bit manipulations.
* All operations tested.

Please concentrate on the last 2 commits.

@meriac @Patater @niklas-arm 