### PR TITLE
ARMv7-M MPU: Halt on a non-recoverable fault

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -276,14 +276,17 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
 
         case UsageFault_IRQn:
             DEBUG_FAULT(FAULT_USAGE, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_USAGE, "Cannot recover from a usage fault.");
             break;
 
         case HardFault_IRQn:
             DEBUG_FAULT(FAULT_HARD, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_HARD, "Cannot recover from a hard fault.");
             break;
 
         case DebugMonitor_IRQn:
             DEBUG_FAULT(FAULT_DEBUG, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_DEBUG, "Cannot recover from a debug fault.");
             break;
 
         case PendSV_IRQn:


### PR DESCRIPTION
Faults were being returned from in the ARMv7-M vMPU module, which led
to very ambiguous debug sessions.

@meriac @Patater @niklas-arm 