### PR TITLE
Add page heap MPU recovery for K64F

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ SOURCES:=\
          $(CORE_SYSTEM_DIR)/src/halt.c \
          $(CORE_SYSTEM_DIR)/src/main.c \
          $(CORE_SYSTEM_DIR)/src/page_allocator.c \
+         $(CORE_SYSTEM_DIR)/src/page_allocator_faults.c \
          $(CORE_SYSTEM_DIR)/src/register_gateway.c \
          $(CORE_SYSTEM_DIR)/src/stdlib.c \
          $(CORE_SYSTEM_DIR)/src/svc.c \

--- a/api/rtx/src/unsupported_page_allocator.c
+++ b/api/rtx/src/unsupported_page_allocator.c
@@ -33,6 +33,7 @@
 #define HALT_ERROR(id, ...) {}
 #define UVISOR_PAGE_ALLOCATOR_MUTEX_AQUIRE  page_allocator_mutex_aquire()
 #define UVISOR_PAGE_ALLOCATOR_MUTEX_RELEASE osMutexRelease(g_page_allocator_mutex_id)
+#define page_allocator_reset_faults(...) {}
 
 /* Forward declaration of the page allocator API. */
 int page_allocator_malloc(UvisorPageTable * const table);

--- a/core/cmsis/inc/mpu_kinetis.h
+++ b/core/cmsis/inc/mpu_kinetis.h
@@ -1126,6 +1126,14 @@ typedef struct {
   __IO uint32_t RGDAAC[12];                        /**< Region Descriptor Alternate Access Control n, array offset: 0x800, array step: 0x4 */
 } MPU_Type, *MPU_MemMapPtr;
 
+/** MPU - Region Layout Typedef */
+typedef struct {
+    __IO uint32_t STARTADDR;
+    __IO uint32_t ENDADDR;
+    __IO uint32_t PERMISSIONS;
+    __IO uint32_t CONTROL;
+} MPU_Region;
+
 /* ----------------------------------------------------------------------------
    -- MPU - Register accessor macros
    ---------------------------------------------------------------------------- */

--- a/core/system/inc/mpu/vmpu_freescale_k64_mem.h
+++ b/core/system/inc/mpu/vmpu_freescale_k64_mem.h
@@ -37,5 +37,6 @@ extern int vmpu_mem_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl
 extern void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box);
 extern uint32_t vmpu_fault_find_acl_mem(uint8_t box_id, uint32_t fault_addr, uint32_t size);
 extern void vmpu_mem_init(void);
+extern int vmpu_mem_push_page_acl(uint32_t start_addr, uint32_t end_addr);
 
 #endif/*__VMPU_FREESCALE_K64_MEM_H__*/

--- a/core/system/inc/page_allocator.h
+++ b/core/system/inc/page_allocator.h
@@ -18,6 +18,7 @@
 #define __PAGE_ALLOCATOR_H__
 
 #include "api/inc/page_allocator_exports.h"
+#include "page_allocator_config.h"
 
 /* Initialize the page allocator.
  *
@@ -47,5 +48,19 @@ int page_allocator_malloc(UvisorPageTable * const table);
  * @returns Non-zero on failure with failure class `UVISOR_ERROR_CLASS_PAGE`. See `UVISOR_ERROR_PAGE_*`.
  */
 int page_allocator_free(const UvisorPageTable * const table);
+
+/* Map an address to a page index.
+ * @return page index or `UVISOR_PAGE_UNUSED` if address does not belong to page heap.
+ */
+uint8_t page_allocator_get_page_from_address(uint32_t address);
+
+/* Contains the configured page size. */
+extern uint32_t g_page_size;
+/* Points to the beginning of the page heap. */
+extern const void * g_page_heap_start;
+/* Contains the total number of available pages. */
+extern uint8_t g_page_count_total;
+/* Maps the page to the owning box handle. */
+extern page_owner_t g_page_owner_table[];
 
 #endif /* __PAGE_ALLOCATOR_H__ */

--- a/core/system/inc/page_allocator_config.h
+++ b/core/system/inc/page_allocator_config.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PAGE_ALLOCATOR_CONFIG_H__
+#define __PAGE_ALLOCATOR_CONFIG_H__
+/* This file can be compiled externally to provide the page allocator algorithm
+ * for devices NOT supported by uVisor. For this purpose this file is copied as
+ * is into the target build folder and compiled by the target build system. */
+
+/* We can only protect a small number of pages efficiently, so there should be
+ * a relatively low limit to the number of pages.
+ * By default a maximum of 16 pages are allowed. This can only be overwritten
+ * by the porting engineer for the current platform. */
+#ifndef UVISOR_PAGE_TABLE_MAX_COUNT
+#define UVISOR_PAGE_TABLE_MAX_COUNT ((uint32_t) 16)
+#endif
+/* The number of pages is decided by the page size. A small page size leads to
+ * a lot of pages, however, number of pages is capped for efficiency.
+ * Furthermore, when allocating large continous memory, a too small page size
+ * will lead to allocation failures. This can only be overwritten
+ * by the porting engineer for the current platform. */
+#ifndef UVISOR_PAGE_SIZE_MINIMUM
+#define UVISOR_PAGE_SIZE_MINIMUM ((uint32_t) 1024)
+#endif
+
+/* The page box_id is the box id which is 8-bit large. */
+typedef uint8_t page_owner_t;
+/* Define a unused value for the page table. */
+#define UVISOR_PAGE_UNUSED ((page_owner_t) (-1))
+
+#endif /* __PAGE_ALLOCATOR_CONFIG_H__ */

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -28,4 +28,16 @@ void page_allocator_register_fault(uint8_t page);
 /** @returns the number of faults on this page. */
 uint32_t page_allocator_get_faults(uint8_t page);
 
+/** Map an address to the start and end addresses of a page.
+ * If the address is not part of any page, or the page does not belong to the
+ * active box or box 0 an error is returned and `start` and `end` are invalid.
+ *
+ * @param address           the address to map
+ * @param[out] start_addr   pointer to the start address value
+ * @param[out] end_addr     pointer to the end address value
+ * @param[out] page         pointer to the page index value
+ * @returns Non-zero on failure with failure class `UVISOR_ERROR_CLASS_PAGE`. See `UVISOR_ERROR_PAGE_*`.
+ */
+int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * start_addr, uint32_t * end_addr, uint8_t * page);
+
 #endif /* __PAGE_ALLOCATOR_FAULTS_H__ */

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __PAGE_ALLOCATOR_FAULTS_H__
+#define __PAGE_ALLOCATOR_FAULTS_H__
+
+#include "api/inc/page_allocator_exports.h"
+
+/** Resets the fault count on a page. */
+void page_allocator_reset_faults(uint8_t page);
+
+/** Registers a fault on a page. */
+void page_allocator_register_fault(uint8_t page);
+
+/** @returns the number of faults on this page. */
+uint32_t page_allocator_get_faults(uint8_t page);
+
+#endif /* __PAGE_ALLOCATOR_FAULTS_H__ */

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -40,4 +40,19 @@ uint32_t page_allocator_get_faults(uint8_t page);
  */
 int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * start_addr, uint32_t * end_addr, uint8_t * page);
 
+/** Callback for iterating over pages.
+ * @param start_addr    the page start address
+ * @param end_addr      the page end address
+ * @param page          the page index
+ * @retval 0            stop iteration after this callback.
+ * @retval !0           continue iteration after this callback.
+ */
+typedef int (*PageAllocatorIteratorCallback)(uint32_t start_addr, uint32_t end_addr, uint8_t page);
+
+/* Iterate over all pages belonging to the active box or box 0 and execute the callback.
+ * @param callback  the function to execute on every page. May be NULL.
+ * @return          number of active pages.
+ */
+uint8_t page_allocator_iterate_active_pages(PageAllocatorIteratorCallback callback);
+
 #endif /* __PAGE_ALLOCATOR_FAULTS_H__ */

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -331,7 +331,7 @@ void vmpu_mem_init(void)
 
     /* rest of SRAM, accessible to mbed - non-executable for uvisor */
     res = vmpu_mem_add_int(0, __uvisor_config.bss_end,
-        ((uint32_t) __uvisor_config.sram_end) - ((uint32_t) __uvisor_config.bss_end),
+        UVISOR_REGION_ROUND_UP((uint32_t) __uvisor_config.page_start) - ((uint32_t) __uvisor_config.bss_end),
         UVISOR_TACL_SREAD|
         UVISOR_TACL_SWRITE|
         UVISOR_TACL_UREAD|

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -18,6 +18,7 @@
 #include "halt.h"
 #include "vmpu.h"
 #include "vmpu_freescale_k64_mem.h"
+#include "page_allocator_faults.h"
 
 /* The K64F has 12 MPU regions, however, we use region 0 as the background
  * region with `UVISOR_TACL_BACKGROUND` as permissions.
@@ -95,6 +96,16 @@ uint32_t vmpu_fault_find_acl_mem(uint8_t box_id, uint32_t fault_addr, uint32_t s
     return 0;
 }
 
+/* This is the iterator callback for inserting all page heap ACLs into to the
+ * MPU during `vmpu_mem_switch()`. */
+static int vmpu_mem_push_page_acl_iterator(uint32_t start_addr, uint32_t end_addr, uint8_t page)
+{
+    /* Insert the MPU region at the `g_mpu_slot`. */
+    vmpu_mem_push_page_acl(start_addr, end_addr);
+    /* We only continue if we have not wrapped around the end of the MPU regions yet. */
+    return (g_mpu_slot > K64F_MPU_REGIONS_USER);
+}
+
 void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box)
 {
     uint32_t t, u, dst_count;
@@ -112,13 +123,11 @@ void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box)
 
     box = &g_mem_box[dst_box];
 
-    /* Disable all user MPU regions. */
-    for (t = K64F_MPU_REGIONS_USER; t < K64F_MPU_REGIONS_MAX; t++) {
-        MPU->WORD[t][3] = 0;
-    }
-
-    /* for box zero, just return. */
+    /* For box zero, disable all user MPU regions and return. */
     if(src_box && !dst_box) {
+        for (t = K64F_MPU_REGIONS_USER; t < K64F_MPU_REGIONS_MAX; t++) {
+            ((MPU_Region *) MPU->WORD[t])->CONTROL = 0;
+        }
         return;
     }
 
@@ -144,6 +153,17 @@ void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box)
         /* If no MPU regions are free anymore, set the RR marker at the
          * of the USER MPU regions (leaving stack and context intact!). */
         g_mpu_slot = K64F_MPU_REGIONS_USER;
+    } else {
+        /* Copy the active page heap ACLs into the MPU regions:
+         * This will start at index `g_mpu_slot` and continue to `K64F_MPU_REGIONS_MAX`. */
+        /* FIXME: Use page fault count to prioritize which pages are enabled! */
+        t = K64F_MPU_REGIONS_MAX - g_mpu_slot;
+        if (page_allocator_iterate_active_pages(vmpu_mem_push_page_acl_iterator) < t) {
+            /* Disable all remaining regions. */
+            for (t = g_mpu_slot; t < K64F_MPU_REGIONS_MAX; t++) {
+                ((MPU_Region *) MPU->WORD[t])->CONTROL = 0;
+            }
+        }
     }
     /* Copy the ACLs into the MPU regions. */
     for (t = K64F_MPU_REGIONS_STATIC; t < u; t++, rgd++) {

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -22,6 +22,7 @@
 
 #include <uvisor.h>
 #include "page_allocator.h"
+#include "page_allocator_faults.h"
 #include "mpu/vmpu_unpriv_access.h"
 #include "mpu/vmpu.h"
 #include "halt.h"
@@ -135,6 +136,7 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
     uint32_t page = 0;
     for (; page < UVISOR_PAGE_TABLE_MAX_COUNT; page++) {
         g_page_owner_table[page] = UVISOR_PAGE_UNUSED;
+        page_allocator_reset_faults(page);
     }
 }
 
@@ -178,6 +180,8 @@ int page_allocator_malloc(UvisorPageTable * const table)
         if (g_page_owner_table[page] == UVISOR_PAGE_UNUSED) {
             /* Marry this page to the box id. */
             g_page_owner_table[page] = box_id;
+            /* Reset the fault count for this page. */
+            page_allocator_reset_faults(page);
             /* Get the pointer to the page. */
             void * ptr = (void *) g_page_heap_start + page * g_page_size;
             /* Zero the entire page before handing it out. */

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -38,40 +38,31 @@
 
 #endif /* defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1) */
 
-/* We can only protect a small number of pages efficiently, so there should be
- * a relatively low limit to the number of pages.
- * By default a maximum of 16 pages are allowed. This can only be overridden
- * by the porting engineer for the current platform. */
-#ifndef UVISOR_PAGE_TABLE_MAX_COUNT
-#define UVISOR_PAGE_TABLE_MAX_COUNT ((uint32_t) 16)
-#endif
-/* The number of pages is decided by the page size. A small page size leads to
- * a lot of pages, however, number of pages is capped for efficiency.
- * Furthermore, when allocating large continous memory, a too small page size
- * will lead to allocation failures. This can only be overridden
- * by the porting engineer for the current platform. */
-#ifndef UVISOR_PAGE_SIZE_MINIMUM
-#define UVISOR_PAGE_SIZE_MINIMUM ((uint32_t) 1024)
-#endif
+#include "page_allocator_config.h"
 
-/* The page box_id is the box id which is 8-bit large. */
-typedef uint8_t page_owner_t;
 /* Maps the page to the owning box handle. */
-static page_owner_t g_page_owner_table[UVISOR_PAGE_TABLE_MAX_COUNT];
-/* Define a unused value for the page table. */
-#define UVISOR_PAGE_UNUSED ((page_owner_t) (-1))
-
+page_owner_t g_page_owner_table[UVISOR_PAGE_TABLE_MAX_COUNT];
 /* Contains the configured page size. */
-static uint32_t g_page_size;
+uint32_t g_page_size;
 /* Points to the beginning of the page heap. */
-static const void * g_page_heap_start;
+const void * g_page_heap_start;
 /* Points to the end of the page heap. */
-static const void * g_page_heap_end;
+const void * g_page_heap_end;
 /* Contains the number of free pages. */
-static uint8_t g_page_count_free;
+uint8_t g_page_count_free;
 /* Contains the total number of available pages. */
-static uint8_t g_page_count_total;
+uint8_t g_page_count_total;
 
+/* Helper function maps pointer to page id, or UVISOR_PAGE_UNUSED. */
+uint8_t page_allocator_get_page_from_address(uint32_t address)
+{
+    /* Range check the returned pointer. */
+    if (address < (uint32_t) g_page_heap_start || address >= (uint32_t) g_page_heap_end) {
+        return UVISOR_PAGE_UNUSED;
+    }
+    /* Compute the index for the pointer. */
+    return (address - (uint32_t) g_page_heap_start) / g_page_size;
+}
 
 void page_allocator_init(void * const heap_start, void * const heap_end, const uint32_t * const page_size)
 {
@@ -142,7 +133,7 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
             (unsigned int) (g_page_size / 1024));
 
     uint32_t page = 0;
-    for (; page < g_page_count_total; page++) {
+    for (; page < UVISOR_PAGE_TABLE_MAX_COUNT; page++) {
         g_page_owner_table[page] = UVISOR_PAGE_UNUSED;
     }
 }
@@ -239,14 +230,14 @@ int page_allocator_free(const UvisorPageTable * const table)
     int table_size = page_count;
     for (; table_size > 0; page_table++, table_size--) {
         void * page = (void *) page_table_read((uint32_t) page_table);
+        /* Compute the index for the pointer. */
+        uint8_t page_index = page_allocator_get_page_from_address((uint32_t) page);
         /* Range check the returned pointer. */
-        if (page < g_page_heap_start || page >= g_page_heap_end) {
+        if (page_index == UVISOR_PAGE_UNUSED) {
             DPRINTF("uvisor_page_free: FAIL: Pointer 0x%08x does not belong to any page!\n\n", (unsigned int) page);
             UVISOR_PAGE_ALLOCATOR_MUTEX_RELEASE;
             return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
         }
-        /* Compute the index for the pointer. */
-        uint32_t page_index = (page - g_page_heap_start) / g_page_size;
         /* Check if the page belongs to the caller. */
         if (g_page_owner_table[page_index] == box_id) {
             g_page_owner_table[page_index] = UVISOR_PAGE_UNUSED;

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -45,3 +45,25 @@ uint32_t page_allocator_get_faults(uint8_t page)
     }
     return 0;
 }
+
+int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * start_addr, uint32_t * end_addr, uint8_t * page)
+{
+    const page_owner_t box_id = g_active_box;
+
+    /* Compute the page id. */
+    uint8_t p = page_allocator_get_page_from_address(address);
+    if (p == UVISOR_PAGE_UNUSED) {
+        /* This address does not correspond to any page. */
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
+    }
+    /* Check that the page actually belongs to this box or box 0. */
+    if ((g_page_owner_table[p] != 0) && (g_page_owner_table[p] != box_id)) {
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
+    }
+    /* Compute the page start and end address */
+    *start_addr = (uint32_t) g_page_heap_start + g_page_size * p;
+    *end_addr = *start_addr + g_page_size;
+    *page = p;
+
+    return UVISOR_ERROR_PAGE_OK;
+}

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <uvisor.h>
+#include "page_allocator.h"
+#include "page_allocator_faults.h"
+#include "page_allocator_config.h"
+#include "context.h"
+
+/* Maps the number of faults to a page. */
+uint32_t g_page_fault_table[UVISOR_PAGE_TABLE_MAX_COUNT];
+
+void page_allocator_reset_faults(uint8_t page)
+{
+    if (page < g_page_count_total) {
+        g_page_fault_table[page] = 0;
+    }
+}
+
+void page_allocator_register_fault(uint8_t page)
+{
+    if (page < g_page_count_total) {
+        g_page_fault_table[page]++;
+    }
+}
+
+uint32_t page_allocator_get_faults(uint8_t page)
+{
+    if (page < g_page_count_total) {
+        return g_page_fault_table[page];
+    }
+    return 0;
+}


### PR DESCRIPTION
This disables access to the page heap and adds on round robin scheduling for access to pages on MPU fault recovery.

cc @meriac @AlessandroA @Patater 