### PR TITLE
Remove deprecated assertions on bss_size == 0

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -563,7 +563,6 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
     {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
-        assert(bss_size == 0);
         assert(stack_size == 0);
 
         /* assign main box stack pointer to existing

--- a/core/system/src/mpu/vmpu_freescale_k64.c
+++ b/core/system/src/mpu/vmpu_freescale_k64.c
@@ -175,7 +175,6 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
     {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
-        assert(bss_size == 0);
         assert(stack_size == 0);
 
         /* assign main box stack pointer to existing


### PR DESCRIPTION
The assertions were used in the `vmpu_acl_stack()` functions (Kinetis and
ARM MPUs) to check that box 0 has no context.

Now the concept of context has been extended to a more general BSS, and
the BSS for a box (including box 0) has always a size greater than 0.

@meriac @Patater @niklas-arm 