### PR TITLE
Swap the revision and variant fields of CPUID

### DIFF
--- a/core/cmsis/inc/hardware_support.h
+++ b/core/cmsis/inc/hardware_support.h
@@ -27,8 +27,8 @@
 /* Note: Currently the revision requirement (>= r2p0) is needed because we use
  *       the SCnSCB->ACTLR register to disable write buffering in debug mode. */
 #define CORE_PARTNO        0xC23 /* PartNO   == Cortex-M3 */
-#define CORE_REVISTION_MIN 0x2   /* Revision >= r2 */
-#define CORE_VARIANT_MIN   0x0   /* Variant  >= p0 */
+#define CORE_VARIANT_MIN   0x2   /* Variant  >= r2 */
+#define CORE_REVISTION_MIN 0x0   /* Revision >= p0 */
 
 /* This setting enables some conditional definitions in the core_cm3.h file. */
 /* Note: Currently (CMSIS v4.10) the __CM3_REV symbol affects the conditional
@@ -43,8 +43,8 @@
 #elif defined(CORE_CORTEX_M4)
 
 #define CORE_PARTNO        0xC24 /* PartNO   == Cortex-M4 */
-#define CORE_REVISTION_MIN 0x0   /* Revision >= r0 */
-#define CORE_VARIANT_MIN   0x0   /* Variant  >= p0 */
+#define CORE_VARIANT_MIN   0x0   /* Variant  >= r0 */
+#define CORE_REVISTION_MIN 0x0   /* Revision >= p0 */
 
 /* This setting enables some conditional definitions in the core_cm4.h file. */
 /* Note: Currently (CMSIS v4.10) the __CM4_REV symbol does not affect any

--- a/core/cmsis/inc/hardware_support.h
+++ b/core/cmsis/inc/hardware_support.h
@@ -26,9 +26,9 @@
 
 /* Note: Currently the revision requirement (>= r2p0) is needed because we use
  *       the SCnSCB->ACTLR register to disable write buffering in debug mode. */
-#define CORE_PARTNO        0xC23 /* PartNO   == Cortex-M3 */
-#define CORE_VARIANT_MIN   0x2   /* Variant  >= r2 */
-#define CORE_REVISTION_MIN 0x0   /* Revision >= p0 */
+#define CORE_PARTNO       0xC23 /* PartNO   == Cortex-M3 */
+#define CORE_VARIANT_MIN  0x2   /* Variant  >= r2 */
+#define CORE_REVISION_MIN 0x0   /* Revision >= p0 */
 
 /* This setting enables some conditional definitions in the core_cm3.h file. */
 /* Note: Currently (CMSIS v4.10) the __CM3_REV symbol affects the conditional
@@ -42,9 +42,9 @@
 
 #elif defined(CORE_CORTEX_M4)
 
-#define CORE_PARTNO        0xC24 /* PartNO   == Cortex-M4 */
-#define CORE_VARIANT_MIN   0x0   /* Variant  >= r0 */
-#define CORE_REVISTION_MIN 0x0   /* Revision >= p0 */
+#define CORE_PARTNO       0xC24 /* PartNO   == Cortex-M4 */
+#define CORE_VARIANT_MIN  0x0   /* Variant  >= r0 */
+#define CORE_REVISION_MIN 0x0   /* Revision >= p0 */
 
 /* This setting enables some conditional definitions in the core_cm4.h file. */
 /* Note: Currently (CMSIS v4.10) the __CM4_REV symbol does not affect any
@@ -66,6 +66,6 @@
      (((SCB->CPUID & SCB_CPUID_PARTNO_Msk) >> SCB_CPUID_PARTNO_Pos) == CORE_PARTNO))
 #define CORE_REVISION_CHECK() \
     ((((SCB->CPUID & SCB_CPUID_VARIANT_Msk) >> SCB_CPUID_VARIANT_Pos) >= CORE_VARIANT_MIN) && \
-     (((SCB->CPUID & SCB_CPUID_REVISION_Msk) >> SCB_CPUID_REVISION_Pos) >= CORE_REVISTION_MIN))
+     (((SCB->CPUID & SCB_CPUID_REVISION_Msk) >> SCB_CPUID_REVISION_Pos) >= CORE_REVISION_MIN))
 
 #endif/*__HARDWARE_SUPPORT_H__*/


### PR DESCRIPTION
When verifying the core version against the minimum requirements, the
variant and revision fields in the CPUID register where swapped.

If a core version if r2p0, then the variant is r2, the revision is p0.

Reported and fixed by @fvincenzo.

@meriac @Patater @niklas-arm 