### PR TITLE
Fix the SRAM BSS section sanity checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,17 +129,6 @@ ifeq ("$(PROGRAM_VERSION)","")
 PROGRAM_VERSION:='unknown'
 endif
 
-# Read UVISOR_MAGIC and UVISOR_{FLASH, SRAM}_LENGTH from uvisor-config.h.
-ifeq ("$(wildcard  $(CORE_DIR)/uvisor-config.h)","")
-	UVISOR_MAGIC:=0
-	UVISOR_FLASH_LENGTH:=0
-	UVISOR_SRAM_LENGTH:=0
-else
-	UVISOR_MAGIC:=$(shell grep UVISOR_MAGIC $(CORE_DIR)/uvisor-config.h | sed -E 's/^.* (0x[0-9A-Fa-f]+).*$\/\1/')
-	UVISOR_FLASH_LENGTH:=$(shell grep UVISOR_FLASH_LENGTH $(CORE_DIR)/uvisor-config.h | sed -E 's/^.* (0x[0-9A-Fa-f]+).*$\/\1/')
-	UVISOR_SRAM_LENGTH:=$(shell grep UVISOR_SRAM_LENGTH $(CORE_DIR)/uvisor-config.h | sed -E 's/^.* (0x[0-9A-Fa-f]+).*$\/\1/')
-endif
-
 FLAGS_CM4:=-mcpu=cortex-m4 -march=armv7e-m -mthumb
 
 LDFLAGS:=\
@@ -178,15 +167,14 @@ OBJS:=$(foreach SOURCE, $(SOURCES), $(SOURCE).$(CONFIGURATION_LOWER).$(BUILD_MOD
 
 LINKER_CONFIG:=\
     -D$(CONFIGURATION) \
-    -DUVISOR_FLASH_LENGTH=$(UVISOR_FLASH_LENGTH) \
-    -DUVISOR_SRAM_LENGTH=$(UVISOR_SRAM_LENGTH) \
-    -include $(PLATFORM_DIR)/$(PLATFORM)/inc/config.h
+    -I$(PLATFORM_DIR)/$(PLATFORM)/inc \
+    -include $(CORE_DIR)/uvisor-config.h
 
 API_CONFIG:=\
-    -DUVISOR_FLASH_LENGTH=$(UVISOR_FLASH_LENGTH) \
-    -DUVISOR_SRAM_LENGTH=$(UVISOR_SRAM_LENGTH) \
-    -DUVISOR_MAGIC=$(UVISOR_MAGIC) \
-    -DUVISOR_BIN=\"$(CONFIGURATION_PREFIX).bin\"
+    -DUVISOR_BIN=\"$(CONFIGURATION_PREFIX).bin\" \
+    -D$(CONFIGURATION) \
+    -I$(PLATFORM_DIR)/$(PLATFORM)/inc \
+    -include $(CORE_DIR)/uvisor-config.h
 
 .PHONY: all fresh configurations release clean ctags
 

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -104,13 +104,24 @@
 
 #if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
 
+/** Round an address down to the closest 32-byte boundary.
+ * @param address[in]   The address to round.
+ */
+#define UVISOR_ROUND32_DOWN(address) ((address) & ~0x1FUL)
+
+/** Round an address up to the closest 32-byte boundary.
+ * @param address[in]   The address to round.
+ */
+#define UVISOR_ROUND32_UP(address) UVISOR_ROUND32_DOWN((address) + 31UL)
+
+
 #if defined(ARCH_MPU_ARMv7M)
 #define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~((1UL << UVISOR_REGION_BITS(x)) - 1))
 #define UVISOR_REGION_ROUND_UP(x)   (1UL << UVISOR_REGION_BITS(x))
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP(x)
 #elif defined(ARCH_MPU_KINETIS)
-#define UVISOR_REGION_ROUND_DOWN(x) ((x) & ~0x1FUL)
-#define UVISOR_REGION_ROUND_UP(x)   UVISOR_REGION_ROUND_DOWN((x) + 31UL)
+#define UVISOR_REGION_ROUND_DOWN(x) UVISOR_ROUND32_DOWN(x)
+#define UVISOR_REGION_ROUND_UP(x)   UVISOR_ROUND32_UP(x)
 #define UVISOR_STACK_SIZE_ROUND(x)  UVISOR_REGION_ROUND_UP((x) + (UVISOR_STACK_BAND_SIZE * 2))
 #else
 #error "Unknown MPU architecture. uvisor: Check your Makefile. uvisor-lib: Check if uVisor is supported"

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -128,4 +128,4 @@ __uvisor_ps:
 /* Reserve space for the uVisor BSS section. This section is zeroed by uVisor at
  * boot time. */
 .section .keep.uvisor.bss.main, "awM", @nobits
-    .space UVISOR_SRAM_LENGTH
+    .space UVISOR_SRAM_LENGTH_USED

--- a/core/linker/default.h
+++ b/core/linker/default.h
@@ -24,21 +24,21 @@ ENTRY(main_entry)
 #define UVISOR_FLASH_LENGTH_MAX (FLASH_LENGTH_MIN - FLASH_OFFSET)
 #define UVISOR_SRAM_LENGTH_MAX  (SRAM_LENGTH_MIN - SRAM_OFFSET)
 
-/* Check that the uVisor memory requirements can be satisfied */
+/* Check that the uVisor memory requirements can be satisfied. */
 #if UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_MAX
-#error "uVisor does not fit into the target memory. UVISOR_FLASH_LENGTH must be smaller than UVISOR_FLASH_LENGTH_MAX"
+#error "uVisor does not fit into the target memory. UVISOR_FLASH_LENGTH must be smaller than UVISOR_FLASH_LENGTH_MAX."
 #endif /* UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_MAX */
 #if UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_MAX
-#error "uVisor does not fit into the target memory. UVISOR_SRAM_LENGTH must be smaller than UVISOR_SRAM_LENGTH_MAX"
+#error "uVisor does not fit into the target memory. UVISOR_SRAM_LENGTH must be smaller than UVISOR_SRAM_LENGTH_MAX."
 #endif /* UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_MAX */
 
 #ifndef STACK_GUARD_BAND
 #define STACK_GUARD_BAND 32
-#endif/*STACK_GUARD_BAND*/
+#endif /* STACK_GUARD_BAND */
 
 #ifndef STACK_SIZE
 #define STACK_SIZE 1024
-#endif/*STACK_SIZE*/
+#endif /* STACK_SIZE */
 
 MEMORY
 {

--- a/core/linker/default.h
+++ b/core/linker/default.h
@@ -21,16 +21,16 @@ ENTRY(main_entry)
  * family. If for example a family of devices has Flash memories ranging from
  * 512KB to 4MB we must ensure that uVisor fits into 512KB (possibly minus the
  * offset at which uVisor is positioned). */
-#define UVISOR_FLASH_LENGTH_MAX (FLASH_LENGTH_MIN - FLASH_OFFSET)
-#define UVISOR_SRAM_LENGTH_MAX  (SRAM_LENGTH_MIN - SRAM_OFFSET)
+#define UVISOR_FLASH_LENGTH_AVAIL (FLASH_LENGTH_MIN - FLASH_OFFSET)
+#define UVISOR_SRAM_LENGTH_AVAIL  (SRAM_LENGTH_MIN - SRAM_OFFSET)
 
 /* Check that the uVisor memory requirements can be satisfied. */
-#if UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_MAX
-#error "uVisor does not fit into the target memory. UVISOR_FLASH_LENGTH must be smaller than UVISOR_FLASH_LENGTH_MAX."
-#endif /* UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_MAX */
-#if UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_MAX
-#error "uVisor does not fit into the target memory. UVISOR_SRAM_LENGTH must be smaller than UVISOR_SRAM_LENGTH_MAX."
-#endif /* UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_MAX */
+#if UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_AVAIL
+#error "uVisor does not fit into the target memory. UVISOR_FLASH_LENGTH must be smaller than UVISOR_FLASH_LENGTH_AVAIL."
+#endif /* UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_AVAIL */
+#if UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_AVAIL
+#error "uVisor does not fit into the target memory. UVISOR_SRAM_LENGTH must be smaller than UVISOR_SRAM_LENGTH_AVAIL."
+#endif /* UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_AVAIL */
 
 #ifndef STACK_GUARD_BAND
 #define STACK_GUARD_BAND 32

--- a/core/linker/default.h
+++ b/core/linker/default.h
@@ -24,13 +24,17 @@ ENTRY(main_entry)
 #define UVISOR_FLASH_LENGTH_AVAIL (FLASH_LENGTH_MIN - FLASH_OFFSET)
 #define UVISOR_SRAM_LENGTH_AVAIL  (SRAM_LENGTH_MIN - SRAM_OFFSET)
 
-/* Check that the uVisor memory requirements can be satisfied. */
-#if UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_AVAIL
-#error "uVisor does not fit into the target memory. UVISOR_FLASH_LENGTH must be smaller than UVISOR_FLASH_LENGTH_AVAIL."
+/* Check that the uVisor memory requirements can be satisfied.
+ * Flash: We do not know how much memory uVisor will actually use, so we compare
+ *        the available memory against the maximum uVisor could require.
+ * SRAM: We already have a symbol of the actual memory space requirement for
+ *       uVisor, so we use it for comparison. */
+#if UVISOR_FLASH_LENGTH_MAX > UVISOR_FLASH_LENGTH_AVAIL
+#error "uVisor does not fit into the target memory. UVISOR_FLASH_LENGTH_MAX must be smaller than UVISOR_FLASH_LENGTH_AVAIL."
 #endif /* UVISOR_FLASH_LENGTH > UVISOR_FLASH_LENGTH_AVAIL */
-#if UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_AVAIL
-#error "uVisor does not fit into the target memory. UVISOR_SRAM_LENGTH must be smaller than UVISOR_SRAM_LENGTH_AVAIL."
-#endif /* UVISOR_SRAM_LENGTH > UVISOR_SRAM_LENGTH_AVAIL */
+#if UVISOR_SRAM_LENGTH_USED > UVISOR_SRAM_LENGTH_AVAIL
+#error "uVisor does not fit into the target memory. UVISOR_SRAM_LENGTH_USED must be smaller than UVISOR_SRAM_LENGTH_AVAIL."
+#endif /* UVISOR_SRAM_LENGTH_USED > UVISOR_SRAM_LENGTH_AVAIL */
 
 #ifndef STACK_GUARD_BAND
 #define STACK_GUARD_BAND 32
@@ -43,10 +47,10 @@ ENTRY(main_entry)
 MEMORY
 {
   FLASH (rx) : ORIGIN = (FLASH_ORIGIN + FLASH_OFFSET),
-               LENGTH = UVISOR_FLASH_LENGTH - FLASH_OFFSET
+               LENGTH = UVISOR_FLASH_LENGTH_MAX
   RAM   (rwx): ORIGIN = (SRAM_ORIGIN + SRAM_OFFSET),
-               LENGTH = UVISOR_SRAM_LENGTH - SRAM_OFFSET - STACK_SIZE
-  STACK (rw) : ORIGIN = (SRAM_ORIGIN + UVISOR_SRAM_LENGTH - STACK_SIZE),
+               LENGTH = UVISOR_SRAM_LENGTH_USED - STACK_SIZE
+  STACK (rw) : ORIGIN = (SRAM_ORIGIN + SRAM_OFFSET + UVISOR_SRAM_LENGTH_USED - STACK_SIZE),
                LENGTH = STACK_SIZE
 }
 

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -85,15 +85,15 @@ static int vmpu_sanity_checks(void)
         VMPU_REGION_SIZE(__uvisor_config.bss_main_start,
                          __uvisor_config.bss_main_end));
     DPRINTF("             (0x%08X (%u bytes) [linker]\n",
-            SRAM_OFFSET_START, UVISOR_SRAM_LENGTH);
+            SRAM_OFFSET_START, UVISOR_SRAM_LENGTH_USED);
     assert( __uvisor_config.bss_main_end > __uvisor_config.bss_main_start );
     assert( VMPU_REGION_SIZE(__uvisor_config.bss_main_start,
-                             __uvisor_config.bss_main_end) == UVISOR_SRAM_LENGTH );
+                             __uvisor_config.bss_main_end) == UVISOR_SRAM_LENGTH_USED );
     assert(&__stack_end__ <= __uvisor_config.bss_main_end);
 
     assert( (uint32_t) __uvisor_config.bss_main_start == SRAM_OFFSET_START);
     assert( (uint32_t) __uvisor_config.bss_main_end == (SRAM_OFFSET_START +
-                                                        UVISOR_SRAM_LENGTH) );
+                                                        UVISOR_SRAM_LENGTH_USED) );
 
     /* verify that secure flash area is accessible and after public code */
     assert(!vmpu_public_flash_addr((uint32_t) __uvisor_config.secure_start));

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -81,6 +81,16 @@ static int vmpu_sanity_checks(void)
         SRAM_ORIGIN + SRAM_OFFSET,
         UVISOR_SRAM_LENGTH_USED);
 
+    /* Verify that the sections inside the BSS region are disjoint. */
+    DPRINTF("bss_boxes  : @0x%08X (%u bytes) [config]\n",
+        __uvisor_config.bss_boxes_start,
+        VMPU_REGION_SIZE(__uvisor_config.bss_boxes_start, __uvisor_config.bss_boxes_end));
+    assert(__uvisor_config.bss_end > __uvisor_config.bss_start);
+    assert(__uvisor_config.bss_main_end > __uvisor_config.bss_main_start);
+    assert(__uvisor_config.bss_boxes_end > __uvisor_config.bss_boxes_start);
+    assert((__uvisor_config.bss_main_start >= __uvisor_config.bss_boxes_end) ||
+           (__uvisor_config.bss_main_end <= __uvisor_config.bss_boxes_start));
+
     /* Verify the uVisor expectations regarding its own memories. */
     assert(VMPU_REGION_SIZE(__uvisor_config.bss_main_start, __uvisor_config.bss_main_end) == UVISOR_SRAM_LENGTH_USED);
     assert((uint32_t) __uvisor_config.bss_main_end == (SRAM_ORIGIN + SRAM_OFFSET + UVISOR_SRAM_LENGTH_USED));

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -95,6 +95,13 @@ static int vmpu_sanity_checks(void)
     assert(VMPU_REGION_SIZE(__uvisor_config.bss_main_start, __uvisor_config.bss_main_end) == UVISOR_SRAM_LENGTH_USED);
     assert((uint32_t) __uvisor_config.bss_main_end == (SRAM_ORIGIN + SRAM_OFFSET + UVISOR_SRAM_LENGTH_USED));
     assert((uint32_t) __uvisor_config.bss_main_end == (SRAM_ORIGIN + UVISOR_SRAM_LENGTH_PROTECTED));
+
+    /* Verify SRAM sections are within uVisor's own SRAM. */
+    assert(&__bss_start__ >= __uvisor_config.bss_main_start);
+    assert(&__bss_end__ <= __uvisor_config.bss_main_end);
+    assert(&__data_start__ >= __uvisor_config.bss_main_start);
+    assert(&__data_end__ <= __uvisor_config.bss_main_end);
+    assert(&__stack_start__ >= __uvisor_config.bss_main_start);
     assert(&__stack_end__ <= __uvisor_config.bss_main_end);
 
     /* Verify that the secure flash area is accessible and after public code. */

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -71,7 +71,7 @@
 /* MPU helper macros */
 #define MPU_RBAR(region,addr)   (((uint32_t)(region))|MPU_RBAR_VALID_Msk|addr)
 #define MPU_RBAR_RNR(addr)     (addr)
-#define MPU_STACK_GUARD_BAND_SIZE (UVISOR_SRAM_LENGTH/8)
+#define MPU_STACK_GUARD_BAND_SIZE (UVISOR_SRAM_LENGTH_PROTECTED/8)
 
 /* various MPU flags */
 #define MPU_RASR_AP_PNO_UNO (0x00UL<<MPU_RASR_AP_Pos)

--- a/core/uvisor-config.h
+++ b/core/uvisor-config.h
@@ -48,6 +48,11 @@
 #error "Invalid SRAM configuration. SRAM_OFFSET must be smaller than UVISOR_SRAM_LENGTH_PROTECTED"
 #endif
 
+/* Check that the SRAM offset is aligned to 32 bytes. */
+#if (SRAM_ORIGIN + SRAM_OFFSET) & 0x1FUL
+#error "Invalid SRAM configuration. SRAM_ORIGIN + SRAM_OFFSET must be aligned to 32 bytes."
+#endif /* (SRAM_ORIGIN + SRAM_OFFSET) & 0x1FUL */
+
 /* SRAM_OFFSET >= UVISOR_SRAM_LENGTH_PROTECTED */
 /** Check that the SRAM_ORIGIN address is a multiple of the \ref
  * UVISOR_SRAM_LENGTH_PROTECTED space that will be protected by uVisor at


### PR DESCRIPTION
There were 2 issues with the vMPU sanity checks for the SRAM relocation:

* The configuration table symbols for the BSS main start/end were used
  as-is, while in fact those symbols are rounded to 32 bytes in the
  linker script. Because of alignment, the size given to the BSS main
  section might be more than what we asked for, `UVISOR_SRAM_LENGTH`.

* The start of the uVisor BSS section was checked using an MPU driver-specifc macro.
   Instead, we know that the physical address will **always** be rounded to 32 bits (see linker script).
  **Note**: In the ARM v7-M driver the actual start address for
  the MPU region that covers the uVisor SRAM is `SRAM_ORIGIN` anyway,
  regardless of the offset. This change only affects the sanity checks!

@meriac @Patater @niklas-arm 