### PR TITLE
Register gateway: Provide macros for the shared bit

### DIFF
--- a/api/inc/register_gateway_exports.h
+++ b/api/inc/register_gateway_exports.h
@@ -79,6 +79,10 @@ typedef struct {
                  (((uint16_t) (width) << __UVISOR_RGW_OP_WIDTH_POS) & __UVISOR_RGW_OP_WIDTH_MASK) | \
                  (((uint16_t) (shared) << __UVISOR_RGW_OP_SHARED_POS) & __UVISOR_RGW_OP_SHARED_MASK)))
 
+/** Register gateway operation - Shared */
+#define UVISOR_RGW_SHARED    1
+#define UVISOR_RGW_EXCLUSIVE 0
+
 /** Register gateway operation - Type */
 #define UVISOR_RGW_OP_READ          0 /**< value = *address */
 #define UVISOR_RGW_OP_READ_AND      1 /**< value = *address & mask */


### PR DESCRIPTION
@meriac @patater @niklas-arm 

The API would now look like this:

```C
uint16_t val = uvisor_read(my_box, UVISOR_RGW_EXCLUSIVE, address, UVISOR_RGW_OP_READ, 0xFFFFFFFFUL);
```