### PR TITLE
Build artifacts end up in separate folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ CONFIGURATION_PREFIX:=$(PLATFORM_DIR)/$(PLATFORM)/$(BUILD_MODE)/$(CONFIGURATION_
 # Release library definitions
 API_ASM_HEADER:=$(API_DIR)/src/uvisor-header.S
 API_ASM_INPUT:=$(API_DIR)/src/uvisor-input.S
-API_ASM_OUTPUT:=$(API_ASM_INPUT).$(CONFIGURATION_LOWER).$(BUILD_MODE).s
+API_ASM_OUTPUT:=$(CONFIGURATION_PREFIX)/$(API_DIR)/uvisor-output.s
 API_RELEASE:=$(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)/$(CONFIGURATION_LOWER).a
 API_VERSION:=$(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)/$(CONFIGURATION_LOWER).txt
 
@@ -70,7 +70,10 @@ API_VERSION:=$(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)/$(CONFIGURATION_LOWER).txt
 #       will be compiled by the host OS in case uVisor is not supported.
 API_SOURCES:=$(wildcard $(API_DIR)/src/*.c)
 API_SOURCES:=$(filter-out $(API_DIR)/src/unsupported.c, $(API_SOURCES))
-API_OBJS:=$(foreach API_SOURCE, $(API_SOURCES), $(API_SOURCE).$(CONFIGURATION_LOWER).$(BUILD_MODE).o) $(API_ASM_OUTPUT:.s=.o)
+
+# Release library object files
+API_OBJS:=$(foreach API_SOURCE, $(API_SOURCES), $(CONFIGURATION_PREFIX)/$(API_DIR)/$(notdir $(API_SOURCE:.c=.o))) \
+          $(API_ASM_OUTPUT:.s=.o)
 
 # Make the ARMv7-M MPU driver the default.
 ifeq ("$(ARCH_MPU)","")
@@ -93,6 +96,7 @@ MPU_SRC:=\
          $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64_mem.c
 endif
 
+# Core source files
 SOURCES:=\
          $(CORE_SYSTEM_DIR)/src/benchmark.c \
          $(CORE_SYSTEM_DIR)/src/context.c \
@@ -111,6 +115,27 @@ SOURCES:=\
          $(CORE_LIB_DIR)/printf/tfp_printf.c \
          $(MPU_SRC) \
          $(PLATFORM_SRC)
+
+# Core object files
+OBJS:=$(foreach SOURCE, $(SOURCES), $(CONFIGURATION_PREFIX)/$(CORE_DIR)/$(notdir $(SOURCE:.c=.o)))
+
+# Source files search path
+# The vpath command allows us to look for source files by only using their
+# basename. It is required because we want object files to be placed in a
+# different path from their corresponding sources.
+# The search path needs to be set depending on whether the current target is to
+# build the core or the release library (so the two can have the same names
+# without collisions).
+ifneq ($(MAKECMDGOALS),build_core)
+vpath %.c $(API_DIR)/src
+vpath %.s $(API_DIR)/src
+else
+vpath %.c $(CORE_SYSTEM_DIR)/src:\
+          $(CORE_SYSTEM_DIR)/src/mpu:\
+          $(CORE_DEBUG_DIR)/src:\
+          $(CORE_LIB_DIR)/printf:\
+          $(PLATFORM_DIR)/src
+endif
 
 SYSLIBS:=-lgcc -lc -lnosys
 DEBUG:=-g3
@@ -174,8 +199,6 @@ CFLAGS_PRE:=\
 CFLAGS:=$(FLAGS_CM4) $(CFLAGS_PRE)
 CPPFLAGS:=-fno-exceptions
 
-OBJS:=$(foreach SOURCE, $(SOURCES), $(SOURCE).$(CONFIGURATION_LOWER).$(BUILD_MODE).o)
-
 LINKER_CONFIG:=\
     -D$(CONFIGURATION) \
     -DUVISOR_FLASH_LENGTH=$(UVISOR_FLASH_LENGTH) \
@@ -188,7 +211,7 @@ API_CONFIG:=\
     -DUVISOR_MAGIC=$(UVISOR_MAGIC) \
     -DUVISOR_BIN=\"$(CONFIGURATION_PREFIX).bin\"
 
-.PHONY: all fresh configurations release clean ctags
+.PHONY: all fresh configurations build_core build_api clean ctags
 
 # Build both the release and debug versions for all platforms for all
 # configurations.
@@ -201,10 +224,10 @@ fresh: clean all
 # The "all" target uses this target to iterate over all platforms.
 platform-%:
 	@echo
-	# 2nd-level make
+	@# 2nd-level make
 	make BUILD_MODE=debug PLATFORM=$* configurations
 	@echo
-	# 2nd-level make
+	@# 2nd-level make
 	make BUILD_MODE=release PLATFORM=$* configurations
 
 # This middleware target is needed because the 1st-level make does not know the
@@ -224,54 +247,67 @@ endif
 ifndef BUILD_MODE
 	$(error "Missing build mode. Use PLATFORM=<platform> BUILD_MODE=<build_mode> make CONFIGURATION_<configuration>")
 endif
-	# 3rd-level make
-	make BUILD_MODE=$(BUILD_MODE) PLATFORM=$(PLATFORM) CONFIGURATION=$@ api_release
+	@# 3rd-level make
+	make BUILD_MODE=$(BUILD_MODE) PLATFORM=$(PLATFORM) CONFIGURATION=$@ build_core
+	@# 3rd-level make
+	make BUILD_MODE=$(BUILD_MODE) PLATFORM=$(PLATFORM) CONFIGURATION=$@ build_api
+
+# This middleware target is needed because the parent make does not know the
+# name to give to the core binary yet.
+# $(CONFIGURATION_PREFIX).bin is defined using platform-, configuration-, and
+# build-mode-specific definitions, so this target can only be called by the
+# 3rd-level make.
+build_core: $(CONFIGURATION_PREFIX).bin
 
 # This middleware target is needed because the parent make does not know the
 # name to give to the release library yet.
 # $(API_RELEASE) is defined using platform-, configuration-, and
 # build-mode-specific definitions, so this target can only be called by the
 # 3rd-level make.
-api_release: $(API_RELEASE)
+build_api: $(API_RELEASE)
+
+# Generate the needed folders if they do not exist.
+$(CONFIGURATION_PREFIX)/$(CORE_DIR):
+	mkdir -p $(CONFIGURATION_PREFIX)/$(CORE_DIR)
+$(CONFIGURATION_PREFIX)/$(API_DIR):
+	mkdir -p $(CONFIGURATION_PREFIX)/$(API_DIR)
+$(dir $(API_RELEASE)):
+	mkdir -p $(dir $(API_RELEASE))
 
 # Generate the pre-linked uVisor binary for the given platform, configuration
 # and build mode.
 # The binary is then packaged with the uVisor library implementations into a
 # unique .a file.
-$(API_RELEASE): $(API_ASM_OUTPUT) $(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE) $(API_OBJS)
+$(API_RELEASE): $(dir $(API_RELEASE)) $(CONFIGURATION_PREFIX)/$(API_DIR) $(API_OBJS)
 	$(AR) Dcr $(API_RELEASE) $(API_OBJS)
 	echo "$(PROGRAM_VERSION)" > $(API_VERSION)
-
-# Generate the output asm file from the asm input file and the INCBIN'ed binary.
-$(API_ASM_OUTPUT): $(CONFIGURATION_PREFIX).bin
-	cp -f $(API_ASM_HEADER) $(API_ASM_OUTPUT)
-	$(CPP) -w -P $(API_CONFIG) $(API_ASM_INPUT) > $(API_ASM_OUTPUT)
-
-# Generate the library folders if they do not exist.
-$(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE):
-	mkdir -p $(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)
 
 # Copy the core ELF file into a binary.
 $(CONFIGURATION_PREFIX).bin: $(CONFIGURATION_PREFIX).elf
 	$(OBJCOPY) $< -O binary $@
 
-# Link all object files into the core ELF.
-$(CONFIGURATION_PREFIX).elf: $(OBJS) $(CONFIGURATION_PREFIX).linker
+# Link all the core object files into the core ELF.
+$(CONFIGURATION_PREFIX).elf: $(CONFIGURATION_PREFIX)/$(CORE_DIR) $(OBJS) $(CONFIGURATION_PREFIX).linker
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(SYSLIBS)
 	$(OBJDUMP) -d $@ > $(CONFIGURATION_PREFIX).asm
 
 # Pre-process the core linker script.
 $(CONFIGURATION_PREFIX).linker: $(CORE_LINKER_DIR)/default.h
-	mkdir -p $(dir $(CONFIGURATION_PREFIX))
 	$(CPP) -w -P $(LINKER_CONFIG) $< -o $@
 
-# Pre-process and compile a C file into an object file.
-%.c.$(CONFIGURATION_LOWER).$(BUILD_MODE).o: %.c
+# Pre-process and compile a core C file into an object file.
+$(CONFIGURATION_PREFIX)/$(CORE_DIR)/%.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
-# Pre-process and compile an S file into an object file.
-%.S.$(CONFIGURATION_LOWER).$(BUILD_MODE).o: %.S.$(CONFIGURATION_LOWER).$(BUILD_MODE).s
+# Pre-process and compile a release library C file into an object file.
+$(CONFIGURATION_PREFIX)/$(API_DIR)/%.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+# Generate the output asm file from the asm input file and the INCBIN'ed binary.
+$(API_ASM_OUTPUT:.s=.o): $(CONFIGURATION_PREFIX).bin $(API_ASM_INPUT)
+	cp $(API_ASM_HEADER) $(API_ASM_OUTPUT)
+	$(CPP) -w -P $(API_CONFIG) $(API_ASM_INPUT) >> $(API_ASM_OUTPUT)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $(API_ASM_OUTPUT) -o $@
 
 ctags: source.c.tags
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ CORE_SYSTEM_DIR:=$(CORE_DIR)/system
 
 # List of supported platforms
 # Note: One could do it in a simpler way but this prevents spurious files in
-# $(PLATFORM_DIR) from getting picked.
+#       $(PLATFORM_DIR) from getting picked.
 PLATFORMS = $(notdir $(realpath $(dir $(wildcard $(PLATFORM_DIR)/*/))))
 
 # List of uVisor configurations for the given platform
@@ -72,7 +72,7 @@ API_SOURCES:=$(wildcard $(API_DIR)/src/*.c)
 API_SOURCES:=$(filter-out $(API_DIR)/src/unsupported.c, $(API_SOURCES))
 API_OBJS:=$(foreach API_SOURCE, $(API_SOURCES), $(API_SOURCE).$(CONFIGURATION_LOWER).$(BUILD_MODE).o) $(API_ASM_OUTPUT:.s=.o)
 
-# make ARMv7-M MPU driver the default
+# Make the ARMv7-M MPU driver the default.
 ifeq ("$(ARCH_MPU)","")
 ARCH_MPU:=ARMv7M
 endif
@@ -96,15 +96,15 @@ endif
 SOURCES:=\
          $(CORE_SYSTEM_DIR)/src/benchmark.c \
          $(CORE_SYSTEM_DIR)/src/context.c \
+         $(CORE_SYSTEM_DIR)/src/export_table.c \
          $(CORE_SYSTEM_DIR)/src/halt.c \
          $(CORE_SYSTEM_DIR)/src/main.c \
          $(CORE_SYSTEM_DIR)/src/page_allocator.c \
          $(CORE_SYSTEM_DIR)/src/register_gateway.c \
          $(CORE_SYSTEM_DIR)/src/stdlib.c \
          $(CORE_SYSTEM_DIR)/src/svc.c \
-         $(CORE_SYSTEM_DIR)/src/unvic.c \
-         $(CORE_SYSTEM_DIR)/src/export_table.c \
          $(CORE_SYSTEM_DIR)/src/system.c \
+         $(CORE_SYSTEM_DIR)/src/unvic.c \
          $(CORE_SYSTEM_DIR)/src/mpu/vmpu.c \
          $(CORE_DEBUG_DIR)/src/debug.c \
          $(CORE_DEBUG_DIR)/src/memory_map.c \
@@ -123,7 +123,7 @@ else
 OPT:=-Os -DNDEBUG
 endif
 
-# determine repository version
+# Determine the repository version.
 PROGRAM_VERSION:=$(shell git describe --tags --abbrev=4 --dirty 2>/dev/null | sed s/^v//)
 ifeq ("$(PROGRAM_VERSION)","")
 PROGRAM_VERSION:='unknown'
@@ -194,23 +194,29 @@ API_CONFIG:=\
 # configurations.
 all: $(foreach PLATFORM, $(PLATFORMS), platform-$(PLATFORM))
 
-# Same as all, but clean first.
+# Same as "all", but clean first.
 fresh: clean all
 
-# This target is used to iterate over all platforms. It builds both the release
-# and debug versions of all the platform-specific configurations.
+# This target builds the release and debug version of a platform.
+# The "all" target uses this target to iterate over all platforms.
 platform-%:
 	@echo
+	# 2nd-level make
 	make BUILD_MODE=debug PLATFORM=$* configurations
 	@echo
+	# 2nd-level make
 	make BUILD_MODE=release PLATFORM=$* configurations
 
-# This middleware target is needed because the parent make does not know the
-# configurations yet (they are platform-specific).
+# This middleware target is needed because the 1st-level make does not know the
+# configurations yet.
+# $(CONFIGURATIONS) is defined by the platform-specific Makefile extension, so
+# this target can only be called by the 2nd-level make.
 configurations: $(CONFIGURATIONS)
 
-# This target is used to iterate over all configurations for the current
-# platform.
+# This target builds a single configuration, provided that the platform and the
+# build mode are already configured.
+# The "configurations" target uses this target to iterate over all
+# configurations for a platform, given a build mode.
 CONFIGURATION_%:
 ifndef PLATFORM
 	$(error "Missing platform. Use PLATFORM=<platform> BUILD_MODE=<build_mode> make CONFIGURATION_<configuration>")
@@ -218,13 +224,18 @@ endif
 ifndef BUILD_MODE
 	$(error "Missing build mode. Use PLATFORM=<platform> BUILD_MODE=<build_mode> make CONFIGURATION_<configuration>")
 endif
-	make BUILD_MODE=$(BUILD_MODE) PLATFORM=$(PLATFORM) CONFIGURATION=$@ release
+	# 3rd-level make
+	make BUILD_MODE=$(BUILD_MODE) PLATFORM=$(PLATFORM) CONFIGURATION=$@ api_release
 
 # This middleware target is needed because the parent make does not know the
-# name to give to the binary release yet (it is configuration-specific).
-release: $(API_RELEASE)
+# name to give to the release library yet.
+# $(API_RELEASE) is defined using platform-, configuration-, and
+# build-mode-specific definitions, so this target can only be called by the
+# 3rd-level make.
+api_release: $(API_RELEASE)
 
-# Generate the pre-linked uVisor binary for the given platform and configuration.
+# Generate the pre-linked uVisor binary for the given platform, configuration
+# and build mode.
 # The binary is then packaged with the uVisor library implementations into a
 # unique .a file.
 $(API_RELEASE): $(API_ASM_OUTPUT) $(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE) $(API_OBJS)
@@ -240,20 +251,25 @@ $(API_ASM_OUTPUT): $(CONFIGURATION_PREFIX).bin
 $(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE):
 	mkdir -p $(API_DIR)/lib/$(PLATFORM)/$(BUILD_MODE)
 
+# Copy the core ELF file into a binary.
 $(CONFIGURATION_PREFIX).bin: $(CONFIGURATION_PREFIX).elf
 	$(OBJCOPY) $< -O binary $@
 
+# Link all object files into the core ELF.
 $(CONFIGURATION_PREFIX).elf: $(OBJS) $(CONFIGURATION_PREFIX).linker
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(SYSLIBS)
 	$(OBJDUMP) -d $@ > $(CONFIGURATION_PREFIX).asm
 
+# Pre-process the core linker script.
 $(CONFIGURATION_PREFIX).linker: $(CORE_LINKER_DIR)/default.h
 	mkdir -p $(dir $(CONFIGURATION_PREFIX))
 	$(CPP) -w -P $(LINKER_CONFIG) $< -o $@
 
+# Pre-process and compile a C file into an object file.
 %.c.$(CONFIGURATION_LOWER).$(BUILD_MODE).o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+# Pre-process and compile an S file into an object file.
 %.S.$(CONFIGURATION_LOWER).$(BUILD_MODE).o: %.S.$(CONFIGURATION_LOWER).$(BUILD_MODE).s
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
@@ -262,6 +278,8 @@ ctags: source.c.tags
 source.c.tags: $(SOURCES)
 	CFLAGS="$(CFLAGS_PRE)" geany -g $@ $^
 
+# Clean everything.
+# Note: You will lose any previously compiled library.
 clean:
 	rm -f source.c.tags
 	find $(ROOT_DIR) -iname '*.o' -delete


### PR DESCRIPTION
This PR makes sure that build artifacts end up in separate folders from the source files paths.

We have 2 classes of build artifacts:

* For the uVisor core build. Artifacts now end up in `$(CONFIGURATION)/$(BUILD_MODE)/core/`.
* For the uVisor APIs build. Artifacts now end up in `$(CONFIGURATION)/$(BUILD_MODE)/api/`.

The source files in the `core` and `api` folders can still have the same name, without generating collisions (an example is `benchmark.c` in both `api/src/` and `core/system/src/`).

As a bonus, the core and APIs builds are now separated, so in the future one can be changed without affecting the other.

@meriac @Patater @niklas-arm 