### PR TITLE
Fix 2 ARMv7-M vMPU bugs

### DIFF
--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -186,6 +186,12 @@ static int vmpu_fault_recovery_mpu(uint32_t pc, uint32_t sp, uint32_t fault_addr
     if ((region = vmpu_fault_find_region(fault_addr)) == NULL)
         return 0;
 
+    /* In a secure box the first available region is for the stack, so it must
+     * be excluded from the round-robin. */
+    if (g_active_box != 0 && g_mpu_slot == ARMv7M_MPU_RESERVED_REGIONS) {
+        g_mpu_slot++;
+    }
+
     /* FIXME: use random numbers for box number */
     MPU->RBAR = region->base | g_mpu_slot++ | MPU_RBAR_VALID_Msk;
     MPU->RASR = region->rasr;

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -132,16 +132,17 @@ static const TMpuRegion* vmpu_fault_find_region(uint32_t fault_addr)
     const TMpuRegion *region;
 
     /* check current box if not base */
-    if ((g_active_box) && ((region = vmpu_fault_find_box_region(fault_addr, &g_mpu_box[g_active_box])) == NULL)) {
-        return NULL;
+    if ((g_active_box) && ((region = vmpu_fault_find_box_region(fault_addr, &g_mpu_box[g_active_box])) != NULL)) {
+        return region;
     }
 
     /* check base-box */
-    if ((region = vmpu_fault_find_box_region(fault_addr, &g_mpu_box[0])) == NULL) {
-        return NULL;
+    if ((region = vmpu_fault_find_box_region(fault_addr, &g_mpu_box[0])) != NULL) {
+        return region;
     }
 
-    return region;
+    /* If no region was found. */
+    return NULL;
 }
 
 uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)


### PR DESCRIPTION
This PR fixes 2 bugs:

* The box 0 ACLs (which are shared by default) were never used when handling a fault coming from `g_active_box != 0`.
* The stack ACL for `g_active_box !=0` was overwritten in the round-robin ACL application, which turns out to be a bug in a special case.

You can read more about the bugs and their fixes in the related commit messages.

@meriac @Patater @niklas-arm 