### PR TITLE
Add osEvents notifications for unsupported

### DIFF
--- a/api/inc/export_table_exports.h
+++ b/api/inc/export_table_exports.h
@@ -17,6 +17,7 @@
 #ifndef __UVISOR_API_EXPORT_TABLE_EXPORTS_H__
 #define __UVISOR_API_EXPORT_TABLE_EXPORTS_H__
 
+#include "rt_OsEventObserver.h"
 #include <stdint.h>
 
 /* If this magic doesn't match what you get in a TUvisorExportTable, then you
@@ -35,6 +36,8 @@ typedef struct {
      * be interpreted correctly. */
     uint32_t magic;
     uint32_t version;
+
+    OsEventObserver os_event_observer;
 
     /* This must be the last element of the table so that uvisor-input.S can
      * export the size statically. */

--- a/api/src/unsupported.c
+++ b/api/src/unsupported.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "uvisor-lib/uvisor-lib.h"
+#include "rt_OsEventObserver.h"
 
 #if !(defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1))
 
@@ -28,8 +29,30 @@ UVISOR_EXTERN void uvisor_init(void)
     return;
 }
 
+extern RtxBoxIndex * __uvisor_ps;
+
+static void thread_switch(void *context)
+{
+    if (context == NULL) return;
+
+    /* If the active_heap is NULL, then the process heap needs to be
+     * initialized. The initializer sets the active heap itself. */
+    if (__uvisor_ps->index.active_heap) {
+        __uvisor_ps->index.active_heap = context;
+    }
+}
+
+static OsEventObserver os_event_observer = {
+    .version = 0,
+    .pre_start = 0,
+    .thread_create = 0,
+    .thread_destroy = 0,
+    .thread_switch = thread_switch,
+};
+
 int uvisor_lib_init(void)
 {
+    osRegisterForOsEvents(&os_event_observer);
     return 0;
 }
 

--- a/core/cmsis/inc/rt_OsEventObserver.h
+++ b/core/cmsis/inc/rt_OsEventObserver.h
@@ -1,0 +1,62 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    os_events.h
+ *      Purpose: OS Event Callbacks for CMSIS RTOS
+ *      Rev.:    VX.XX
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2016 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+#ifndef _RT_OS_EVENT_OBSERVER_H
+#define _RT_OS_EVENT_OBSERVER_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* TODO The real ARM_DRIVER_VERSION type or something like it should be used.
+*/
+typedef uint32_t ARM_DRIVER_VERSION;
+
+typedef struct {
+    ARM_DRIVER_VERSION version;
+    void (*pre_start)(void);
+    void *(*thread_create)(int thread_id, void *context);
+    void (*thread_destroy)(void *context);
+    void (*thread_switch)(void *context);
+} OsEventObserver;
+extern const OsEventObserver *osEventObs;
+
+void osRegisterForOsEvents(const OsEventObserver *observer);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif


### PR DESCRIPTION
This adds the osEvents notification and allocator switching code to uVisor for the unsupported case.

cc @meriac @AlessandroA @Patater