### PR TITLE
RPC Gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ CFLAGS_PRE:=\
         -fdata-sections
 
 CFLAGS:=$(FLAGS_CM4) $(CFLAGS_PRE)
+CPPFLAGS:=
 CXXFLAGS:=-fno-exceptions
 
 LINKER_CONFIG:=\
@@ -287,17 +288,17 @@ $(CONFIGURATION_PREFIX).linker: $(CORE_LINKER_DIR)/default.h
 
 # Pre-process and compile a core C file into an object file.
 $(CONFIGURATION_PREFIX)/$(CORE_DIR)/%.o: %.c
-	$(CC) $(CXXFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 # Pre-process and compile a release library C file into an object file.
 $(CONFIGURATION_PREFIX)/$(API_DIR)/%.o: %.c
-	$(CC) $(CXXFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 # Generate the output asm file from the asm input file and the INCBIN'ed binary.
 $(API_ASM_OUTPUT:.s=.o): $(CONFIGURATION_PREFIX).bin $(API_ASM_INPUT)
 	cp $(API_ASM_HEADER) $(API_ASM_OUTPUT)
 	$(CPP) -w -P $(API_CONFIG) $(API_ASM_INPUT) >> $(API_ASM_OUTPUT)
-	$(CC) $(CXXFLAGS) $(CFLAGS) -c $(API_ASM_OUTPUT) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $(API_ASM_OUTPUT) -o $@
 
 ctags: source.c.tags
 

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ CFLAGS_PRE:=\
         -fdata-sections
 
 CFLAGS:=$(FLAGS_CM4) $(CFLAGS_PRE)
-CPPFLAGS:=-fno-exceptions
+CXXFLAGS:=-fno-exceptions
 
 LINKER_CONFIG:=\
     -D$(CONFIGURATION) \
@@ -287,17 +287,17 @@ $(CONFIGURATION_PREFIX).linker: $(CORE_LINKER_DIR)/default.h
 
 # Pre-process and compile a core C file into an object file.
 $(CONFIGURATION_PREFIX)/$(CORE_DIR)/%.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CXXFLAGS) $(CFLAGS) -c $< -o $@
 
 # Pre-process and compile a release library C file into an object file.
 $(CONFIGURATION_PREFIX)/$(API_DIR)/%.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CXXFLAGS) $(CFLAGS) -c $< -o $@
 
 # Generate the output asm file from the asm input file and the INCBIN'ed binary.
 $(API_ASM_OUTPUT:.s=.o): $(CONFIGURATION_PREFIX).bin $(API_ASM_INPUT)
 	cp $(API_ASM_HEADER) $(API_ASM_OUTPUT)
 	$(CPP) -w -P $(API_CONFIG) $(API_ASM_INPUT) >> $(API_ASM_OUTPUT)
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $(API_ASM_OUTPUT) -o $@
+	$(CC) $(CXXFLAGS) $(CFLAGS) -c $(API_ASM_OUTPUT) -o $@
 
 ctags: source.c.tags
 

--- a/api/inc/register_gateway.h
+++ b/api/inc/register_gateway.h
@@ -73,7 +73,7 @@
 #define uvisor_read(box_name, shared, addr, op, msk) \
     ({ \
         /* Instanstiate the gateway. This gets resolved at link-time. */ \
-        __attribute__((aligned(4))) static TRegisterGateway const register_gateway = { \
+        UVISOR_ALIGN(4) static TRegisterGateway const register_gateway = { \
             .svc_opcode = UVISOR_SVC_OPCODE(UVISOR_SVC_ID_REGISTER_GATEWAY), \
             .branch     = BRANCH_OPCODE(__UVISOR_OFFSETOF(TRegisterGateway, branch), \
                                         __UVISOR_OFFSETOF(TRegisterGateway, bxlr)), \
@@ -119,7 +119,7 @@
 #define uvisor_write(box_name, shared, addr, val, op, msk) \
     { \
         /* Instanstiate the gateway. This gets resolved at link-time. */ \
-        __attribute__((aligned(4))) static TRegisterGateway const register_gateway = { \
+        UVISOR_ALIGN(4) static TRegisterGateway const register_gateway = { \
             .svc_opcode = UVISOR_SVC_OPCODE(UVISOR_SVC_ID_REGISTER_GATEWAY), \
             .branch     = BRANCH_OPCODE(__UVISOR_OFFSETOF(TRegisterGateway, branch), \
                                         __UVISOR_OFFSETOF(TRegisterGateway, bxlr)), \

--- a/api/inc/register_gateway_exports.h
+++ b/api/inc/register_gateway_exports.h
@@ -47,7 +47,7 @@ typedef struct {
     uint32_t mask;
     uint16_t operation;
     uint16_t bxlr;
-} UVISOR_PACKED __attribute__((aligned(4))) TRegisterGateway;
+} UVISOR_PACKED UVISOR_ALIGN(4) TRegisterGateway;
 
 /** Register gateway operation - Masks
  * @internal

--- a/api/inc/rpc.h
+++ b/api/inc/rpc.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_API_RPC_H__
+#define __UVISOR_API_RPC_H__
+
+#include "api/inc/uvisor_exports.h"
+#include <stdint.h>
+
+/* This is the token to wait on for the result of an asynchronous RPC. */
+typedef uint32_t uvisor_rpc_result_t;
+
+typedef uint32_t (*TFN_Ptr)(uint32_t, uint32_t, uint32_t, uint32_t);
+typedef int (*TFN_RPC_Callback)(int);
+
+/* This synchronous function is easy-mode. It gets you talkin' with the other
+ * box, but not in a mutually distrustful fashion: for instance, you have to
+ * trust that the target box will eventually return. */
+UVISOR_EXTERN uint32_t rpc_fncall(uint32_t p0, uint32_t p1, uint32_t p2, uint32_t p3, const TFN_Ptr fn);
+
+/* Start an asynchronous RPC. After this call, the caller can, at any time in
+ * any thread, wait on the result token to get the result of the call. */
+UVISOR_EXTERN int rpc_fncall_async(uint32_t p0, uint32_t p1, uint32_t p2, uint32_t p3, const TFN_Ptr fn,
+                                   uvisor_rpc_result_t result);
+
+/** Wait for incoming RPC.
+ *
+ * @param fn_ptr_array an array of RPC function targets that this call to
+ *                     `rpc_fncall_waitfor` should handle RPC to
+ * @param fn_count     the number of function targets in this array
+ * @param timeout_ms   specifies how long to wait (in ms) for an incoming RPC
+ *                     message before returning
+ */
+int rpc_fncall_waitfor(const TFN_Ptr fn_ptr_array[], size_t fn_count, uint32_t timeout_ms);
+
+#endif /* __UVISOR_API_RPC_H__ */

--- a/api/inc/rpc.h
+++ b/api/inc/rpc.h
@@ -20,6 +20,14 @@
 #include "api/inc/uvisor_exports.h"
 #include <stdint.h>
 
+/** Specify the maximum number of incoming RPC messages for a box
+ *
+ * @param max_num_incoming_rpc The maximum number of incoming RPC messages for
+ *                             a box
+ */
+/* XXX This is a dummy implementation. */
+#define UVISOR_BOX_RPC_MAXIMUM_INCOMING_RPC(max_num_incoming_rpc)
+
 /* This is the token to wait on for the result of an asynchronous RPC. */
 typedef uint32_t uvisor_rpc_result_t;
 

--- a/api/inc/rpc_gateway.h
+++ b/api/inc/rpc_gateway.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_API_RPC_GATEWAY_H__
+#define __UVISOR_API_RPC_GATEWAY_H__
+
+#include "api/inc/rpc_gateway_exports.h"
+#include "api/inc/rpc.h"
+#include "api/inc/uvisor_exports.h"
+#include <stdint.h>
+
+/* ldr pc, [pc, #<label - instr + 4>]
+ * LDR (immediate) - ARMv7M ARM section A7.7.42
+ * 1111;1 00 0; 0 10 1; <Rn - 1111>; <Rt - 1111>; <imm12> (Encoding T3) */
+#define LDR_PC_PC_IMM_OPCODE(instr, label) \
+    ((uint32_t) (0xF000F8DFU | ((((uint32_t) (label) - ((uint32_t) (instr) + 4U)) & 0xFFFU) << 16U)))
+
+/** Synchronous RPC Gateway
+ *
+ * This macro declares a new function pointer (with no name mangling) named
+ * `gw_name` to perform a remote procedure call (RPC) to the target function
+ * given by `fn_name`. RPCs are assembled into a read-only flash structure that
+ * is read and validated by uVisor before performing the operation.
+ *
+ * Create function with following signature:
+ * UVISOR_EXTERN fn_type fn_name(uint32_t a, uint32_t b);
+ *
+ * @param box_name[in] The name of the source box as declared in
+ *                     `UVISOR_BOX_CONFIG`
+ * @param gw_name[in]  The new, callable function pointer for performing RPC
+ * @param fn_name[in]  The function being designated as an RPC target
+ * @param fn_type[in]  The return type of the function being designated as an
+ *                     RPC target
+ * @param __VA_ARGS__  The type of each parameter passed to the target
+ *                     function. There can be up to 4 parameters. Each
+ *                     parameter must be no more than uint32_t in size. If the
+ *                     RPC target function accepts no arguments, pass `void`
+ *                     here.
+ */
+#define UVISOR_BOX_RPC_GATEWAY_SYNC(box_name, gw_name, fn_name, fn_type, ...) \
+    UVISOR_STATIC_ASSERT(sizeof(fn_type) <= sizeof(uint32_t), gw_name ## _return_type_too_big); \
+    _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK(gw_name, __VA_ARGS__) \
+    _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER(fn_name, __VA_ARGS__) \
+    /* Instanstiate the gateway. This gets resolved at link-time. */ \
+    UVISOR_EXTERN TRPCGateway const gw_name ## _rpc_gateway = { \
+        .ldr_pc   = LDR_PC_PC_IMM_OPCODE(__UVISOR_OFFSETOF(TRPCGateway, ldr_pc), \
+                                         __UVISOR_OFFSETOF(TRPCGateway, function)), \
+        .magic    = UVISOR_RPC_GATEWAY_MAGIC_SYNC, \
+        .box_ptr  = (uint32_t) &box_name ## _cfg_ptr, \
+        .function = (uint32_t) _sgw_sync_ ## fn_name, \
+    }; \
+    \
+    /* Pointer to the gateway we just created. The pointer is located in a
+     * discoverable linker section. */ \
+    __attribute__((section(".keep.uvisor.rpc_gateway_ptr"))) \
+    static uint32_t const gw_name ## _rpc_gateway_ptr = (uint32_t) &gw_name ## _rpc_gateway; \
+    \
+    /* Declare the actual gateway. */ \
+    UVISOR_EXTERN fn_type (*gw_name)(__VA_ARGS__) __attribute__((alias(UVISOR_TO_STRING(gw_name ## _rpc_gateway))));
+
+/** Asynchronous RPC Gateway
+ *
+ * This macro declares a new function pointer (with no name mangling) named
+ * `gw_name` to perform a remote procedure call (RPC) to the target function
+ * given by `fn_name`. RPCs are assembled into a read-only flash structure that
+ * is read and validated by uVisor before performing the operation.
+ *
+ * Create function with following signature:
+ * UVISOR_EXTERN int gw_name(uvisor_rpc_result_t *, uint32_t a, uint32_t b);
+ *
+ * @param box_name[in] The name of the source box as declared in
+ *                     `UVISOR_BOX_CONFIG`
+ * @param gw_name[in]  The new, callable function pointer for performing RPC
+ * @param fn_name[in]  The function being designated as an RPC target
+ * @param fn_type[in]  The return type of the function being designated as an
+ *                     RPC target
+ * @param __VA_ARGS__  The type of each parameter passed to the target
+ *                     function. There can be up to 4 parameters. Each
+ *                     parameter must be no more than uint32_t in size. If the
+ *                     RPC target function accepts no arguments, pass `void`
+ *                     here.
+ */
+#define UVISOR_BOX_RPC_GATEWAY_ASYNC(box_name, gw_name, fn_name, fn_type, ...) \
+    UVISOR_STATIC_ASSERT(sizeof(fn_type) <= sizeof(uint32_t), gw_name ## _return_type_too_big); \
+    _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK(gw_name, __VA_ARGS__) \
+    _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER(fn_name, __VA_ARGS__) \
+    /* Instanstiate the gateway. This gets resolved at link-time. */ \
+    UVISOR_EXTERN TRPCGateway const gw_name ## _rpc_gateway = { \
+        .ldr_pc   = LDR_PC_PC_IMM_OPCODE(__UVISOR_OFFSETOF(TRPCGateway, ldr_pc), \
+                                         __UVISOR_OFFSETOF(TRPCGateway, function)), \
+        .magic    = UVISOR_RPC_GATEWAY_MAGIC_ASYNC, \
+        .box_ptr  = (uint32_t) &box_name ## _cfg_ptr, \
+        .function = (uint32_t) _sgw_async_ ## fn_name, \
+    }; \
+    \
+    /* Pointer to the gateway we just created. The pointer is located in a
+     * discoverable linker section. */ \
+    __attribute__((section(".keep.uvisor.rpc_gateway_ptr"))) \
+    static uint32_t const gw_name ## _rpc_gateway_ptr = (uint32_t) &gw_name ## _rpc_gateway; \
+    \
+    /* Declare the actual gateway. */ \
+    UVISOR_EXTERN int (*gw_name)(uvisor_rpc_result_t *, __VA_ARGS__) __attribute__((alias(UVISOR_TO_STRING(gw_name ## _rpc_gateway))));
+
+#define _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK(gw_name, ...) \
+    __UVISOR_BOX_MACRO(__VA_ARGS__, _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_4, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_3, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_2, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_1, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_0)(gw_name, __VA_ARGS__)
+
+#define _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_0(gw_name)
+
+#define _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_1(gw_name, p0_type) \
+    UVISOR_STATIC_ASSERT(sizeof(p0_type) <= sizeof(uint32_t), gw_name ## _param_0_too_big);
+
+#define _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_2(gw_name, p0_type, p1_type) \
+    UVISOR_STATIC_ASSERT(sizeof(p0_type) <= sizeof(uint32_t), gw_name ## _param_0_too_big); \
+    UVISOR_STATIC_ASSERT(sizeof(p1_type) <= sizeof(uint32_t), gw_name ## _param_1_too_big);
+
+#define _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_3(gw_name, p0_type, p1_type, p2_type) \
+    UVISOR_STATIC_ASSERT(sizeof(p0_type) <= sizeof(uint32_t), gw_name ## _param_0_too_big); \
+    UVISOR_STATIC_ASSERT(sizeof(p1_type) <= sizeof(uint32_t), gw_name ## _param_1_too_big); \
+    UVISOR_STATIC_ASSERT(sizeof(p2_type) <= sizeof(uint32_t), gw_name ## _param_2_too_big);
+
+#define _UVISOR_BOX_RPC_GATEWAY_ARG_CHECK_4(gw_name, p0_type, p1_type, p2_type, p3_type) \
+    UVISOR_STATIC_ASSERT(sizeof(p0_type) <= sizeof(uint32_t), gw_name ## _param_0_too_big); \
+    UVISOR_STATIC_ASSERT(sizeof(p1_type) <= sizeof(uint32_t), gw_name ## _param_1_too_big); \
+    UVISOR_STATIC_ASSERT(sizeof(p2_type) <= sizeof(uint32_t), gw_name ## _param_2_too_big); \
+    UVISOR_STATIC_ASSERT(sizeof(p3_type) <= sizeof(uint32_t), gw_name ## _param_3_too_big);
+
+#define _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER(fn_name, ...) \
+    __UVISOR_BOX_MACRO(__VA_ARGS__, _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_4, \
+                                    _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_3, \
+                                    _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_2, \
+                                    _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_1, \
+                                    _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_0)(fn_name, __VA_ARGS__)
+
+#define _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_0(fn_name, ...) \
+    static uint32_t _sgw_sync_ ## fn_name(void) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall(0, 0, 0, 0, fp); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_1(fn_name, ...) \
+    static uint32_t _sgw_sync_ ## fn_name(uint32_t p0) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall(p0, 0, 0, 0, fp); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_2(fn_name, ...) \
+    static uint32_t _sgw_sync_ ## fn_name(uint32_t p0, uint32_t p1) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall(p0, p1, 0, 0, fp); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_3(fn_name, ...) \
+    static uint32_t _sgw_sync_ ## fn_name(uint32_t p0, uint32_t p1, uint32_t p2) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall(p0, p1, p2, 0, fp); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_SYNC_CALLER_4(fn_name, ...) \
+    static uint32_t _sgw_sync_ ## fn_name(uint32_t p0, uint32_t p1, uint32_t p2, uint32_t p3) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall(p0, p1, p2, p3, fp); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER(fn_name, ...) \
+    __UVISOR_BOX_MACRO(__VA_ARGS__, _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_4, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_3, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_2, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_1, \
+                                    _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_0)(fn_name, __VA_ARGS__)
+
+#define _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_0(fn_name, ...) \
+    static uint32_t _sgw_async_ ## fn_name(uvisor_rpc_result_t * result) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall_async(0, 0, 0, 0, fp, result); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_1(fn_name, ...) \
+    static uint32_t _sgw_async_ ## fn_name(uvisor_rpc_result_t * result, uint32_t p0) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall_async(p0, 0, 0, 0, fp, result); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_2(fn_name, ...) \
+    static uint32_t _sgw_async_ ## fn_name(uvisor_rpc_result_t * result, uint32_t p0, uint32_t p1) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall_async(p0, p1, 0, 0, fp, result); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_3(fn_name, ...) \
+    static uint32_t _sgw_async_ ## fn_name(uvisor_rpc_result_t * result, uint32_t p0, uint32_t p1, uint32_t p2) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall_async(p0, p1, p2, 0, fp, result); \
+    }
+
+#define _UVISOR_BOX_RPC_GATEWAY_ASYNC_CALLER_4(fn_name, ...) \
+    static uint32_t _sgw_async_ ## fn_name(uvisor_rpc_result_t * result, uint32_t p0, uint32_t p1, uint32_t p2, uint32_t p3) \
+    { \
+        TFN_Ptr fp = (TFN_Ptr) fn_name; \
+        return rpc_fncall_async(p0, p1, p2, p3, fp, result); \
+    }
+
+#endif /* __UVISOR_API_RPC_GATEWAY_H__ */

--- a/api/inc/rpc_gateway_exports.h
+++ b/api/inc/rpc_gateway_exports.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_API_RPC_GATEWAY_EXPORTS_H__
+#define __UVISOR_API_RPC_GATEWAY_EXPORTS_H__
+
+#include "api/inc/uvisor_exports.h"
+#include <stdint.h>
+
+/* udf imm16
+ * UDF - ARMv7M ARM section A7.7.191
+ * 111 1;0 111;1111; <imm4>; 1 01 0; <imm12> (Encoding T2)
+ */
+#define UDF_OPCODE(imm16) \
+    ((uint32_t) (0xA000F7F0U | (((uint32_t) (imm16) & 0xFFFU) << 16U) | (((uint32_t) (imm16) & 0xF000U) >> 12U)))
+
+/** RPC gateway magics
+ *
+ * The following magics are used to verify an RPC gateway structure. The magics are
+ * chosen to be one of the explicitly undefined Thumb-2 instructions.
+ */
+/* TODO Unify all sources of magic (for register gateway, rpc gateway, and
+ * everybody else) */
+#if defined(__thumb__) && defined(__thumb2__)
+#define UVISOR_RPC_GATEWAY_MAGIC_ASYNC UDF_OPCODE(0x07C2)
+#define UVISOR_RPC_GATEWAY_MAGIC_SYNC  UDF_OPCODE(0x07C3)
+#else
+#error "Unsupported instruction set. The ARM Thumb-2 instruction set must be supported."
+#endif   /* __thumb__ && __thumb2__ */
+
+
+/** RPC gateway structure
+ *
+ * This struct is packed because we must ensure that the `ldr_pc` field has no
+ * padding before itself and will be located at a valid instruction location,
+ * and that the `function` field is at a pre-determined offset from the
+ * `ldr_pc` field.
+ */
+typedef struct {
+    uint32_t ldr_pc;
+    uint32_t magic;
+    uint32_t box_ptr;
+    uint32_t function; /* It's like a pretend literal pool. */
+} UVISOR_PACKED UVISOR_ALIGN(4) TRPCGateway;
+
+#endif /* __UVISOR_API_RPC_GATEWAY_EXPORTS_H__ */

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -33,6 +33,7 @@
 #include "api/inc/interrupts.h"
 #include "api/inc/register_gateway.h"
 #include "api/inc/rpc.h"
+#include "api/inc/rpc_gateway.h"
 #include "api/inc/secure_access.h"
 
 #else /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
@@ -56,6 +57,7 @@ UVISOR_EXTERN int uvisor_lib_init(void);
 #include "api/inc/export_table_exports.h"
 #include "api/inc/halt_exports.h"
 #include "api/inc/register_gateway_exports.h"
+#include "api/inc/rpc_gateway_exports.h"
 #include "api/inc/svc_exports.h"
 #include "api/inc/priv_sys_irq_hook_exports.h"
 #include "api/inc/unvic_exports.h"

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -32,6 +32,7 @@
 #include "api/inc/error.h"
 #include "api/inc/interrupts.h"
 #include "api/inc/register_gateway.h"
+#include "api/inc/rpc.h"
 #include "api/inc/secure_access.h"
 
 #else /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */

--- a/api/inc/uvisor_exports.h
+++ b/api/inc/uvisor_exports.h
@@ -52,6 +52,23 @@
 /* array count macro */
 #define UVISOR_ARRAY_COUNT(x) (sizeof(x)/sizeof(x[0]))
 
+/** Static Assertion Macro
+ *
+ * This macro is relatively portable, and the macro works from inside or
+ * outside function scope.
+ *
+ * Code is CC BY-SA
+ * Based on bobbogo's answer to the following question on Stack Overflow
+ *   <http://stackoverflow.com/questions/3385515/static-assert-in-c>
+ *   <http://stackoverflow.com/users/470195/bobbogo>
+ * Modified for style */
+#define _UVISOR_CTASTR2(pre, post) pre##post
+#define _UVISOR_CTASTR(pre, post) _UVISOR_CTASTR2(pre, post)
+#define UVISOR_STATIC_ASSERT(cond, msg) \
+    typedef struct { \
+        int _UVISOR_CTASTR(static_assertion_failed_, msg) : !!(cond); \
+    } _UVISOR_CTASTR(static_assertion_failed_, __COUNTER__)
+
 /* convert macro argument to string */
 /* note: this needs one level of indirection, accomplished with the helper macro
  *       __UVISOR_TO_STRING */

--- a/api/inc/uvisor_exports.h
+++ b/api/inc/uvisor_exports.h
@@ -36,12 +36,14 @@
 
 /* Shared compiler attributes */
 #if defined(__ICCARM__)
+#define UVISOR_ALIGN(x)    __align(x)
 #define UVISOR_FORCEINLINE inline
 #define UVISOR_PACKED      __packed
 #define UVISOR_WEAK        __weak
 #define UVISOR_NORETURN    __noreturn
 #define UVISOR_RAMFUNC     __ramfunc
 #else
+#define UVISOR_ALIGN(x)    __attribute__((aligned(x)))
 #define UVISOR_FORCEINLINE inline __attribute__((always_inline))
 #define UVISOR_PACKED      __attribute__((packed))
 #define UVISOR_WEAK        __attribute__((weak))


### PR DESCRIPTION
Implement an in-flash, verifiable, callable RPC structure that nominates a function as suitable RPC target.

Please give a thorough review. This PR targets unstable, but is intended to be dev-branch quality, with the exception of the reliance on the `Dummy-implement rpc_fncall and fpc_fncall_async` commit, and with the exception that we don't yet have a complete end-to-end prototype to verify this design as implemented.

Note that this enables building uvisor-lib out of C++ files, if we so desire. We don't have a need for that yet, as the dummy RPC implementation in this PR could be in C, but I anticipate we might want to use C++ in implementing some portion of RPC. If it's a requirement that uvisor-lib must never use C++ ever, then we can easily drop those commits and reimplement the RPC dummy in C.

@AlessandroA @niklas-arm @meriac