### PR TITLE
fixup! Add tier-2 allocator init and wrapper functions

### DIFF
--- a/api/rtx/src/rtx_malloc_wrapper.c
+++ b/api/rtx/src/rtx_malloc_wrapper.c
@@ -111,7 +111,8 @@ static void * memory(void * ptr, size_t size, int heap, int operation)
         return NULL;
     }
     /* Check if we need to aquire the mutex. */
-    int mutexed = (is_kernel_initialized() && (heap == HEAP_PROCESS));
+    int mutexed = is_kernel_initialized() &&
+                  ((heap == HEAP_PROCESS) || __uvisor_ps->index.box_heap == __uvisor_ps->index.active_heap);
     void * allocator = (heap == HEAP_PROCESS) ?
                        (__uvisor_ps->index.box_heap) :
                        (__uvisor_ps->index.active_heap);


### PR DESCRIPTION
Previously, we weren't acquiring the memory mutex if the box_heap was
the active heap. This allowed multiple threads to clobber each other's
memories when the active heap was the box_heap.

@meriac @AlessandroA @niklas-arm 