### PR TITLE
Update documentation to new mbed OS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The uVisor is a self-contained software hypervisor that creates independent secu
 
 ## Overview
 
-To start using uVisor you will need to include it as a library in your design. We release the uVisor library periodically in the form of a yotta module in the [ARMmbed/uvisor-lib](https://github.com/ARMmbed/uvisor-lib) repository.
+To start using uVisor you will need to include it as a library in your design. We release the uVisor library periodically in the mbed OS repository, [mbedmicro/mbed](https://github.com/mbedmicro/mbed).
 
 If you want to learn more about the uVisor security model and get an overview of its features this is the right place. In this document you will read about:
 
@@ -16,14 +16,14 @@ If you want to learn more about the uVisor security model and get an overview of
 
 Other documents you might be interested in:
 
-| I want to...                               | Document                                                                                      |
-|--------------------------------------------|-----------------------------------------------------------------------------------------------|
-| Start using uVisor on a supported platform | [`uvisor-lib` quick-start guide](https://github.com/ARmmbed/uvisor-lib/blob/master/README.md) |
-| Know everything I can do with uVisor       | [API documentation](https://github.com/ARmmbed/uvisor-lib/blob/master/DOCUMENTATION.md)       |
-| Enable debug messages                      | [Debugging uVisor](docs/DEBUGGING.md)                                                         |
-| Port uVisor to my platform                 | [Porting guide](docs/PORTING.md)                                                              |
-| Test and experiment with uVisor            | [Developing with uVisor locally](docs/DEVELOPING_LOCALLY.md)                                  |
-| Contribute to uVisor                       | [Contributing to uVisor](CONTRIBUTING.md)                                                     |
+| I want to...                               | Document                                                     |
+|--------------------------------------------|--------------------------------------------------------------|
+| Start using uVisor on a supported platform | [uVisor quick-start guide](docs/QUICKSTART.md)               |
+| Know everything I can do with uVisor       | [API documentation](docs/API.md)                             |
+| Enable debug messages                      | [Debugging uVisor](docs/DEBUGGING.md)                        |
+| Port uVisor to my platform                 | [Porting guide](docs/PORTING.md)                             |
+| Test and experiment with uVisor            | [Developing with uVisor locally](docs/DEVELOPING_LOCALLY.md) |
+| Contribute to uVisor                       | [Contributing to uVisor](CONTRIBUTING.md)                    |
 
 ### Word of caution
 
@@ -41,10 +41,17 @@ Some of the open uVisor issues in progress are listed here:
 
 ### Supported platforms
 
-The following platforms are currently supported:
+The following platforms are currently supported by the uVisor core:
 
 * [NXP FRDM-K64F](http://developer.mbed.org/platforms/FRDM-K64F/)
 * [STMicorelectronics STM32F429I-DISCO](http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/PF259090)
+* [Silicon Labs EFM32 Gecko](http://www.silabs.com/products/mcu/32-bit/efm32-gecko/pages/efm32-gecko.aspx) (Cortex M3 and M4 devices).
+
+To use uVisor on a platform, though, the porting process needs to be completed on the target OS as well. Currently uVisor is only supported on the following platforms:
+
+* mbed OS: [NXP FRDM-K64F](http://developer.mbed.org/platforms/FRDM-K64F/)
+
+For more information on the porting process, for both the uVisor core and library, please read the [porting guide](docs/PORTING.md)
 
 The uVisor pre-linked binary images are built with the Launchpad [GCC ARM Embedded](https://launchpad.net/gcc-arm-embedded) toolchain. Currently only applications built with the same toolchain are supported.
 
@@ -88,7 +95,7 @@ All the code that is not explicitly part of the uVisor is generally referred to 
 
 The unprivileged code can be made of mutually untrusted isolated modules (or boxes). This way, even if all are running with unprivileged permissions, different modules can protect their own secrets and execute critical code securely.
 
-For more details on how to setup a secure box and protect memories and peripherals, please read the [`uvisor-lib` quick-start guide](https://github.com/ARMmbed/uvisor-lib/blob/master/README.md).
+For more details on how to setup a secure box and protect memories and peripherals, please read the [quick-start guide](docs/QUICKSTART.md).
 
 ### Memory layout
 
@@ -131,7 +138,7 @@ The main memory sections that the uVisor protects are detailed in the following 
   </tbody>
 </table>
 
-If you want to know how to use the uVisor APIs to setup a secure box please refer to the [`uvisor-lib` quick-start guide](https://github.com/ARMmbed/uvisor-lib/blob/master/README.md) and to the full [API documentation](https://github.com/ARMmbed/uvisor-lib/blob/master/DOCUMENTATION.md).
+If you want to know how to use the uVisor APIs to setup a secure box please refer to the [quick-start guide](docs/QUICKSTART.md) and to the full [API documentation](docs/API.md).
 
 ### The boot process
 
@@ -162,6 +169,4 @@ During a context switch, the uVisor stores the state of the previous context and
 * It re-configures the MPU and the peripherals protection.
 * It hands the execution to the target context.
 
-A context switch might be triggered automatically every time an interrupt belonging to a different box is served while another context is active. Context switches can also be manually triggered by using a so-called *secure gateway*.
-
-For more details on how to use the secure gateway please read the [`uvisor-lib` quick-start guide](https://github.com/ARMmbed/uvisor-lib/blob/master/README.md).
+A context switch is triggered automatically every time the target of a function call or exception handling routine (interrupts) belongs to a different secure domain. This applies to user interrupt service routines, threads and direct function calls.

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,13 +1,16 @@
-# Debugging uVisor
+# Debugging uVisor on mbed OS
 
-The uVisor is distributed as a pre-linked binary blob. Blobs for different mbed platforms are released in a yotta module called `uvisor-lib`, and are linked to your application when you build it. Two classes of binary blobs are released for each version — one for release and one for debug.
+The uVisor is distributed as a pre-linked binary blob. Blobs for different mbed platforms are released in the mbed OS repository, [mbedmicro/mbed](https://github.com/mbedmicro/mbed), and are linked to your application when you build it. Two classes of binary blobs are released for each version — one for release and one for debug.
 
 If you only want to use the uVisor debug features on an already supported platform, you do not need to clone it and build it locally. If you instead want to make modifications to uVisor (or port it to your platform) and test the modifications locally with your app, please follow the [Developing with uVisor locally](DEVELOPING_LOCALLY.md) guide first.
 
 In this quick guide we will show you how to enable the default debug features on uVisor, and how to instrument it to get even more debug information. You will need the following:
 
 * A GDB-enabled board (and the related tools).
-* yotta.
+* A [target supported](https://github.com/ARMmbed/uvisor/blob/master/README.md#supported-platforms) by uVisor on mbed OS. If your target is not supported yet, you can follow the [uVisor porting guide](https://github.com/ARMmbed/uvisor/blob/master/docs/PORTING.md).
+* The Launchpad [GCC ARM Embedded](https://launchpad.net/gcc-arm-embedded) toolchain.
+* GNU make.
+* git.
 
 ## Debug capabilities
 
@@ -25,19 +28,18 @@ If you want to observe the uVisor runtime messages you need to have a debugger c
 
 ```bash
 $ cd ~/code
-$ yotta target frdm-k64f-gcc
-$ yotta install uvisor-helloworld
-$ cd uvisor-helloworld
+$ mbed import https://github.com/ARMmbed/mbed-os-example-uvisor
+$ cd mbed-os-example-uvisor
 ```
 
 Of course any other application can be used, provided that it is correctly set up to use uVisor. See [Developing with uVisor locally](DEVELOPING_LOCALLY.md) for more details.
-Runtime messages are silenced by default. In order to enable them, you need to build your application linking to the debug version of uVisor. Starting with v2.0.0, `uvisor-lib` comes with both the release and debug builds of uVisor, so you only need to run the following command:
+Runtime messages are silenced by default. In order to enable them, you need to build your application linking to the debug version of uVisor. The uVisor libraries that we publish in mbed OS provide both the release and debug builds of uVisor, so you only need to run the following command:
 
 ```bash
-$ yotta build -d
+$ mbed compile -m ${your_target} -t GCC_ARM -o "debug-info"
 ```
 
-The `-d` option ensures that yotta enables debug symbols and disables optimizations. In addition, it ensures that the `uvisor-lib` modules selects the debug build of uVisor, which enables the uVisor runtime messages.
+The `-o "debug-info"` option ensures that the build system enables debug symbols and disables optimizations. In addition, it ensures that the debug build of uVisor is selected, which enables the uVisor runtime messages.
 
 Now start the GDB server. This step changes depending on which debugger you are using. In case you are using a J-Link debugger, run:
 
@@ -104,6 +106,8 @@ Currently the following messages are printed:
 
 ## The debug box
 
+> Warning: We are currently working on porting the debug box to the new version of mbed OS. Coming soon.
+
 > Warning: The debug box feature is an early prototype. The APIs and procedures described here might change several times in non-backwards-compatible ways.
 
 The uVisor code is instrumented to output debug information when it is relevant. In order to keep the uVisor as simple and hardware-independent as possible, some of this information is not handled and interpreted directly by uVisor.
@@ -124,7 +128,7 @@ typedef struct TUvisorDebugDriver {
 The following is an example of how to implement and configure a debug box.
 
 ```C
-#include "mbed-drivers/mbed.h"
+#include "mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 /* Configure the debug box. */


### PR DESCRIPTION
Minor updates were missing:

* The README had some deprecated information.
* The debugging guide had yotta-specific instructions.

@meriac @patater @niklas-arm 