### PR TITLE
Kinetis: Fix the SRAM_OFFSET configuration parameter

### DIFF
--- a/platform/kinetis/inc/configurations.h
+++ b/platform/kinetis/inc/configurations.h
@@ -36,10 +36,7 @@
 /* Memory boundaries */
 #define FLASH_ORIGIN 0x00000000
 #define FLASH_OFFSET 0x410
-/* FIXME The SRAM offset should be 0x400 (according to the NXP SDK linker
- *       scripts) but the mbed linker script uses 0x200. Fix the mbed linker
- *       script and amend the value here. */
-#define SRAM_OFFSET  0x200
+#define SRAM_OFFSET  0x400
 
 /*******************************************************************************
  * Hardware-specific configurations


### PR DESCRIPTION
A previous FIXME in the code was referring to a mismatch between the
mbed 3.0 linker script configuration (0x200) and the original offset as
set by the official Freescale/NXP linker scripts.

Now that mbed features 0x400 again, we can remove the FIXME message and
use that value.

@meriac @patater @niklas-arm 