### PR TITLE
FIXUP: Add page allocator for unsupported targets

### DIFF
--- a/api/rtx/src/unsupported_page_allocator.c
+++ b/api/rtx/src/unsupported_page_allocator.c
@@ -99,6 +99,6 @@ static inline void page_table_write(uint32_t addr, uint32_t data)
 }
 
 /* Include the original page allocator source directly. */
-#include "source/page_allocator.c_inc"
+#include "../page_allocator.c_inc"
 
 #endif


### PR DESCRIPTION
XXX We need to apply this as a fixup to the following commit before
integrating from dev to master.

Fixes: 1fdafa6537fe ("Add page allocator for unsupported targets")