### PR TITLE
fixup! export-table: Add export table

### DIFF
--- a/core/system/src/export_table.c
+++ b/core/system/src/export_table.c
@@ -20,7 +20,7 @@
  * table can be exported correctly. Placing this table into the .export_table
  * section locates this table at the end of the uVisor binary. */
 __attribute__((section(".export_table")))
-static const TUvisorExportTable __uvisor_export_table = {
+const TUvisorExportTable __uvisor_export_table = {
     .magic = UVISOR_EXPORT_MAGIC,
     .version = UVISOR_EXPORT_VERSION,
     .size = sizeof(TUvisorExportTable)


### PR DESCRIPTION
The original implementation of the export table had a bug where, only in
release builds, the export table was optimized out by the compiler. Make
the export table non-static so that the compiler will not optimize out the
export table in release builds.

Fixes: 7408972eddd3 ("export-table: Add export table")

@meriac @AlessandroA @niklas-arm