### PR TITLE
Require explicit declaration of page heap sizes

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -18,6 +18,7 @@
 #define __UVISOR_API_BOX_CONFIG_H__
 
 #include "api/inc/uvisor_exports.h"
+#include "api/inc/page_allocator_exports.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -52,6 +53,14 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
     }; \
     \
     extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_cfg;
+
+/* Creates a global page heap with at least `minimum_number_of_pages` each of size `page_size` in bytes.
+ * The total page heap size is at least `minimum_number_of_pages * page_size`. */
+#define UVISOR_SET_PAGE_HEAP(page_size, minimum_number_of_pages) \
+    const uint32_t __uvisor_page_size = (page_size); \
+    uint8_t __attribute__((section(".keep.uvisor.page_heap"))) \
+        main_page_heap_reserved[ (page_size) * (minimum_number_of_pages) ]
+
 
 /* this macro selects an overloaded macro (variable number of arguments) */
 #define __UVISOR_BOX_MACRO(_1, _2, _3, _4, NAME, ...) NAME

--- a/api/inc/page_allocator.h
+++ b/api/inc/page_allocator.h
@@ -34,4 +34,7 @@ UVISOR_EXTERN int uvisor_page_malloc(UvisorPageTable * const table);
  */
 UVISOR_EXTERN int uvisor_page_free(const UvisorPageTable * const table);
 
+/* @returns the active page size for one page. */
+UVISOR_EXTERN uint32_t uvisor_get_page_size(void);
+
 #endif /* __UVISOR_API_PAGE_ALLOCATOR_H__ */

--- a/api/inc/page_allocator_exports.h
+++ b/api/inc/page_allocator_exports.h
@@ -30,27 +30,9 @@
 #define UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER    (UVISOR_ERROR_CLASS_PAGE + 5)
 #define UVISOR_ERROR_PAGE_INVALID_PAGE_COUNT    (UVISOR_ERROR_CLASS_PAGE + 6)
 
-
-/* Must be a power of 2 for MPU alignment in ARMv7-M with ARM MPU.
- * Must be multiple of 32 for K64F MPU. */
-#ifndef UVISOR_PAGE_SIZE
-#define UVISOR_PAGE_SIZE ((uint32_t) 16 * 1024)
-#endif
-
-/* Return the rounded up number of pages required to hold `size`. */
-#define UVISOR_PAGES_FOR_SIZE(size) ((size + UVISOR_PAGE_SIZE - 1) / UVISOR_PAGE_SIZE)
-
-/* Create a page table with `count` many entries. */
-#define UVISOR_PAGE_TABLE(count) \
-    struct { \
-        uint32_t page_size; \
-        uint32_t page_count; \
-        void * page_origins[count]; \
-    }
-
-/* Create a page table with enough pages to hold `size`. */
-#define UVISOR_PAGE_TABLE_FOR_SIZE(size) UVISOR_PAGE_TABLE(UVISOR_PAGES_FOR_SIZE(size))
-
+/* Contains the uVisor page size.
+ * @warning Do not read directly, instead use `uvisor_get_page_size()` accessor! */
+UVISOR_EXTERN const uint32_t __uvisor_page_size;
 
 typedef struct {
     uint32_t page_size;     /* The page size in bytes. Must be multiple of `UVISOR_PAGE_SIZE`! */

--- a/api/src/page_allocator.c
+++ b/api/src/page_allocator.c
@@ -27,3 +27,8 @@ int uvisor_page_free(const UvisorPageTable * const table)
 {
     return UVISOR_SVC(UVISOR_SVC_ID_PAGE_FREE, "", table);
 }
+
+uint32_t uvisor_get_page_size(void)
+{
+    return __uvisor_page_size;
+}

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -20,6 +20,7 @@
 .globl __uvisor_ps
 .type  uvisor_init, %function
 .weak  __uvisor_mode
+.weak  __uvisor_page_size
 .globl __uvisor_priv_sys_irq_hooks
 
 .section .uvisor.main, "x"


### PR DESCRIPTION
This removes the global `UVISOR_PAGE_SIZE` define and instead introduces
the `uvisor_get_page_size()` getter function to retrieve the page size
for the tier-2 allocator.

The user is now required to declare the minimum page size by explicitly
stating the required page size and the minimum number of pages in the
heap. This allows applications to specify their requirements, which can
then be checked by linker which raises an error if not enough memory
for the page heap is available.

Note: This fixes a bug where the `__uvisor_page_size` was not declared weak and there could not be changed.

cc @meriac @AlessandroA @Patater