### PR TITLE
ARMv7-M MPU: Use subregions to blacklist the uVisor memories

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -379,8 +379,17 @@ SECTIONS
         . = ALIGN(32);
         __uvisor_bss_boxes_end = .;
 
+        /************************** ARMv7-M MPU only **************************/
+        __uvisor_bss_end_padding_max = (2 << (LOG2CEIL(__uvisor_bss_end - ORIGIN(m_data)) - 1)) / 8;
+        . = MIN(
+            __uvisor_bss_end_padding_max * (((__uvisor_bss_end - ORIGIN(m_data)) / __uvisor_bss_end_padding_max) +
+            MIN((__uvisor_bss_end - ORIGIN(m_data)) % __uvisor_bss_end_padding_max, 1)) - __UVISOR_SRAM_OFFSET,
+            ORIGIN(m_data) + LENGTH(m_data)
+        ); 
+        /********************** Other MPU architectures ***********************/
         . = ALIGN(32);
-        __uvisor_bss_end = .;
+        /**********************************************************************/
+        __uvisor_bss_end= .;
     } > m_data
 
     /* Now we can place the .data section, which will be loaded to SRAM. */


### PR DESCRIPTION
When uVisor shares its memories with the host OS we need to first open a region (1) for the whole SRAM and then close a region (2) for the uVisor.

**Issue**: If the uVisor SRAM sections are located at an offset in SRAM (due to VTOR relocation), then the `.uvisor.bss` section is not aligned any more to a valid MPU boundary.

**Solution**: This PR ensures that region (2) is padded to a valid MPU subregion boundary. The change requires a linker script addition that has been documented in the porting guide. The side effect is that we also waste less memory now by using subregions instead of whole regions.

**Note**: This code might be soon superseded by the work @niklas-arm is doing to improve the page allocator protection. I would still like to include this fix as it applies to other existing targets (cc @fvincenzo) and because it fixes an existing bug.

@meriac @patater @niklas-arm 