### PR TITLE
Port page heap access switching to ARMv7-M MPU

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -18,6 +18,7 @@
 #define __UVISOR_API_BOX_CONFIG_H__
 
 #include "api/inc/uvisor_exports.h"
+#include "api/inc/page_allocator_exports.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -52,6 +53,14 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
     }; \
     \
     extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_cfg;
+
+/* Creates a global page heap with at least `minimum_number_of_pages` each of size `page_size` in bytes.
+ * The total page heap size is at least `minimum_number_of_pages * page_size`. */
+#define UVISOR_SET_PAGE_HEAP(page_size, minimum_number_of_pages) \
+    const uint32_t __uvisor_page_size = (page_size); \
+    uint8_t __attribute__((section(".keep.uvisor.page_heap"))) \
+        main_page_heap_reserved[ (page_size) * (minimum_number_of_pages) ]
+
 
 /* this macro selects an overloaded macro (variable number of arguments) */
 #define __UVISOR_BOX_MACRO(_1, _2, _3, _4, NAME, ...) NAME

--- a/api/inc/page_allocator.h
+++ b/api/inc/page_allocator.h
@@ -34,4 +34,7 @@ UVISOR_EXTERN int uvisor_page_malloc(UvisorPageTable * const table);
  */
 UVISOR_EXTERN int uvisor_page_free(const UvisorPageTable * const table);
 
+/* @returns the active page size for one page. */
+UVISOR_EXTERN uint32_t uvisor_get_page_size(void);
+
 #endif /* __UVISOR_API_PAGE_ALLOCATOR_H__ */

--- a/api/inc/page_allocator_exports.h
+++ b/api/inc/page_allocator_exports.h
@@ -30,27 +30,9 @@
 #define UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER    (UVISOR_ERROR_CLASS_PAGE + 5)
 #define UVISOR_ERROR_PAGE_INVALID_PAGE_COUNT    (UVISOR_ERROR_CLASS_PAGE + 6)
 
-
-/* Must be a power of 2 for MPU alignment in ARMv7-M with ARM MPU.
- * Must be multiple of 32 for K64F MPU. */
-#ifndef UVISOR_PAGE_SIZE
-#define UVISOR_PAGE_SIZE ((uint32_t) 16 * 1024)
-#endif
-
-/* Return the rounded up number of pages required to hold `size`. */
-#define UVISOR_PAGES_FOR_SIZE(size) ((size + UVISOR_PAGE_SIZE - 1) / UVISOR_PAGE_SIZE)
-
-/* Create a page table with `count` many entries. */
-#define UVISOR_PAGE_TABLE(count) \
-    struct { \
-        uint32_t page_size; \
-        uint32_t page_count; \
-        void * page_origins[count]; \
-    }
-
-/* Create a page table with enough pages to hold `size`. */
-#define UVISOR_PAGE_TABLE_FOR_SIZE(size) UVISOR_PAGE_TABLE(UVISOR_PAGES_FOR_SIZE(size))
-
+/* Contains the uVisor page size.
+ * @warning Do not read directly, instead use `uvisor_get_page_size()` accessor! */
+UVISOR_EXTERN const uint32_t __uvisor_page_size;
 
 typedef struct {
     uint32_t page_size;     /* The page size in bytes. Must be multiple of `UVISOR_PAGE_SIZE`! */

--- a/api/src/page_allocator.c
+++ b/api/src/page_allocator.c
@@ -27,3 +27,8 @@ int uvisor_page_free(const UvisorPageTable * const table)
 {
     return UVISOR_SVC(UVISOR_SVC_ID_PAGE_FREE, "", table);
 }
+
+uint32_t uvisor_get_page_size(void)
+{
+    return __uvisor_page_size;
+}

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -20,6 +20,7 @@
 .globl __uvisor_ps
 .type  uvisor_init, %function
 .weak  __uvisor_mode
+.weak  __uvisor_page_size
 .globl __uvisor_priv_sys_irq_hooks
 
 .section .uvisor.main, "x"

--- a/core/system/inc/page_allocator.h
+++ b/core/system/inc/page_allocator.h
@@ -60,7 +60,7 @@ extern uint32_t g_page_size;
 extern const void * g_page_heap_start;
 /* Contains the total number of available pages. */
 extern uint8_t g_page_count_total;
-/* Maps the page to the owning box handle. */
-extern page_owner_t g_page_owner_table[];
+/* Contains the page usage mapped by owner. */
+extern uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
 
 #endif /* __PAGE_ALLOCATOR_H__ */

--- a/core/system/inc/page_allocator.h
+++ b/core/system/inc/page_allocator.h
@@ -58,8 +58,6 @@ uint8_t page_allocator_get_page_from_address(uint32_t address);
 extern uint32_t g_page_size;
 /* Points to the beginning of the page heap. */
 extern const void * g_page_heap_start;
-/* Contains the total number of available pages. */
-extern uint8_t g_page_count_total;
 /* Contains the page usage mapped by owner. */
 extern uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
 

--- a/core/system/inc/page_allocator_config.h
+++ b/core/system/inc/page_allocator_config.h
@@ -25,8 +25,8 @@
  * a relatively low limit to the number of pages.
  * By default a maximum of 16 pages are allowed. This can only be overwritten
  * by the porting engineer for the current platform. */
-#ifndef UVISOR_PAGE_TABLE_MAX_COUNT
-#define UVISOR_PAGE_TABLE_MAX_COUNT ((uint32_t) 16)
+#ifndef UVISOR_PAGE_MAX_COUNT
+#define UVISOR_PAGE_MAX_COUNT ((uint32_t) 16)
 #endif
 /* The number of pages is decided by the page size. A small page size leads to
  * a lot of pages, however, number of pages is capped for efficiency.
@@ -41,5 +41,34 @@
 typedef uint8_t page_owner_t;
 /* Define a unused value for the page table. */
 #define UVISOR_PAGE_UNUSED ((page_owner_t) (-1))
+
+/** Sets the page bit in the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ */
+static inline void page_allocator_map_set(uint32_t * const map, uint8_t page)
+{
+    map[page / 32] |= (1UL << (page % 32));
+}
+
+/** Clears the page bit in the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ */
+static inline void page_allocator_map_clear(uint32_t * const map, uint8_t page)
+{
+    map[page / 32] &= ~(1UL << (page % 32));
+}
+
+/** Check if the page bit is set int the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ * @retval 0    if page bit is not set
+ * @retval 1    if page bit is set
+ */
+static inline int page_allocator_map_get(const uint32_t * const map, uint8_t page)
+{
+    return (map[page / 32] >> (page % 32)) & 0x1;
+}
 
 #endif /* __PAGE_ALLOCATOR_CONFIG_H__ */

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -60,19 +60,75 @@ int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * st
  */
 int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask, uint8_t * index, uint8_t * page);
 
+typedef enum
+{
+    /** The iterator will start at the lowest page counting upwards. */
+    PAGE_ALLOCATOR_ITERATOR_DIRECTION_FORWARD = 1,
+    /** The iterator will start at the highest page counting downwards. */
+    PAGE_ALLOCATOR_ITERATOR_DIRECTION_BACKWARD = -1,
+} PageAllocatorIteratorDirection;
+
 /** Callback for iterating over pages.
+ *
+ * Note that the page index always increments relative to iteration direction.
+ * This means if you iterate backwards, page index 0 corresponds the the
+ * physically highest page and "increments" downwards.
+ *
  * @param start_addr    the page start address
  * @param end_addr      the page end address
- * @param page          the page index
+ * @param page          the page index relative to iteration direction
  * @retval 0            stop iteration after this callback.
  * @retval !0           continue iteration after this callback.
  */
 typedef int (*PageAllocatorIteratorCallback)(uint32_t start_addr, uint32_t end_addr, uint8_t page);
 
-/* Iterate over all pages belonging to the active box or box 0 and execute the callback.
- * @param callback  the function to execute on every page. May be NULL.
- * @return          number of active pages.
+/* Iterate over all pages belonging to the active box or box 0 and execute the callback.ss
+ *
+ * @param callback  the function to execute on every page. Returns number of active pages if `NULL`.
+ * @param direction forward or backwards direction.
+ * @return          number of callbacks, or if `NULL` passed as callback, number of active pages.
  */
-uint8_t page_allocator_iterate_active_pages(PageAllocatorIteratorCallback callback);
+uint8_t page_allocator_iterate_active_pages(PageAllocatorIteratorCallback callback, PageAllocatorIteratorDirection direction);
+
+/** Callback for iterating over 8-bit page masks.
+ *
+ * Note that the mask and the mask index are always aligned to the 8-bit boundary!
+ * This means that iterating forward starts indexing at the LSB of the map, and
+ * iterating  backwards starts indexing at the MSB of the map.
+ * For right-aligned maps, the MSB is the highest byte containing page owner bits,
+ * and for left-aligned maps, the LSB is the lowest byte containing page owner bits.
+ *
+ * Example with 12 pages:
+ *  - right-aligned map: 0b00001111'11111111
+ *      1. forward iteration callbacks:
+ *          1. mask=0xFF, index=0
+ *          2. mask=0x0F, index=1
+ *      2. backward iteration callbacks:
+ *          1. mask=0x0F, index=0
+ *          2. mask=0xFF, index=1
+ *  - left-aligned map:  0b11111111'11110000
+ *      1. forward iteration callbacks:
+ *          1. mask=0xF0, index=0
+ *          2. mask=0xFF, index=1
+ *      2. backward iteration callbacks:
+ *          1. mask=0xFF, index=0
+ *          2. mask=0xF0, index=1
+ *
+ * @see UVISOR_PAGE_OWNER_MAP_LEFT_ALIGNED
+ *
+ * @param mask          the page owner mask
+ * @param index         the index of the page mask
+ * @retval 0            stop iteration after this callback.
+ * @retval !0           continue iteration after this callback.
+ */
+typedef int (*PageAllocatorIteratorMaskCallback)(uint8_t mask, uint8_t index);
+
+/* Iterate over all page masks belonging to the active box or box 0 and execute the callback.
+ *
+ * @param callback  the function to execute on every page mask. Returns number of active page masks if `NULL`.
+ * @param direction forward or backwards direction.
+ * @return          number of callbacks, or if `NULL` passed as callback, number of active page masks.
+ */
+uint8_t page_allocator_iterate_active_page_masks(PageAllocatorIteratorMaskCallback callback, PageAllocatorIteratorDirection direction);
 
 #endif /* __PAGE_ALLOCATOR_FAULTS_H__ */

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -30,15 +30,35 @@ uint32_t page_allocator_get_faults(uint8_t page);
 
 /** Map an address to the start and end addresses of a page.
  * If the address is not part of any page, or the page does not belong to the
- * active box or box 0 an error is returned and `start` and `end` are invalid.
+ * active box or box 0 an error is returned and `start`, `end` and `page` are invalid.
  *
- * @param address           the address to map
- * @param[out] start_addr   pointer to the start address value
- * @param[out] end_addr     pointer to the end address value
- * @param[out] page         pointer to the page index value
+ * @param address           the address to locate in the page heap
+ * @param[out] start_addr   the start address of the found page
+ * @param[out] end_addr     the end address of the found page
+ * @param[out] page         the physical page index of the found page
  * @returns Non-zero on failure with failure class `UVISOR_ERROR_CLASS_PAGE`. See `UVISOR_ERROR_PAGE_*`.
  */
 int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * start_addr, uint32_t * end_addr, uint8_t * page);
+
+/** Map an address to an 8-bit page mask.
+ * If the address is not part of any page, or the page does not belong to the
+ * active box or box 0 an error is returned and `mask`, `index` and `page` are invalid.
+ *
+ * Example with 12 pages:
+ *  - right-aligned map: 0b00000000'00000000'00001111'11111111
+ *      1. address maps to page 9: mask=0x0F, index=1, page=9
+ *      2. address maps to page 3: mask=0xFF, index=0, page=3
+ *  - left-aligned map:  0b11111111'11110000'00000000'00000000
+ *      1. address maps to page 9: mask=0xFF, index=3, page=9
+ *      2. address maps to page 3: mask=0xF0, index=2, page=3
+ *
+ * @param address           the address to locate in the page heap
+ * @param[out] mask         the 8-bit aligned page mask containing the found page
+ * @param[out] index        the position of the page mask counting from the LSB!
+ * @param[out] page         the physical page index of the found page
+ * @returns Non-zero on failure with failure class `UVISOR_ERROR_CLASS_PAGE`. See `UVISOR_ERROR_PAGE_*`.
+ */
+int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask, uint8_t * index, uint8_t * page);
 
 /** Callback for iterating over pages.
  * @param start_addr    the page start address

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -31,6 +31,30 @@
 #define ARMv7M_MPU_REGIONS 8
 #endif/*ARMv7M_MPU_REGIONS*/
 
+/* The ARMv7-M MPU has 8 MPU regions plus one background region.
+ * Region 0 and 1 are used to unlock Application RAM and Flash.
+ * When switching into a secure box, region 2 is used to protect the boxes
+ * stack and context.
+ * If a box uses the page heap, the next region is used to protect it.
+ * This leaves 4 to 6 MPU regions for round robin scheduling:
+ *
+ *      8      <-- End of MPU regions, K64F_MPU_REGIONS_MAX
+ * +---------+
+ * |    7    |
+ * |   ...   |
+ * |  2/3/4  | <-- Start of round robin
+ * +---------+
+ * |   2/3   | <-- Optional Box Pages
+ * +---------+
+ * |    2    | <-- Secure Box Stack + Context, K64F_MPU_REGIONS_STATIC
+ * +---------+
+ * |    1    | <-- Application SRAM unlock
+ * |    0    | <-- Application Flash unlock
+ * +---------+
+ */
+#define ARMv7M_MPU_REGIONS_STATIC 2
+#define ARMv7M_MPU_REGIONS_MAX (ARMv7M_MPU_REGIONS)
+
 /* Sanity checks on SRAM boundaries */
 #if SRAM_LENGTH_MIN <= 0
 #error "SRAM_LENGTH_MIN must be strictly positive."
@@ -704,45 +728,69 @@ void vmpu_arch_init_hw(void)
         UVISOR_TACLDEF_SECURE_CONST | UVISOR_TACL_EXECUTE
     );
 
-    /* Enable the public SRAM. */
-    /* Note: This region can be larger than the physical SRAM. */
-    /* Note: This uses the host-related symbols as uVisor might be placed in a
-     *       different SRAM. If the uVisor shares the SRAM with the host, these
-     *       symbols will be identical to the uVisor-related ones. */
+    /* Enable the public SRAM:
+     *
+     * We use one region for this, which start at SRAM origin (which is always
+     * aligned) and has a power-of-two size that is equal or _larger_ than SRAM.
+     * This means the region may end _behind_ the end of SRAM!
+     *
+     * At the beginning of SRAM uVisor places its private BSS section and behind
+     * that the page heap. In order to use only one region, we require the end of
+     * the page heap to align with 1/8th of the region size, so that we can use
+     * the subregion mask.
+     * The page heap reduces the memory wastage to less than one page size, by
+     * "growing" the page heap downwards from the subregion alignment towards
+     * the uVisor bss.
+     *
+     * Note: The correct alignment needs to be done in the host linkerscript.
+     *       Use `ALIGN( (1 << LOG2CEIL(LENGTH(SRAM)) / 8 )` for GNU linker.
+     *
+     *     2^n     <-- region end
+     *     ...
+     * .---------. <-- uvisor_config.sram_end
+     * |  box 0  |
+     * | public  |
+     * | memory  |
+     * +---------+ <-- uvisor_config.page_end: n/8th of _region_ size (not SRAM size)
+     * |  page   |
+     * |  heap   |
+     * +---------+ <-- aligned to page size
+     * | wastage | <-- wasted SRAM is less than 1 page size
+     * +---------+ <-- uvisor_config.page_start
+     * |  uVisor |
+     * |   bss   |
+     * '---------' <-- uvisor_config.sram_start, region start
+     *
+     * Example: The region size of a 96kB SRAM will be 128kB, and the page heap
+     *          end will have to be aligned to 16kB, _not_ 12kB (= 96kB / 8).
+     *
+     * Note: In case the uVisor bss section is moved to another memory region
+     *       (tightly-coupled memory for example), the page heap remains and
+     *       the same considerations apply. Therefore the uVisor bss section
+     *       location has no impact on this.
+     */
+    /* Calculate the region size by rounding up the SRAM size to the next power-of-two. */
+    const uint32_t total_size = (1 << vmpu_region_bits((uint32_t) __uvisor_config.sram_end - (uint32_t) __uvisor_config.sram_start));
+    /* The alignment is 1/8th of the region size = rounded up SRAM size. */
+    const uint32_t subregions_size = total_size / 8;
+    const uint32_t protected_size = (uint32_t) __uvisor_config.page_end - (uint32_t) __uvisor_config.sram_start;
+    /* The protected size must be aligned to the subregion size. */
+    if (protected_size % subregions_size != 0) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+                   "The __uvisor_page_end symbol (0x%08X)is not aligned to an MPU subregion boundary.",
+                   (uint32_t) __uvisor_config.page_end);
+    }
+    /* Note: It's called the subregion _disable_ mask, so setting one bit in it _disables_ the
+     *       permissions in this subregion. Totally not confusing, amiright!? */
+    const uint8_t subregions_disable_mask = (uint8_t) ((1UL << (protected_size / subregions_size)) - 1UL);
+
+    /* Unlock the upper SRAM subregion only. */
     vmpu_acl_static_region(
         1,
-        (void *) HOST_SRAM_ORIGIN_MIN,
-        UVISOR_REGION_ROUND_UP(HOST_SRAM_LENGTH_MAX),
-        UVISOR_TACLDEF_DATA | UVISOR_TACL_EXECUTE
+        __uvisor_config.sram_start,
+        total_size,
+        UVISOR_TACLDEF_DATA | UVISOR_TACL_EXECUTE | UVISOR_TACL_SUBREGIONS(subregions_disable_mask)
     );
-
-#if !defined(UVISOR_IN_STANDALONE_SRAM)
-    /* Calculate the subregion mask based on the __uvisor_bss_end symbol.
-     * The BSS section occupied by uVisor in the host linker script must be
-     * aligned to an MPU subregion boundary, so that the maximum memory wasted
-     * for padding purposes is 1/8 of the total uVisor BSS section. */
-    uint32_t original_size = (uint32_t) __uvisor_config.bss_end - SRAM_ORIGIN;
-    uint32_t rounded_size = UVISOR_REGION_ROUND_UP(original_size);
-    uint32_t subregions_size = rounded_size / 8;
-    if (original_size % subregions_size != 0) {
-        HALT_ERROR(SANITY_CHECK_FAILED,
-                   "The __uvisor_bss_end symbol (0x%08X)is not aligned to an MPU subregion boundary.",
-                   (uint32_t) __uvisor_config.bss_end);
-    }
-    uint8_t subregions_mask = (uint8_t) ~(0xFFUL >> (8 - (original_size / subregions_size)));
-
-    /* Protect the uVisor SRAM.
-     * This region needs protection only if uVisor shares the SRAM with the
-     * host. The configuration requires that uVisor is right at the beginning of
-     * the SRAM. If not, uVisor would end up owning a memory regions that
-     * contains non-uVisor data. */
-    vmpu_acl_static_region(
-        2,
-        (void *) SRAM_ORIGIN,
-        rounded_size,
-        UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE | UVISOR_TACL_SUBREGIONS(subregions_mask)
-    );
-#endif /* !defined(UVISOR_IN_STANDALONE_SRAM) */
 }
 
 int vmpu_is_region_size_valid(uint32_t size)

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -22,6 +22,8 @@
 #include "svc.h"
 #include "unvic.h"
 #include "vmpu.h"
+#include "page_allocator_faults.h"
+#include "page_allocator.h"
 
 /* This file contains the configuration-specific symbols. */
 #include "configurations.h"
@@ -130,6 +132,7 @@ typedef struct {
 } TMpuBox;
 
 static uint32_t g_mpu_region_count, g_box_mem_pos;
+static uint8_t g_mpu_slot, g_mpu_slot_wrap_around;
 static TMpuRegion g_mpu_list[MPU_REGION_COUNT];
 static TMpuBox g_mpu_box[UVISOR_MAX_BOXES];
 
@@ -196,34 +199,38 @@ uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)
     }
 }
 
+static int vmpu_mem_push_page_acl_iterator(uint8_t mask, uint8_t index);
+
 static int vmpu_fault_recovery_mpu(uint32_t pc, uint32_t sp, uint32_t fault_addr, uint32_t fault_status)
 {
     const TMpuRegion *region;
-
-    /* Initialize the round-robin slot pointer. */
-    static uint32_t mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
+    uint8_t mask, index, page;
 
     /* no recovery possible if the MPU syndrome register is not valid */
     if (fault_status != 0x82) {
         return 0;
     }
 
-    /* find region for faulting address */
-    if ((region = vmpu_fault_find_region(fault_addr)) == NULL)
-        return 0;
+    if (page_allocator_get_active_mask_for_address(fault_addr, &mask, &index, &page) == UVISOR_ERROR_PAGE_OK)
+    {
+        /* Remember this fault. */
+        page_allocator_register_fault(page);
 
-    /* In a secure box the first available region is for the stack, so it must
-     * be excluded from the round-robin. */
-    if (g_active_box != 0 && mpu_slot == ARMv7M_MPU_RESERVED_REGIONS) {
-        mpu_slot++;
+        vmpu_mem_push_page_acl_iterator(mask, UVISOR_PAGE_MAP_COUNT * 4 - 1 - index);
+    }
+    else {
+        /* find region for faulting address */
+        if ((region = vmpu_fault_find_region(fault_addr)) == NULL)
+            return 0;
+
+        /* FIXME: use random numbers for box number */
+        MPU->RBAR = region->base | g_mpu_slot++ | MPU_RBAR_VALID_Msk;
+        MPU->RASR = region->rasr;
     }
 
-    /* FIXME: use random numbers for box number */
-    MPU->RBAR = region->base | mpu_slot++ | MPU_RBAR_VALID_Msk;
-    MPU->RASR = region->rasr;
-
-    if (mpu_slot >= ARMv7M_MPU_REGIONS)
-        mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
+    if (g_mpu_slot >= ARMv7M_MPU_REGIONS) {
+        g_mpu_slot = g_mpu_slot_wrap_around;
+    }
 
     return 1;
 }
@@ -336,10 +343,23 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
     }
 }
 
+static int vmpu_mem_push_page_acl_iterator(uint8_t mask, uint8_t index)
+{
+    vmpu_acl_static_region(
+        g_mpu_slot,
+        (void *) ((uint32_t) __uvisor_config.page_end - g_page_size * 8 * (index + 1)),
+        g_page_size * 8,
+        UVISOR_TACLDEF_DATA | UVISOR_TACL_EXECUTE | UVISOR_TACL_SUBREGIONS(~mask)
+    );
+    g_mpu_slot++;
+    /* We do not add more than one region for the page heap. */
+    return 0;
+}
+
 /* FIXME: added very simple MPU region switching - optimize! */
 void vmpu_switch(uint8_t src_box, uint8_t dst_box)
 {
-    int i, mpu_slot;
+    uint32_t dst_count;
     const TMpuBox *box;
     const TMpuRegion *region;
 
@@ -353,52 +373,68 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
         HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The destination box ID is out of range (%u).\r\n", dst_box);
     }
 
-    /* update target box first to make target stack available */
-    mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
+    box = &g_mpu_box[dst_box];
+
+    /* Update target box first to make target stack available. */
+    g_mpu_slot = ARMv7M_MPU_REGIONS_STATIC;
+    g_mpu_slot_wrap_around = ARMv7M_MPU_REGIONS_STATIC;
+    region = box->region;
+    dst_count = box->count;
+
+    /* Only write stack and context ACL for secure boxes. */
     if (dst_box)
     {
-        /* handle target box next */
-        box = &g_mpu_box[dst_box];
-        region = box->region;
+        assert(dst_count);
+        /* Push the stack and context protection ACL into ARMv7M_MPU_REGIONS_STATIC. */
+        MPU->RBAR = region->base | g_mpu_slot | MPU_RBAR_VALID_Msk;
+        MPU->RASR = region->rasr;
+        g_mpu_slot++;
+        g_mpu_slot_wrap_around++;
+        region++;
+        dst_count--;
+    }
 
-        for (i = 0; i < box->count; i++)
-        {
-            if (mpu_slot >= ARMv7M_MPU_REGIONS)
-                 return;
-            MPU->RBAR = region->base | mpu_slot | MPU_RBAR_VALID_Msk;
-            MPU->RASR = region->rasr;
+    /* Push one ACL for the page heap into place. */
+    g_mpu_slot_wrap_around += page_allocator_iterate_active_page_masks(vmpu_mem_push_page_acl_iterator, PAGE_ALLOCATOR_ITERATOR_DIRECTION_BACKWARD);
+    /* g_mpu_slot may now have been incremented by one, if page heap is used by this box. */
 
-            /* process next slot */
-            region++;
-            mpu_slot++;
-        }
+    while (g_mpu_slot < ARMv7M_MPU_REGIONS_MAX && dst_count)
+    {
+        MPU->RBAR = region->base | g_mpu_slot | MPU_RBAR_VALID_Msk;
+        MPU->RASR = region->rasr;
+        g_mpu_slot++;
+        region++;
+        dst_count--;
     }
 
     /* handle main box last */
     box = g_mpu_box;
     region = box->region;
+    dst_count = box->count;
 
-    for (i=0; i<box->count; i++) {
-        if (mpu_slot>=ARMv7M_MPU_REGIONS)
-             return;
-        MPU->RBAR = region->base | mpu_slot | MPU_RBAR_VALID_Msk;
+    while (g_mpu_slot < ARMv7M_MPU_REGIONS_MAX && dst_count)
+    {
+        MPU->RBAR = region->base | g_mpu_slot | MPU_RBAR_VALID_Msk;
         MPU->RASR = region->rasr;
-
-        /* process next slot */
+        g_mpu_slot++;
         region++;
-        mpu_slot++;
+        dst_count--;
     }
 
     /* clear remaining slots */
-    while(mpu_slot<ARMv7M_MPU_REGIONS)
+    while (g_mpu_slot < ARMv7M_MPU_REGIONS_MAX)
     {
         /* We need to make sure that we disable an enabled MPU region before any
          * other modification, hence we cannot select the MPU region using the
          * region number field in the RBAR register. */
-        MPU->RNR = mpu_slot;
+        MPU->RNR = g_mpu_slot;
         MPU->RASR = 0;
         MPU->RBAR = 0;
-        mpu_slot++;
+        g_mpu_slot++;
+    }
+
+    if (g_mpu_slot >= ARMv7M_MPU_REGIONS_MAX) {
+        g_mpu_slot = g_mpu_slot_wrap_around;
     }
 }
 

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -336,8 +336,8 @@ void vmpu_mem_init(void)
     MPU_Region * region;
 
     /* rest of SRAM, accessible to mbed - non-executable for uvisor */
-    res = vmpu_mem_add_int(0, __uvisor_config.bss_end,
-        UVISOR_REGION_ROUND_UP((uint32_t) __uvisor_config.page_start) - ((uint32_t) __uvisor_config.bss_end),
+    res = vmpu_mem_add_int(0, __uvisor_config.page_end,
+        (uint32_t) __uvisor_config.sram_end - ((uint32_t) __uvisor_config.page_end),
         UVISOR_TACL_SREAD|
         UVISOR_TACL_SWRITE|
         UVISOR_TACL_UREAD|

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -41,8 +41,10 @@
 
 #include "page_allocator_config.h"
 
-/* Maps the page to the owning box handle. */
-page_owner_t g_page_owner_table[UVISOR_PAGE_TABLE_MAX_COUNT];
+/* Contains the page usage mapped by owner. */
+uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
+/* Contains total page usage. */
+uint32_t g_page_usage_map[(UVISOR_PAGE_MAX_COUNT + 31) / 32];
 /* Contains the configured page size. */
 uint32_t g_page_size;
 /* Points to the beginning of the page heap. */
@@ -119,8 +121,8 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
         g_page_count_total = ((uint32_t) heap_end - start) / g_page_size;
     }
     /* Clamp page count to table size. */
-    if (g_page_count_total > UVISOR_PAGE_TABLE_MAX_COUNT) {
-        g_page_count_total = UVISOR_PAGE_TABLE_MAX_COUNT;
+    if (g_page_count_total > UVISOR_PAGE_MAX_COUNT) {
+        g_page_count_total = UVISOR_PAGE_MAX_COUNT;
     }
     g_page_count_free = g_page_count_total;
     /* Remember the end of the heap. */
@@ -133,11 +135,9 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
             (unsigned int) g_page_count_total,
             (unsigned int) (g_page_size / 1024));
 
-    uint32_t page = 0;
-    for (; page < UVISOR_PAGE_TABLE_MAX_COUNT; page++) {
-        g_page_owner_table[page] = UVISOR_PAGE_UNUSED;
-        page_allocator_reset_faults(page);
-    }
+    /* Force a reset of owner and usage page maps. */
+    memset(g_page_owner_map, 0, sizeof(g_page_owner_map));
+    memset(g_page_usage_map, 0, sizeof(g_page_usage_map));
 }
 
 int page_allocator_malloc(UvisorPageTable * const table)
@@ -177,9 +177,19 @@ int page_allocator_malloc(UvisorPageTable * const table)
     uint32_t page = 0;
     for (; (page < g_page_count_total) && pages_required; page++) {
         /* If the page is unused, it's entry is UVISOR_PAGE_UNUSED (not NULL!). */
-        if (g_page_owner_table[page] == UVISOR_PAGE_UNUSED) {
-            /* Marry this page to the box id. */
-            g_page_owner_table[page] = box_id;
+        if (!page_allocator_map_get(g_page_usage_map, page)) {
+            /* Remember this page as used. */
+            page_allocator_map_set(g_page_usage_map, page);
+            /* Pages of box 0 are accessible to all other boxes! */
+            if (box_id == 0) {
+                uint32_t ii = 0;
+                for (; ii < UVISOR_MAX_BOXES; ii++) {
+                    page_allocator_map_set(g_page_owner_map[ii], page);
+                }
+            } else {
+                /* Otherwise, remember ownership only for active box. */
+                page_allocator_map_set(g_page_owner_map[box_id], page);
+            }
             /* Reset the fault count for this page. */
             page_allocator_reset_faults(page);
             /* Get the pointer to the page. */
@@ -243,14 +253,25 @@ int page_allocator_free(const UvisorPageTable * const table)
             return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
         }
         /* Check if the page belongs to the caller. */
-        if (g_page_owner_table[page_index] == box_id) {
-            g_page_owner_table[page_index] = UVISOR_PAGE_UNUSED;
+        if (page_allocator_map_get(g_page_owner_map[box_id], page_index)) {
+            /* Clear the owner and usage page maps for this page. */
+            page_allocator_map_clear(g_page_usage_map, page_index);
+            /* If the page was owned by box 0, we need to remove it from all other boxes! */
+            if (box_id == 0) {
+                uint32_t ii = 0;
+                for (; ii < UVISOR_MAX_BOXES; ii++) {
+                    page_allocator_map_clear(g_page_owner_map[ii], page_index);
+                }
+            } else {
+                /* Otherwise, only remove for the active box. */
+                page_allocator_map_clear(g_page_owner_map[box_id], page_index);
+            }
             g_page_count_free++;
             DPRINTF("uvisor_page_free: Freeing page at index %u\n", page_index);
         }
         else {
             /* Abort if the page doesn't belong to the caller. */
-            if (g_page_owner_table[page_index] == UVISOR_PAGE_UNUSED) {
+            if (!page_allocator_map_get(g_page_usage_map, page_index)) {
                 DPRINTF("uvisor_page_free: FAIL: Page %u is not allocated!\n\n", page_index);
             } else {
                 DPRINTF("uvisor_page_free: FAIL: Page %u is not owned by box %u!\n\n", page_index, box_id);

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -122,11 +122,15 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
     }
     /* Clamp page count to table size. */
     if (g_page_count_total > UVISOR_PAGE_MAX_COUNT) {
+        DPRINTF("uvisor_page_init: Clamping available page count from %u to %u!\n", g_page_count_total, UVISOR_PAGE_MAX_COUNT);
+        /* Move the heap start address forward so that the last clamped page is located nearest to the heap end. */
+        g_page_heap_start += (g_page_count_total - UVISOR_PAGE_MAX_COUNT) * g_page_size;
+        /* Clamp the page count. */
         g_page_count_total = UVISOR_PAGE_MAX_COUNT;
     }
     g_page_count_free = g_page_count_total;
     /* Remember the end of the heap. */
-    g_page_heap_end = g_page_heap_start + g_page_count_free * g_page_size;
+    g_page_heap_end = g_page_heap_start + g_page_count_total * g_page_size;
 
     DPRINTF("uvisor_page_init:\n.page_heap start 0x%08x\n.page_heap end   0x%08x\n.page_heap available %ukB split into %u pages of %ukB\n\n",
             (unsigned int) g_page_heap_start,

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -42,9 +42,9 @@
 #include "page_allocator_config.h"
 
 /* Contains the page usage mapped by owner. */
-uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
+uint32_t g_page_owner_map[UVISOR_MAX_BOXES][UVISOR_PAGE_MAP_COUNT];
 /* Contains total page usage. */
-uint32_t g_page_usage_map[(UVISOR_PAGE_MAX_COUNT + 31) / 32];
+uint32_t g_page_usage_map[UVISOR_PAGE_MAP_COUNT];
 /* Contains the configured page size. */
 uint32_t g_page_size;
 /* Points to the beginning of the page heap. */

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -22,7 +22,7 @@
 #include "context.h"
 
 /* Maps the number of faults to a page. */
-uint32_t g_page_fault_table[UVISOR_PAGE_TABLE_MAX_COUNT];
+uint32_t g_page_fault_table[UVISOR_PAGE_MAX_COUNT];
 
 void page_allocator_reset_faults(uint8_t page)
 {
@@ -56,8 +56,8 @@ int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * st
         /* This address does not correspond to any page. */
         return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
     }
-    /* Check that the page actually belongs to this box or box 0. */
-    if ((g_page_owner_table[p] != 0) && (g_page_owner_table[p] != box_id)) {
+    /* Then check if the page is set. */
+    if (!page_allocator_map_get(g_page_owner_map[box_id], p)) {
         return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
     }
     /* Compute the page start and end address */
@@ -72,13 +72,11 @@ uint8_t page_allocator_iterate_active_pages(int (*callback)(uint32_t start_addr,
 {
     uint8_t ii, count = 0;
     uint32_t start_addr, end_addr;
+    const page_owner_t box_id = g_active_box;
 
     /* Iterate over all pages. */
-    /* FIXME: Use bit masks for this to make this page enabling more efficient.
-     * By storing the pages as a bit mask in an array indexed by box id, the lookup
-     * is O(1) and it can be OR-ed with box 0 and then all pages can be enabled at once. */
     for (ii = 0; ii < g_page_count_total; ii++) {
-        if (g_page_owner_table[ii] == g_active_box || g_page_owner_table[ii] == 0) {
+        if (page_allocator_map_get(g_page_owner_map[box_id], ii)) {
             count++;
             if (callback) {
                 /* Compute start and end addresses. */

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -68,6 +68,34 @@ int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * st
     return UVISOR_ERROR_PAGE_OK;
 }
 
+int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask, uint8_t * index, uint8_t * page)
+{
+    const page_owner_t box_id = g_active_box;
+    /* Compute the page id. */
+    uint8_t p = page_allocator_get_page_from_address(address);
+    if (p == UVISOR_PAGE_UNUSED) {
+        /* This address does not correspond to any page. */
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
+    }
+    /* Then check if the page is set. */
+    if (!page_allocator_map_get(g_page_owner_map[box_id], p)) {
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
+    }
+    *page = p;
+    /* Compute the page mask and index. */
+#if UVISOR_PAGE_OWNER_MAP_LEFT_ALIGNED
+    p += UVISOR_PAGE_MAP_COUNT * 32 - g_page_count_total;
+#endif
+#if UVISOR_PAGE_MAP_COUNT == 1
+    *mask = (uint8_t) (g_page_owner_map[box_id][0] >> (p & ~7));
+#else
+    *mask = (uint8_t) (g_page_owner_map[box_id][p / 32] >> ((p % 32) & ~7));
+#endif
+    *index = p / 8;
+
+    return UVISOR_ERROR_PAGE_OK;
+}
+
 uint8_t page_allocator_iterate_active_pages(int (*callback)(uint32_t start_addr, uint32_t end_addr, uint8_t page))
 {
     uint8_t ii, count = 0;

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -96,22 +96,64 @@ int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask,
     return UVISOR_ERROR_PAGE_OK;
 }
 
-uint8_t page_allocator_iterate_active_pages(int (*callback)(uint32_t start_addr, uint32_t end_addr, uint8_t page))
+uint8_t page_allocator_iterate_active_pages(int (*callback)(uint32_t start_addr, uint32_t end_addr, uint8_t page), PageAllocatorIteratorDirection direction)
 {
-    uint8_t ii, count = 0;
+    uint8_t ii, index, count = 0;
     uint32_t start_addr, end_addr;
     const page_owner_t box_id = g_active_box;
 
     /* Iterate over all pages. */
     for (ii = 0; ii < g_page_count_total; ii++) {
-        if (page_allocator_map_get(g_page_owner_map[box_id], ii)) {
+        if (direction < 0) {
+            index = (g_page_count_total - 1) - ii;
+        } else {
+            index = ii;
+        }
+        if (page_allocator_map_get(g_page_owner_map[box_id], index)) {
             count++;
             if (callback) {
                 /* Compute start and end addresses. */
-                start_addr = (uint32_t) g_page_heap_start + g_page_size * ii;
+                start_addr = (uint32_t) g_page_heap_start + g_page_size * index;
                 end_addr = start_addr + g_page_size;
                 /* Call the callback. */
                 if (!callback(start_addr, end_addr, ii)) {
+                    return count;
+                }
+            }
+        }
+    }
+
+    return count;
+}
+
+uint8_t page_allocator_iterate_active_page_masks(int (*callback)(uint8_t mask, uint8_t index), PageAllocatorIteratorDirection direction)
+{
+    uint8_t ii, index, mask, count = 0;
+    const page_owner_t box_id = g_active_box;
+    const uint8_t page_count_octets = ((g_page_count_total + 7) / 8);
+
+    for (ii = 0; ii < page_count_octets; ii++) {
+        if (direction < 0) {
+#if UVISOR_PAGE_OWNER_MAP_LEFT_ALIGNED
+            index = UVISOR_PAGE_MAP_COUNT * 4 - 1 - ii;
+        } else {
+            index = (UVISOR_PAGE_MAP_COUNT * 4 - page_count_octets) + ii;
+#else
+            index = page_count_octets - 1 - ii;
+        } else {
+            index = ii;
+#endif
+        }
+#if UVISOR_PAGE_MAP_COUNT == 1
+        mask = (uint8_t) (g_page_owner_map[box_id][0] >> (index * 8));
+#else
+        mask = (uint8_t) (g_page_owner_map[box_id][index / 4] >> ((index % 4) * 8));
+#endif
+        if (mask) {
+            count++;
+            if (callback) {
+                /* Call the callback. */
+                if (!callback(mask, ii)) {
                     return count;
                 }
             }


### PR DESCRIPTION
This adds the necessary changes to use subregions to access the page heap.
Changes include accessing the page owner bitmap efficiently to map it directly to MPU subregions and moving the page heap to behind the uVisor `.bss` section and aligning it's end with a subregion of the SRAM access region.

Note: This builds on #284 and cherry-picks #280 and #273 from `unstable` to `dev`.

cc @AlessandroA @meriac @Patater 