### PR TITLE
Use bitmaps to map page ownership to box id.

### DIFF
--- a/core/system/inc/page_allocator.h
+++ b/core/system/inc/page_allocator.h
@@ -60,7 +60,7 @@ extern uint32_t g_page_size;
 extern const void * g_page_heap_start;
 /* Contains the total number of available pages. */
 extern uint8_t g_page_count_total;
-/* Maps the page to the owning box handle. */
-extern page_owner_t g_page_owner_table[];
+/* Contains the page usage mapped by owner. */
+extern uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
 
 #endif /* __PAGE_ALLOCATOR_H__ */

--- a/core/system/inc/page_allocator_config.h
+++ b/core/system/inc/page_allocator_config.h
@@ -25,8 +25,8 @@
  * a relatively low limit to the number of pages.
  * By default a maximum of 16 pages are allowed. This can only be overwritten
  * by the porting engineer for the current platform. */
-#ifndef UVISOR_PAGE_TABLE_MAX_COUNT
-#define UVISOR_PAGE_TABLE_MAX_COUNT ((uint32_t) 16)
+#ifndef UVISOR_PAGE_MAX_COUNT
+#define UVISOR_PAGE_MAX_COUNT ((uint32_t) 16)
 #endif
 /* The number of pages is decided by the page size. A small page size leads to
  * a lot of pages, however, number of pages is capped for efficiency.
@@ -41,5 +41,34 @@
 typedef uint8_t page_owner_t;
 /* Define a unused value for the page table. */
 #define UVISOR_PAGE_UNUSED ((page_owner_t) (-1))
+
+/** Sets the page bit in the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ */
+static inline void page_allocator_map_set(uint32_t * const map, uint8_t page)
+{
+    map[page / 32] |= (1UL << (page % 32));
+}
+
+/** Clears the page bit in the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ */
+static inline void page_allocator_map_clear(uint32_t * const map, uint8_t page)
+{
+    map[page / 32] &= ~(1UL << (page % 32));
+}
+
+/** Check if the page bit is set int the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ * @retval 0    if page bit is not set
+ * @retval !0   if page bit is set
+ */
+static inline uint32_t page_allocator_map_get(const uint32_t * const map, uint8_t page)
+{
+    return (map[page / 32] & (1UL << (page % 32)));
+}
 
 #endif /* __PAGE_ALLOCATOR_CONFIG_H__ */

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -41,8 +41,10 @@
 
 #include "page_allocator_config.h"
 
-/* Maps the page to the owning box handle. */
-page_owner_t g_page_owner_table[UVISOR_PAGE_TABLE_MAX_COUNT];
+/* Contains the page usage mapped by owner. */
+uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
+/* Contains total page usage. */
+uint32_t g_page_usage_map[(UVISOR_PAGE_MAX_COUNT + 31) / 32];
 /* Contains the configured page size. */
 uint32_t g_page_size;
 /* Points to the beginning of the page heap. */
@@ -119,8 +121,8 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
         g_page_count_total = ((uint32_t) heap_end - start) / g_page_size;
     }
     /* Clamp page count to table size. */
-    if (g_page_count_total > UVISOR_PAGE_TABLE_MAX_COUNT) {
-        g_page_count_total = UVISOR_PAGE_TABLE_MAX_COUNT;
+    if (g_page_count_total > UVISOR_PAGE_MAX_COUNT) {
+        g_page_count_total = UVISOR_PAGE_MAX_COUNT;
     }
     g_page_count_free = g_page_count_total;
     /* Remember the end of the heap. */
@@ -133,11 +135,9 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
             (unsigned int) g_page_count_total,
             (unsigned int) (g_page_size / 1024));
 
-    uint32_t page = 0;
-    for (; page < UVISOR_PAGE_TABLE_MAX_COUNT; page++) {
-        g_page_owner_table[page] = UVISOR_PAGE_UNUSED;
-        page_allocator_reset_faults(page);
-    }
+    /* Force a reset of owner and usage page maps. */
+    memset(g_page_owner_map, 0, sizeof(g_page_owner_map));
+    memset(g_page_usage_map, 0, sizeof(g_page_usage_map));
 }
 
 int page_allocator_malloc(UvisorPageTable * const table)
@@ -177,9 +177,19 @@ int page_allocator_malloc(UvisorPageTable * const table)
     uint32_t page = 0;
     for (; (page < g_page_count_total) && pages_required; page++) {
         /* If the page is unused, it's entry is UVISOR_PAGE_UNUSED (not NULL!). */
-        if (g_page_owner_table[page] == UVISOR_PAGE_UNUSED) {
-            /* Marry this page to the box id. */
-            g_page_owner_table[page] = box_id;
+        if (!page_allocator_map_get(g_page_usage_map, page)) {
+            /* Remember this page as used. */
+            page_allocator_map_set(g_page_usage_map, page);
+            /* Pages of box 0 are accessible to all other boxes! */
+            if (box_id == 0) {
+                uint32_t ii = 0;
+                for (; ii < UVISOR_MAX_BOXES; ii++) {
+                    page_allocator_map_set(g_page_owner_map[ii], page);
+                }
+            } else {
+                /* Otherwise, remember ownership only for active box. */
+                page_allocator_map_set(g_page_owner_map[box_id], page);
+            }
             /* Reset the fault count for this page. */
             page_allocator_reset_faults(page);
             /* Get the pointer to the page. */
@@ -243,14 +253,25 @@ int page_allocator_free(const UvisorPageTable * const table)
             return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
         }
         /* Check if the page belongs to the caller. */
-        if (g_page_owner_table[page_index] == box_id) {
-            g_page_owner_table[page_index] = UVISOR_PAGE_UNUSED;
+        if (page_allocator_map_get(g_page_owner_map[box_id], page_index)) {
+            /* Clear the owner and usage page maps for this page. */
+            page_allocator_map_clear(g_page_usage_map, page_index);
+            /* If the page was owned by box 0, we need to remove it from all other boxes! */
+            if (box_id == 0) {
+                uint32_t ii = 0;
+                for (; ii < UVISOR_MAX_BOXES; ii++) {
+                    page_allocator_map_clear(g_page_owner_map[ii], page_index);
+                }
+            } else {
+                /* Otherwise, only remove for the active box. */
+                page_allocator_map_clear(g_page_owner_map[box_id], page_index);
+            }
             g_page_count_free++;
             DPRINTF("uvisor_page_free: Freeing page at index %u\n", page_index);
         }
         else {
             /* Abort if the page doesn't belong to the caller. */
-            if (g_page_owner_table[page_index] == UVISOR_PAGE_UNUSED) {
+            if (!page_allocator_map_get(g_page_usage_map, page_index)) {
                 DPRINTF("uvisor_page_free: FAIL: Page %u is not allocated!\n\n", page_index);
             } else {
                 DPRINTF("uvisor_page_free: FAIL: Page %u is not owned by box %u!\n\n", page_index, box_id);

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -22,7 +22,7 @@
 #include "context.h"
 
 /* Maps the number of faults to a page. */
-uint32_t g_page_fault_table[UVISOR_PAGE_TABLE_MAX_COUNT];
+uint32_t g_page_fault_table[UVISOR_PAGE_MAX_COUNT];
 
 void page_allocator_reset_faults(uint8_t page)
 {
@@ -56,8 +56,8 @@ int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * st
         /* This address does not correspond to any page. */
         return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
     }
-    /* Check that the page actually belongs to this box or box 0. */
-    if ((g_page_owner_table[p] != 0) && (g_page_owner_table[p] != box_id)) {
+    /* Then check if the page is set. */
+    if (!page_allocator_map_get(g_page_owner_map[box_id], p)) {
         return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
     }
     /* Compute the page start and end address */
@@ -72,13 +72,11 @@ uint8_t page_allocator_iterate_active_pages(int (*callback)(uint32_t start_addr,
 {
     uint8_t ii, count = 0;
     uint32_t start_addr, end_addr;
+    const page_owner_t box_id = g_active_box;
 
     /* Iterate over all pages. */
-    /* FIXME: Use bit masks for this to make this page enabling more efficient.
-     * By storing the pages as a bit mask in an array indexed by box id, the lookup
-     * is O(1) and it can be OR-ed with box 0 and then all pages can be enabled at once. */
     for (ii = 0; ii < g_page_count_total; ii++) {
-        if (g_page_owner_table[ii] == g_active_box || g_page_owner_table[ii] == 0) {
+        if (page_allocator_map_get(g_page_owner_map[box_id], ii)) {
             count++;
             if (callback) {
                 /* Compute start and end addresses. */


### PR DESCRIPTION
This changes the page owner table to a page owner bitmap. This allows
to query the ownership of a page in O(1), rather than linear search, and
makes it possible to OR together box 0 and active box page bitmap to get
the active pages in O(1).

This is a preparation for porting the page allocator protection to the ARMv7-M MPU.
By storing the ownership information in a bitmap, it makes using the MPU subregions much easier (literally just masking the right 8 bits).

This has been tested on K64F without any failures.

cc @meriac @AlessandroA @Patater 