### PR TITLE
Only include export headers if required.

### DIFF
--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -34,6 +34,16 @@
 #include "api/inc/register_gateway.h"
 #include "api/inc/secure_access.h"
 
+#include "api/inc/debug_exports.h"
+#include "api/inc/context_exports.h"
+#include "api/inc/export_table_exports.h"
+#include "api/inc/halt_exports.h"
+#include "api/inc/register_gateway_exports.h"
+#include "api/inc/svc_exports.h"
+#include "api/inc/priv_sys_irq_hook_exports.h"
+#include "api/inc/unvic_exports.h"
+#include "api/inc/uvisor_exports.h"
+
 #else /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
 
 #include "api/inc/unsupported.h"
@@ -45,21 +55,12 @@
  * what to do with any failures. */
 UVISOR_EXTERN int uvisor_lib_init(void);
 
-#include "api/inc/page_allocator.h"
+#if defined(__GNUC__)
 
-/* Include all exported header files used by uVisor internally.
- * These are included independently on whether uVisor is supported or not by the
- * target platform. */
-#include "api/inc/debug_exports.h"
-#include "api/inc/context_exports.h"
-#include "api/inc/export_table_exports.h"
-#include "api/inc/halt_exports.h"
-#include "api/inc/register_gateway_exports.h"
-#include "api/inc/svc_exports.h"
-#include "api/inc/priv_sys_irq_hook_exports.h"
-#include "api/inc/unvic_exports.h"
-#include "api/inc/uvisor_exports.h"
 #include "api/inc/vmpu_exports.h"
+#include "api/inc/page_allocator.h"
 #include "api/inc/page_allocator_exports.h"
+
+#endif
 
 #endif /* __UVISOR_API_UVISOR_LIB_H__ */


### PR DESCRIPTION
The page allocator header files only work on GCC.

See related #[insert] in mbedmicro.