### PR TITLE
Switch allocators for uVisor supported; Add uVisor box main feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ endif
 
 SOURCES:=\
          $(CORE_SYSTEM_DIR)/src/benchmark.c \
+         $(CORE_SYSTEM_DIR)/src/box_init.c \
          $(CORE_SYSTEM_DIR)/src/context.c \
          $(CORE_SYSTEM_DIR)/src/halt.c \
          $(CORE_SYSTEM_DIR)/src/main.c \

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -45,6 +45,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         sizeof(RtxBoxIndex), \
         0, \
         0, \
+        0, \
         NULL, \
         acl_list, \
         acl_list_count \
@@ -76,6 +77,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         sizeof(RtxBoxIndex), \
         context_size, \
         __uvisor_box_heapsize, \
+        0, \
         __uvisor_box_namespace, \
         acl_list, \
         acl_list_count \

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -77,7 +77,7 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
         sizeof(RtxBoxIndex), \
         context_size, \
         __uvisor_box_heapsize, \
-        0, \
+        __uvisor_box_lib_config, \
         __uvisor_box_namespace, \
         acl_list, \
         acl_list_count \
@@ -117,6 +117,13 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
  * box_namespace as NULL. */
 #define UVISOR_BOX_NAMESPACE(box_namespace) \
     static const char *const __uvisor_box_namespace = box_namespace
+
+/* Use this macro before UVISOR_BOX_CONFIG to define the function the main
+ * thread of your box will use for its body. If you don't want a main thread,
+ * too bad: you have to have one. */
+#define UVISOR_BOX_MAIN(function, priority, stack_size) \
+    static osThreadDef(function, priority, stack_size); \
+    static const void * const __uvisor_box_lib_config = osThread(function);
 
 #define UVISOR_BOX_HEAPSIZE(heap_size) \
     static const uint32_t __uvisor_box_heapsize = heap_size;

--- a/api/inc/svc_exports.h
+++ b/api/inc/svc_exports.h
@@ -114,8 +114,10 @@
 #define UVISOR_SVC_ID_PAGE_FREE             UVISOR_SVC_CUSTOM_TABLE(23)
 
 /* SVC immediate values for hardcoded table (call from unprivileged) */
-#define UVISOR_SVC_ID_UNVIC_OUT        UVISOR_SVC_FIXED_TABLE(0, 0)
-#define UVISOR_SVC_ID_REGISTER_GATEWAY UVISOR_SVC_FIXED_TABLE(3, 0)
+#define UVISOR_SVC_ID_UNVIC_OUT           UVISOR_SVC_FIXED_TABLE(0, 0)
+/* Deprecated: UVISOR_SVC_ID_CX_IN(nargs) UVISOR_SVC_FIXED_TABLE(1, nargs) */
+/* Deprecated: UVISOR_SVC_ID_CX_OUT       UVISOR_SVC_FIXED_TABLE(2, 0) */
+#define UVISOR_SVC_ID_REGISTER_GATEWAY    UVISOR_SVC_FIXED_TABLE(3, 0)
 
 /* SVC immediate values for hardcoded table (call from privileged) */
 #define UVISOR_SVC_ID_UNVIC_IN         UVISOR_SVC_FIXED_TABLE(0, 0)

--- a/api/inc/svc_exports.h
+++ b/api/inc/svc_exports.h
@@ -118,6 +118,8 @@
 /* Deprecated: UVISOR_SVC_ID_CX_IN(nargs) UVISOR_SVC_FIXED_TABLE(1, nargs) */
 /* Deprecated: UVISOR_SVC_ID_CX_OUT       UVISOR_SVC_FIXED_TABLE(2, 0) */
 #define UVISOR_SVC_ID_REGISTER_GATEWAY    UVISOR_SVC_FIXED_TABLE(3, 0)
+#define UVISOR_SVC_ID_BOX_INIT_FIRST      UVISOR_SVC_FIXED_TABLE(4, 0)
+#define UVISOR_SVC_ID_BOX_INIT_NEXT       UVISOR_SVC_FIXED_TABLE(5, 0)
 
 /* SVC immediate values for hardcoded table (call from privileged) */
 #define UVISOR_SVC_ID_UNVIC_IN         UVISOR_SVC_FIXED_TABLE(0, 0)

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -169,6 +169,10 @@ typedef struct {
     /* Contains user provided size of box heap without guards of buffers. */
     uint32_t heap_size;
 
+    /* Opaque-to-uVisor data that potentially contains uvisor-lib-specific or
+     * OS-specific per-box configuration */
+    const void * const lib_config;
+
     const char * box_namespace;
     const UvisorBoxAclItem * const acl_list;
     uint32_t acl_count;

--- a/api/rtx/src/box_init.c
+++ b/api/rtx/src/box_init.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "uvisor-lib/uvisor-lib.h"
+#include "mbed_interface.h"
+#include "cmsis_os.h"
+#include <stdint.h>
+#include <string.h>
+
+/* This function is called by uVisor in unprivileged mode. On this OS, we
+ * create box main threads for the box. */
+void __uvisor_lib_box_init(void * lib_config)
+{
+    osThreadId thread_id;
+    osThreadDef_t * flash_thread_def = lib_config;
+    osThreadDef_t thread_def;
+
+    /* Copy thread definition from flash to RAM. The thread definition is most
+     * likely in flash, so we need to copy it to box-local RAM before we can
+     * modify it. */
+    memcpy(&thread_def, flash_thread_def, sizeof(thread_def));
+
+    /* Note that the box main thread stack is separate from the box stack. This
+     * is because the thread must be created to use a different stack than the
+     * stack osCreateThread() is called from, as context information is saved
+     * to the thread stack by the call to osCreateThread(). */
+    /* Allocate memory for the main thread from the process heap (which is
+     * private to the process). This memory is never freed, even if the box's
+     * main thread exits. */
+    thread_def.stack_pointer = malloc_p(thread_def.stacksize);
+
+    if (thread_def.stack_pointer == NULL) {
+        /* No process heap memory available */
+        mbed_die();
+    }
+
+    thread_id = osThreadCreate(&thread_def, NULL);
+
+    if (thread_id == NULL) {
+        /* Failed to create thread */
+        mbed_die();
+    }
+}

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -106,6 +106,10 @@ uvisor_config:
     /* Privileged system IRQ hooks */
     .long __uvisor_priv_sys_irq_hooks
 
+    /* Functions provided by uVisor Lib for use by uVisor in unprivileged mode
+     * */
+    .long 0
+
 /* uVisor mode of operation
  * Modes available: UVISOR_ENABLED, UVISOR_DISABLED, UVISOR_PERMISSIVE. */
 __uvisor_mode:

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -108,7 +108,7 @@ uvisor_config:
 
     /* Functions provided by uVisor Lib for use by uVisor in unprivileged mode
      * */
-    .long 0
+    .long __uvisor_lib_box_init
 
 /* uVisor mode of operation
  * Modes available: UVISOR_ENABLED, UVISOR_DISABLED, UVISOR_PERMISSIVE. */

--- a/api/src/uvisor-lib.c
+++ b/api/src/uvisor-lib.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "api/inc/export_table_exports.h"
+#include "rt_OsEventObserver.h"
 
 int uvisor_lib_init(void)
 {
@@ -36,6 +37,12 @@ int uvisor_lib_init(void)
         /* The version we understand is not the version we found. */
         return -1;
     }
+
+    /* osRegisterForOsEvents won't allow a second call. For systems that don't
+     * make use of osRegisterForOsEvents we recommend to
+     * osRegisterForOsEvents(NULL) to disable further registrations (which if
+     * allowed would be a backdoor). */
+     osRegisterForOsEvents(&uvisor_export_table->os_event_observer);
 
     return 0;
 }

--- a/core/system/inc/box_init.h
+++ b/core/system/inc/box_init.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __BOX_INIT_H__
+#define __BOX_INIT_H__
+
+#include <stdint.h>
+
+/** Start the recursion for the box initialization routine.
+ * @warning This function trusts the SVCall parameters that are passed to it.
+ * @param src_svc_sp[in]    Unprivileged stack pointer at the time of the SVCall
+ */
+void UVISOR_NAKED box_init_first(uint32_t src_svc_sp);
+
+/** Initialize the next box that requires it by running the default box
+ *  initialization handler.
+ * @warning This function trusts the SVCall parameters that are passed to it.
+ * @param src_svc_sp[in]    Unprivileged stack pointer at the time of the SVCall
+ */
+void UVISOR_NAKED box_init_next(uint32_t src_svc_sp);
+
+#endif /* __BOX_INIT_H__ */

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -95,6 +95,10 @@ typedef struct {
 
     /* Privileged system IRQ hooks */
     UvisorPrivSystemIRQHooks const * const priv_sys_irq_hooks;
+
+    /* Functions provided by uVisor Lib for use by uVisor in unprivileged mode
+     * */
+    void (*lib_box_init)(void * lib_config);
 } UVISOR_PACKED UvisorConfig;
 
 extern UvisorConfig const __uvisor_config;

--- a/core/system/src/box_init.c
+++ b/core/system/src/box_init.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <uvisor.h>
+#include "context.h"
+#include "halt.h"
+#include "linker.h"
+#include "vmpu.h"
+
+/** Flag used to remember whether the box initialization has happened
+ * @internal
+ */
+static bool g_box_init_happened;
+
+/** Counter of boxes that have already been initialized
+ * @internal
+ */
+static uint8_t g_box_init_counter;
+
+/** Cached stack pointer of the first SVCall in the initialization chain
+ * @internal
+ * The stack pointer of box 0 is cached so we do not need to re-compute it and
+ * re-verify it at every step in the chain.
+ */
+static uint32_t g_box_init_box0_sp;
+
+/** Thunk function for the box init initialization
+ * @internal
+ * Since the box initialization is implemented as a recursive gateway that
+ * iterates over all the secure boxes, this thunk is the same SVCall as the
+ * actual API that the user calls from uvisor-lib. The actual SVCall handler
+ * will check at which stage of the recursion we are.
+ */
+static void UVISOR_NAKED box_init_thunk(void)
+{
+    UVISOR_SVC(UVISOR_SVC_ID_BOX_INIT_NEXT, "");
+}
+
+/** Start the recursion for the box initialization routine.
+ * @internal
+ * This wrapper saves the callee-saved registers and then handles execution over
+ * to the actual function, which is \ref box_init_next.
+ * The called function will return from the exception directly. The registers
+ * will be popped when the recursion terminates.
+ */
+void UVISOR_NAKED box_init_first(uint32_t src_svc_sp)
+{
+    /* According to the ARM ABI, r0 will have the following value when this
+     * function is called:
+     *   r0 = src_svc_sp */
+    asm volatile (
+        "push {lr}\n"           /* Store the lr for later. */
+        "push {r4 - r11}\n"     /* Store the callee-saved registers for box 0. */
+        "b    box_init_next\n"  /* return box_init_next(src_svc_sp) */
+        /* The box init handler will be executed after this. */
+        :: "r" (src_svc_sp)
+    );
+}
+
+/** Initialize the next box that requires it by running the default box
+ *  initialization handler.
+ * @internal
+ * This wrapper just clears the registers for the previous box and hands over
+ * execution to the C handler, which is \ref box_init_context_switch_next.
+ */
+void UVISOR_NAKED box_init_next(uint32_t src_svc_sp)
+{
+    /* According to the ARM ABI, r0 will have the following value when this
+     * function is called:
+     *   r0 = src_svc_sp */
+    asm volatile (
+        "push  {lr}\n"                          /* Store the lr. */
+        "bl    box_init_context_switch_next\n"  /* termination =  box_init_context_switch_next(src_svc_sp) */
+        "pop   {lr}\n"                          /* Re-store the lr. */
+        "cbnz  r0, box_init_last\n"             /* if (termination) { return box_init_last(); } */
+        "mov   r4,  #0\n"                       /* Clear r4  */
+        "mov   r5,  #0\n"                       /* Clear r5  */
+        "mov   r6,  #0\n"                       /* Clear r6  */
+        "mov   r7,  #0\n"                       /* Clear r7  */
+        "mov   r8,  #0\n"                       /* Clear r8  */
+        "mov   r9,  #0\n"                       /* Clear r9  */
+        "mov   r10, #0\n"                       /* Clear r10 */
+        "mov   r11, #0\n"                       /* Clear r11 */
+        "bx    lr\n"                            /* Return. */
+        /* The box initialization handler will be executed after this. */
+
+        "box_init_last:\n"
+        "pop {r4 - r11}\n"                      /* Re-store the callee-saved registers previously saved for box 0. */
+        "pop {pc}\n"                            /* Return to the API caller. The lr was stored in box_init_first. */
+        /* The execution will return to the original API caller after this. */
+
+        :: "r" (src_svc_sp)
+    );
+}
+
+/** Perform a chain of context switches to initialize all secure boxes.
+ * @internal
+ * This function implements a recursive chain of context switches, where all
+ * destination contexts execute the same default handler, defined system-wide
+ * and registered in flash, in \ref UvisorConfig.lib_box_init.
+ * The default handler receives only one argument from the uVisor, which is the
+ * \ref UvisorBoxConfig.lib_config pointer. The default handler can parse the
+ * pointed-to data the way it wants; it is implementation-specific.
+ * @note This function can only be run once.
+ * @note Only boxes different from box 0 can be initialized. If an
+ * initialization handler is provided for box 0 it will be ignored.
+ * @param src_svc_sp[in]    Unprivileged stack pointer at the time of the
+ *                          SVCall
+ * @returns `true` if the recursion terminated, `false` otherwise.
+ */
+bool box_init_context_switch_next(uint32_t src_svc_sp)
+{
+    /* Check if this is the first time the box initialization procedure is
+     * requested. */
+    if (g_box_init_happened) {
+        HALT_ERROR(NOT_ALLOWED, "The box initialization routine can only be executed once.");
+    }
+
+    /* If there is only one box (which is box 0) return immediately. Box 0 is
+     * not allowed to have a box initialization function. */
+    if (g_vmpu_box_count == 1) {
+        g_box_init_happened = true;
+        return g_box_init_happened;
+    }
+
+    /* If the currently active box is not the one we expected from our running
+     * counter, then the recursive chain of context switches has been broken. */
+    if (g_active_box != g_box_init_counter) {
+        HALT_ERROR(NOT_ALLOWED, "The current box is inconsistent with the box initialization order.");
+    }
+
+    /* Get the default system-wide initialization handler from the uVisor
+     * configuration table. */
+    uint32_t const dst_fn = (uint32_t) __uvisor_config.lib_box_init;
+    if (dst_fn == 0) {
+        HALT_ERROR(NOT_ALLOWED, "The box initialization procedure requires an unprivileged handler to be specified.");
+    }
+    if (!vmpu_public_flash_addr(dst_fn)) {
+        HALT_ERROR(PERMISSION_DENIED, "The box initialization handler must be in public flash.");
+    }
+
+    /* Find the next box to switch to, if any.
+     * The box needs to have a box-specific configuration pointer. If it does
+     * not, the box is skipped. */
+    uint8_t dst_id = g_box_init_counter + 1;
+    UvisorBoxConfig const * * box_cfg = (UvisorBoxConfig const * *) __uvisor_config.cfgtbl_ptr_start;
+    void const * lib_config = NULL;
+    while (dst_id < g_vmpu_box_count) {
+        lib_config = box_cfg[dst_id]->lib_config;
+        if (lib_config != NULL) {
+            /* The box with ID dst_id is the next one to initialize. */
+            break;
+        } else {
+            /* Continue to the next box. */
+            dst_id++;
+        }
+    }
+
+    /* The stack pointer provided to us as an input comes from an SVC
+     * exception. We must check that it corresponds to a full frame that the
+     * source box can access. */
+    /* This function halts if it finds an error. */
+    uint32_t src_sp = context_validate_exc_sf(src_svc_sp);
+
+    /* If this is not the first context switch in the chain, then we first need
+     * to return from the previous one. */
+    if (g_box_init_counter == 0) {
+        g_box_init_box0_sp = src_sp;
+    } else {
+        context_discard_exc_sf(g_active_box, src_sp);
+        context_switch_out(CONTEXT_SWITCH_FUNCTION_GATEWAY);
+    }
+
+    /* Recursion termination condition
+     * If all boxes have been initialized, we can return to the original caller,
+     * which is in box 0. */
+    /* Note: We do not need to change any state. Everything has been done
+     *       already by the latest context_switch_out. */
+    if (dst_id >= g_vmpu_box_count) {
+        g_box_init_happened = true;
+        return g_box_init_happened;
+    }
+
+    /* If the code gets to this point, then we still have one or more boxes to
+     * initialize. In addition, we can assume that the box-specific
+     * configuration pointer is not NULL. */
+
+    /* The values of dst_id and box_cfg after the loop above represent the box
+     * to initialize. */
+    g_box_init_counter = dst_id;
+
+    /* Forge a stack frame for the destination box.
+     * We always use the cached box 0 stack pointer as a source, which we have
+     * already verified. */
+    uint32_t xpsr = ((uint32_t *) g_box_init_box0_sp)[7];
+    uint32_t dst_sp = context_forge_exc_sf(g_box_init_box0_sp, dst_id, dst_fn, (uint32_t) box_init_thunk, xpsr, 0);
+
+    /* We pass the box-specific configuration pointer to the default box
+     * initialization handler. The way this will be used is
+     * implementation-specific. */
+    if (!vmpu_public_flash_addr((uint32_t) lib_config)) {
+        HALT_ERROR(PERMISSION_DENIED, "The custom box configuration must point to data in public flash.");
+    }
+    ((uint32_t *) dst_sp)[0] = (uint32_t) lib_config;
+
+    /* Perform the context switch to the destination box.
+     * This context switch will update the internal context state, so that the
+     * destination handler can be pre-empted if needed. */
+    /* This function halts if it finds an error. */
+    context_switch_in(CONTEXT_SWITCH_FUNCTION_GATEWAY, dst_id, g_box_init_box0_sp, dst_sp);
+    return g_box_init_happened;
+}

--- a/core/system/src/export_table.c
+++ b/core/system/src/export_table.c
@@ -16,6 +16,7 @@
  */
 #include <uvisor.h>
 #include "api/inc/export_table_exports.h"
+#include "api/inc/svc_exports.h"
 #include "api/inc/vmpu_exports.h"
 #include "context.h"
 #include "halt.h"
@@ -120,6 +121,16 @@ static void thread_switch(void * c)
     }
 }
 
+static void boxes_init(void)
+{
+    /* Tell uVisor to call the uVisor lib box_init function for each box with
+     * each box's uVisor lib config. */
+
+    /* This must be called from unprivileged mode in order for the recursive
+     * gateway chaining to work properly. */
+    UVISOR_SVC(UVISOR_SVC_ID_BOX_INIT_FIRST, "");
+}
+
 /* This table must be located at the end of the uVisor binary so that this
  * table can be exported correctly. Placing this table into the .export_table
  * section locates this table at the end of the uVisor binary. */
@@ -129,6 +140,7 @@ const TUvisorExportTable __uvisor_export_table = {
     .version = UVISOR_EXPORT_VERSION,
     .os_event_observer = {
         .version = 0,
+        .pre_start = boxes_init,
         .thread_create = thread_create,
         .thread_destroy = thread_destroy,
         .thread_switch = thread_switch,

--- a/core/system/src/export_table.c
+++ b/core/system/src/export_table.c
@@ -14,7 +14,111 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <uvisor.h>
 #include "api/inc/export_table_exports.h"
+#include "api/inc/vmpu_exports.h"
+#include "context.h"
+#include "halt.h"
+
+/* By default a maximum of 16 threads are allowed. This can only be overridden
+ * by the porting engineer for the current platform. */
+#ifndef UVISOR_EXPORT_TABLE_THREADS_MAX_COUNT
+#define UVISOR_EXPORT_TABLE_THREADS_MAX_COUNT ((uint32_t) 16)
+#endif
+
+/* Per thread we store the pointer to the allocator and the process id that
+ * this thread belongs to. */
+typedef struct {
+    void * allocator;
+    int process_id;
+} UvisorThreadContext;
+
+static UvisorThreadContext thread[UVISOR_EXPORT_TABLE_THREADS_MAX_COUNT];
+
+
+static int thread_ctx_valid(UvisorThreadContext * context)
+{
+    /* Check if context pointer points into the array. */
+    if ((uint32_t) context < (uint32_t) &thread ||
+        ((uint32_t) &thread + sizeof(thread)) <= (uint32_t) context) {
+        return 0;
+    }
+    /* Check if the context is aligned exactly to a context. */
+    return (((uint32_t) context - (uint32_t) thread) % sizeof(UvisorThreadContext)) == 0;
+}
+
+static void * thread_create(int id, void * c)
+{
+    (void) id;
+    UvisorThreadContext * context = c;
+    const UvisorBoxIndex * const index =
+            (UvisorBoxIndex * const) *(__uvisor_config.uvisor_box_context);
+    /* Search for a free slot in the tasks meta data. */
+    uint32_t ii = 0;
+    for (; ii < UVISOR_EXPORT_TABLE_THREADS_MAX_COUNT; ii++) {
+        if (thread[ii].allocator == NULL) {
+            break;
+        }
+    }
+    if (ii < UVISOR_EXPORT_TABLE_THREADS_MAX_COUNT) {
+        /* Remember the process id for this thread. */
+        thread[ii].process_id = g_active_box;
+        /* Fall back to the process heap if ctx is NULL. */
+        thread[ii].allocator = context ? context : index->box_heap;
+        return &thread[ii];
+    }
+    return context;
+}
+
+static void thread_destroy(void * c)
+{
+    UvisorThreadContext * context = c;
+    if (context == NULL) {
+        return;
+    }
+
+    /* Only if TID is valid and destruction status is zero. */
+    if (thread_ctx_valid(context) && context->allocator && (context->process_id == g_active_box)) {
+        /* Release this slot. */
+        context->allocator = NULL;
+    } else {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "thread context (%08x) is invalid!\n",
+            context);
+    }
+}
+
+static void thread_switch(void * c)
+{
+    UvisorThreadContext * context = c;
+    UvisorBoxIndex * index;
+    if (context == NULL) {
+        return;
+    }
+
+    /* Only if TID is valid and the slot is used */
+    if (!thread_ctx_valid(context) || context->allocator == NULL) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "thread context (%08x) is invalid!\n",
+            context);
+        return;
+    }
+    /* If the thread is inside another process, switch into it. */
+    if (context->process_id != g_active_box) {
+        context_switch_in(CONTEXT_SWITCH_UNBOUND_THREAD, context->process_id, 0, 0);
+    }
+    /* Copy the thread allocator into the (new) box index. */
+    /* Note: The value in index is updated by context_switch_in, or is already
+     *       the correct one if no switch needs to occur. */
+    index = (UvisorBoxIndex *) *(__uvisor_config.uvisor_box_context);
+    if (context->allocator) {
+        /* If the active_heap is NULL, then the process heap needs to be
+         * initialized yet. The initializer sets the active heap itself. */
+        if (index->active_heap) {
+            index->active_heap = context->allocator;
+        }
+    }
+}
 
 /* This table must be located at the end of the uVisor binary so that this
  * table can be exported correctly. Placing this table into the .export_table
@@ -23,5 +127,11 @@ __attribute__((section(".export_table")))
 const TUvisorExportTable __uvisor_export_table = {
     .magic = UVISOR_EXPORT_MAGIC,
     .version = UVISOR_EXPORT_VERSION,
+    .os_event_observer = {
+        .version = 0,
+        .thread_create = thread_create,
+        .thread_destroy = thread_destroy,
+        .thread_switch = thread_switch,
+    },
     .size = sizeof(TUvisorExportTable)
 };

--- a/core/system/src/svc.c
+++ b/core/system/src/svc.c
@@ -16,6 +16,7 @@
  */
 #include <uvisor.h>
 #include "benchmark.h"
+#include "box_init.h"
 #include "debug.h"
 #include "halt.h"
 #include "svc.h"
@@ -136,8 +137,8 @@ void UVISOR_NAKED SVCall_IRQn_Handler(void)
         ".word  __svc_not_implemented\n" // Deprecated: secure_gateway_in
         ".word  __svc_not_implemented\n" // Deprecated: secure_gateway_out
         ".word  register_gateway_perform_operation\n"
-        ".word  __svc_not_implemented\n"
-        ".word  __svc_not_implemented\n"
+        ".word  box_init_first\n"
+        ".word  box_init_next\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"

--- a/core/system/src/svc.c
+++ b/core/system/src/svc.c
@@ -133,8 +133,8 @@ void UVISOR_NAKED SVCall_IRQn_Handler(void)
         ".align 4\n"                                // the jump table must be aligned
     "jump_table_unpriv:\n"
         ".word  unvic_gateway_out\n"
-        ".word  __svc_not_implemented\n"
-        ".word  __svc_not_implemented\n"
+        ".word  __svc_not_implemented\n" // Deprecated: secure_gateway_in
+        ".word  __svc_not_implemented\n" // Deprecated: secure_gateway_out
         ".word  register_gateway_perform_operation\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"

--- a/core/uvisor-config.h
+++ b/core/uvisor-config.h
@@ -27,7 +27,7 @@
  * link failure, so it can be used to track down a rough estimation of the
  * uVisor flash usage upper bound.
  */
-#define UVISOR_FLASH_LENGTH_MAX 0x8800
+#define UVISOR_FLASH_LENGTH_MAX 0x9000
 
 /** Size of the SRAM space protected by uVisor for its own SRAM sections
  * The actual SRAM space used by uVisor depends on the SRAM_OFFSET symbol, which


### PR DESCRIPTION
I've cleaned up the commits we have in unstable.

These PRs were similar to this one, but not as clean or as far along in implementing previous feedback.
https://github.com/ARMmbed/uvisor/pull/260
https://github.com/ARMmbed/uvisor/pull/258

The following is an excerpt from the example-uvisor-threaded-blinky application, illustrating the use of the new box main feature. For the complete working example, see https://github.com/Patater/example-uvisor-threaded-blinky
```C++
static void led1_main(const void *);

UVISOR_BOX_NAMESPACE(NULL);
UVISOR_BOX_HEAPSIZE(8192);
UVISOR_BOX_MAIN(led1_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
UVISOR_BOX_CONFIG(box_led1, acl, UVISOR_BOX_STACK_SIZE, box_context);
```

After this lands in the uVisor dev branch, meriac/mbed-os needs to commit the results of a fresh run of the importer script. Then, https://github.com/ARMmbed/example-uvisor-threaded-blinky/pull/2 needs to be updated to point to this new version of meriac/mbed-os.

@AlessandroA @meriac @niklas-arm