### PR TITLE
ARMv7-M MPU: Fix the disablement of an MPU region

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -359,8 +359,12 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
     /* clear remaining slots */
     while(mpu_slot<ARMv7M_MPU_REGIONS)
     {
-        MPU->RBAR = mpu_slot | MPU_RBAR_VALID_Msk;
+        /* We need to make sure that we disable an enabled MPU region before any
+         * other modification, hence we cannot select the MPU region using the
+         * region number field in the RBAR register. */
+        MPU->RNR = mpu_slot;
         MPU->RASR = 0;
+        MPU->RBAR = 0;
         mpu_slot++;
     }
 }


### PR DESCRIPTION
When an enabled MPU region needs to be disabled, the first thing to do
is turn it off.

If any other region descriptor (address, access attributes) is changed
before disablement, the behaviour of the system might be compromised.

A common example is the following:

* Given this originally enabled region:

```
Start: 0x42000000
Size:  0x2000000
Attributes: XN, S r/w, U r/w
```

* If you now disable it with the following procedure:

```C
/* 1 */ MPU->RBAR = mpu_slot | MPU_RBAR_VALID_Msk;
/* 2 */ MPU->RASR = 0;
```

* You will have the following "temporary" MPU configuration:

```
*** Before line 1 ***
Start: 0x42000000
Size:  0x2000000
Attributes: XN, S r/w, U r/w

*** After line 1 ***
Start: 0x0                         !!! Caused by the write to RBAR
Size:  0x2000000
Attributes: XN, S r/w, U r/w

*** After line 2 ***
---> MemManage fault, caused by the code being in the range
     (0x0, 0x2000000) with attribute XN.
```

---

**Solution**: Use the pattern "select, disable, erase":

```C
MPU->RNR = mpu_slot;
MPU->RASR = 0;
MPU->RBAR = 0;
```

In this way the MPU region is selected (no change to the region itself),
disabled, and then cleared to zero.

@meriac @niklas-arm @Patater 

@niklas-arm Please keep this fix in mind in your work to unify the MPU interface.