### PR TITLE
Secure Memory Allocator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ endif
 ifeq ("$(ARCH_MPU)","ARMv7M")
 MPU_SRC:=\
          $(CORE_SYSTEM_DIR)/src/mpu/vmpu_armv7m.c \
-         $(CORE_SYSTEM_DIR)/src/mpu/vmpu_armv7m_debug.c
+         $(CORE_SYSTEM_DIR)/src/mpu/vmpu_armv7m_debug.c \
+         $(CORE_SYSTEM_DIR)/src/mpu/vmpu_armv7m_mpu.c
 endif
 
 # Freescale K64 MPU driver
@@ -93,7 +94,8 @@ MPU_SRC:=\
          $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64.c \
          $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64_debug.c \
          $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64_aips.c \
-         $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64_mem.c
+         $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64_mem.c \
+         $(CORE_SYSTEM_DIR)/src/mpu/vmpu_freescale_k64_mpu.c
 endif
 
 # Core source files

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -18,6 +18,7 @@
 #define __UVISOR_API_BOX_CONFIG_H__
 
 #include "api/inc/uvisor_exports.h"
+#include "api/inc/page_allocator_exports.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -52,6 +53,14 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
     }; \
     \
     extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_cfg;
+
+/* Creates a global page heap with at least `minimum_number_of_pages` each of size `page_size` in bytes.
+ * The total page heap size is at least `minimum_number_of_pages * page_size`. */
+#define UVISOR_SET_PAGE_HEAP(page_size, minimum_number_of_pages) \
+    const uint32_t __uvisor_page_size = (page_size); \
+    uint8_t __attribute__((section(".keep.uvisor.page_heap"))) \
+        main_page_heap_reserved[ (page_size) * (minimum_number_of_pages) ]
+
 
 /* this macro selects an overloaded macro (variable number of arguments) */
 #define __UVISOR_BOX_MACRO(_1, _2, _3, _4, NAME, ...) NAME

--- a/api/inc/page_allocator.h
+++ b/api/inc/page_allocator.h
@@ -34,4 +34,7 @@ UVISOR_EXTERN int uvisor_page_malloc(UvisorPageTable * const table);
  */
 UVISOR_EXTERN int uvisor_page_free(const UvisorPageTable * const table);
 
+/* @returns the active page size for one page. */
+UVISOR_EXTERN uint32_t uvisor_get_page_size(void);
+
 #endif /* __UVISOR_API_PAGE_ALLOCATOR_H__ */

--- a/api/inc/page_allocator_exports.h
+++ b/api/inc/page_allocator_exports.h
@@ -30,27 +30,9 @@
 #define UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER    (UVISOR_ERROR_CLASS_PAGE + 5)
 #define UVISOR_ERROR_PAGE_INVALID_PAGE_COUNT    (UVISOR_ERROR_CLASS_PAGE + 6)
 
-
-/* Must be a power of 2 for MPU alignment in ARMv7-M with ARM MPU.
- * Must be multiple of 32 for K64F MPU. */
-#ifndef UVISOR_PAGE_SIZE
-#define UVISOR_PAGE_SIZE ((uint32_t) 16 * 1024)
-#endif
-
-/* Return the rounded up number of pages required to hold `size`. */
-#define UVISOR_PAGES_FOR_SIZE(size) ((size + UVISOR_PAGE_SIZE - 1) / UVISOR_PAGE_SIZE)
-
-/* Create a page table with `count` many entries. */
-#define UVISOR_PAGE_TABLE(count) \
-    struct { \
-        uint32_t page_size; \
-        uint32_t page_count; \
-        void * page_origins[count]; \
-    }
-
-/* Create a page table with enough pages to hold `size`. */
-#define UVISOR_PAGE_TABLE_FOR_SIZE(size) UVISOR_PAGE_TABLE(UVISOR_PAGES_FOR_SIZE(size))
-
+/* Contains the uVisor page size.
+ * @warning Do not read directly, instead use `uvisor_get_page_size()` accessor! */
+UVISOR_EXTERN const uint32_t __uvisor_page_size;
 
 typedef struct {
     uint32_t page_size;     /* The page size in bytes. Must be multiple of `UVISOR_PAGE_SIZE`! */

--- a/api/src/page_allocator.c
+++ b/api/src/page_allocator.c
@@ -27,3 +27,8 @@ int uvisor_page_free(const UvisorPageTable * const table)
 {
     return UVISOR_SVC(UVISOR_SVC_ID_PAGE_FREE, "", table);
 }
+
+uint32_t uvisor_get_page_size(void)
+{
+    return __uvisor_page_size;
+}

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -20,6 +20,7 @@
 .globl __uvisor_ps
 .type  uvisor_init, %function
 .weak  __uvisor_mode
+.weak  __uvisor_page_size
 .globl __uvisor_priv_sys_irq_hooks
 
 .section .uvisor.main, "x"

--- a/core/system/inc/mpu/vmpu_mpu.h
+++ b/core/system/inc/mpu/vmpu_mpu.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __VMPU_MPU_H__
+#define __VMPU_MPU_H__
+
+#include "api/inc/uvisor_exports.h"
+#include "api/inc/vmpu_exports.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct
+{
+    uint32_t start;     /**< Start address of the MPU region. */
+    uint32_t end;       /**< End address of the MPU region. */
+    uint32_t config;    /**< MPU specific config data (permissions, subregions, etc). */
+    UvisorBoxAcl acl;   /**< Original box ACL. */
+} MpuRegion;
+
+/* Region management */
+
+/** Translate the start address, size and ACL into an MPU region.
+ *
+ * @param[out] region   MPU region provided by caller
+ * @param start         start address of ACL region
+ * @param size          size of the ACL region
+ * @param acl           access rights of the ACL region
+ * @returns             rounded size of the MPU region depending on ACL flags.
+ * @retval 0            start, size or access rights are not consistent for this platform
+ */
+uint32_t vmpu_region_translate_acl(MpuRegion * const region, uint32_t start, uint32_t size, UvisorBoxAcl acl);
+
+/** Bind an ACL to a box.
+ *
+ * @warning At the moment all ACLs for one box have to be added in one go.
+ *          Do not interleave adding ACLs of different box ids!
+ *
+ * @param box_id        the box id to bind the ACL to
+ * @param start         start address of ACL region
+ * @param size          size of the ACL region
+ * @param acl           access rights of the ACL region
+ * @returns             rounded size of the MPU region depending on ACL flags.
+ * @retval 0            start, size or access rights are not consistent for this platform
+ */
+uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t size, UvisorBoxAcl acl);
+
+/** Returns all MPU regions of a box as an array of `MpuRegion`s.
+ *
+ * @param box_id        the box id to get the ACLs for
+ * @param[out] region   points to array of regions for this box, `NULL` if no regions availabl
+ * @param[out] count    contains the number of regions in the array
+ * @returns             `false` if box out-of-range, `true` otherwise
+ */
+bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, uint32_t * const count);
+
+/** Returns the MPU region of a box id for the specified address.
+ *
+ * @param box_id        the box id to look up the address in
+ * @param address       the address to search in the the MPU regions
+ * @returns             the MPU region that this address belongs to, `NULL` otherwise
+ */
+MpuRegion * vmpu_region_find_for_address(uint8_t box_id, uint32_t address);
+
+/* Region management */
+
+/* MPU access */
+
+/** Initialize the MPU. */
+void vmpu_mpu_init(void);
+
+/** Write an ACL directly into an MPU region.
+ * This is used to set ACLs that are persistent, like unlocking public Flash and insecure box SRAM.
+ *
+ * @warning These function may only be called after `vmpu_mpu_init()`, but before `vmpu_mpu_lock()`!
+ *
+ * @param index         MPU index to write this region to
+ * @param start         start address of ACL region
+ * @param size          size of the ACL region
+ * @param acl           access rights of the ACL region
+ * @returns             rounded size of the MPU region depending on ACL flags.
+ * @retval 0            index, start, size or access rights are not consistent for this platform
+ */
+uint32_t vmpu_mpu_set_static_acl(uint8_t index, uint32_t start, uint32_t size, UvisorBoxAcl acl);
+
+/** Lock the MPU after setting global ACLs using `vmpu_mpu_set_static_acl`. */
+void vmpu_mpu_lock(void);
+
+/** Invalidate all configured MPU regions. */
+void vmpu_mpu_invalidate(void);
+
+/** Push a region into the MPU with the given priority.
+ * A higher priority region replaces a lower priority region.
+ * If no lower priority region can be found, the next viable region is replaced.
+ * Regions with priority `255` are never replaced.
+ * Regions with priority `0` are not allowed (they are upgraded to priority `1`).
+ *
+ * @param region    MPU region to enable
+ * @param priority  region priority in the range of `1` to `254`.
+ * @retval          `true` a viable MPU region was found immediately
+ * @retval          `false` the search for a viable MPU region wrapped around.
+ */
+bool vmpu_mpu_push(const MpuRegion * const region, uint8_t priority);
+
+/* MPU access */
+
+#endif /* __VMPU_MPU_H__ */

--- a/core/system/inc/page_allocator.h
+++ b/core/system/inc/page_allocator.h
@@ -58,9 +58,7 @@ uint8_t page_allocator_get_page_from_address(uint32_t address);
 extern uint32_t g_page_size;
 /* Points to the beginning of the page heap. */
 extern const void * g_page_heap_start;
-/* Contains the total number of available pages. */
-extern uint8_t g_page_count_total;
-/* Maps the page to the owning box handle. */
-extern page_owner_t g_page_owner_table[];
+/* Contains the page usage mapped by owner. */
+extern uint32_t g_page_owner_map[UVISOR_MAX_BOXES][(UVISOR_PAGE_MAX_COUNT + 31) / 32];
 
 #endif /* __PAGE_ALLOCATOR_H__ */

--- a/core/system/inc/page_allocator_config.h
+++ b/core/system/inc/page_allocator_config.h
@@ -25,8 +25,8 @@
  * a relatively low limit to the number of pages.
  * By default a maximum of 16 pages are allowed. This can only be overwritten
  * by the porting engineer for the current platform. */
-#ifndef UVISOR_PAGE_TABLE_MAX_COUNT
-#define UVISOR_PAGE_TABLE_MAX_COUNT ((uint32_t) 16)
+#ifndef UVISOR_PAGE_MAX_COUNT
+#define UVISOR_PAGE_MAX_COUNT (16UL)
 #endif
 /* The number of pages is decided by the page size. A small page size leads to
  * a lot of pages, however, number of pages is capped for efficiency.
@@ -34,12 +34,49 @@
  * will lead to allocation failures. This can only be overwritten
  * by the porting engineer for the current platform. */
 #ifndef UVISOR_PAGE_SIZE_MINIMUM
-#define UVISOR_PAGE_SIZE_MINIMUM ((uint32_t) 1024)
+#define UVISOR_PAGE_SIZE_MINIMUM (1024UL)
 #endif
+
+/* Defines the number of uint32_t page owner masks in the owner map. */
+#define UVISOR_PAGE_MAP_COUNT ((UVISOR_PAGE_MAX_COUNT + 31) / 32)
 
 /* The page box_id is the box id which is 8-bit large. */
 typedef uint8_t page_owner_t;
 /* Define a unused value for the page table. */
 #define UVISOR_PAGE_UNUSED ((page_owner_t) (-1))
+/* Contains the total number of available pages. */
+extern uint8_t g_page_count_total;
+
+/** Sets the page bit in the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ */
+static inline void page_allocator_map_set(uint32_t * const map, uint8_t page)
+{
+    page += UVISOR_PAGE_MAP_COUNT * 32 - g_page_count_total;
+    map[page / 32] |= (1UL << (page % 32));
+}
+
+/** Clears the page bit in the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ */
+static inline void page_allocator_map_clear(uint32_t * const map, uint8_t page)
+{
+    page += UVISOR_PAGE_MAP_COUNT * 32 - g_page_count_total;
+    map[page / 32] &= ~(1UL << (page % 32));
+}
+
+/** Check if the page bit is set int the page map array.
+ * @param map   an array of `uint32_t` containing the page map
+ * @param page  the index of the page to be set
+ * @retval 0    if page bit is not set
+ * @retval 1    if page bit is set
+ */
+static inline int page_allocator_map_get(const uint32_t * const map, uint8_t page)
+{
+    page += UVISOR_PAGE_MAP_COUNT * 32 - g_page_count_total;
+    return (map[page / 32] >> (page % 32)) & 0x1;
+}
 
 #endif /* __PAGE_ALLOCATOR_CONFIG_H__ */

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -30,29 +30,92 @@ uint32_t page_allocator_get_faults(uint8_t page);
 
 /** Map an address to the start and end addresses of a page.
  * If the address is not part of any page, or the page does not belong to the
- * active box or box 0 an error is returned and `start` and `end` are invalid.
+ * active box or box 0 an error is returned and `start`, `end` and `page` are invalid.
  *
- * @param address           the address to map
- * @param[out] start_addr   pointer to the start address value
- * @param[out] end_addr     pointer to the end address value
- * @param[out] page         pointer to the page index value
+ * @param address           the address to locate in the page heap
+ * @param[out] start_addr   the start address of the found page
+ * @param[out] end_addr     the end address of the found page
+ * @param[out] page         the physical page index of the found page
  * @returns Non-zero on failure with failure class `UVISOR_ERROR_CLASS_PAGE`. See `UVISOR_ERROR_PAGE_*`.
  */
 int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * start_addr, uint32_t * end_addr, uint8_t * page);
 
+/** Map an address to an 8-bit page mask.
+ * If the address is not part of any page, or the page does not belong to the
+ * active box or box 0 an error is returned and `mask`, `index` and `page` are invalid.
+ *
+ * Example with 12 pages:
+ *  - map:  0b11111111'11110000'00000000'00000000
+ *      1. address maps to page 9: mask=0xFF, index=3, page=9
+ *      2. address maps to page 3: mask=0xF0, index=2, page=3
+ *
+ * @param address           the address to locate in the page heap
+ * @param[out] mask         the 8-bit aligned page mask containing the found page
+ * @param[out] index        the position of the page mask counting from the LSB!
+ * @param[out] page         the physical page index of the found page
+ * @returns Non-zero on failure with failure class `UVISOR_ERROR_CLASS_PAGE`. See `UVISOR_ERROR_PAGE_*`.
+ */
+int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask, uint8_t * index, uint8_t * page);
+
+typedef enum
+{
+    /** The iterator will start at the lowest page counting upwards. */
+    PAGE_ALLOCATOR_ITERATOR_DIRECTION_FORWARD = 1,
+    /** The iterator will start at the highest page counting downwards. */
+    PAGE_ALLOCATOR_ITERATOR_DIRECTION_BACKWARD = -1,
+} PageAllocatorIteratorDirection;
+
 /** Callback for iterating over pages.
+ *
+ * Note that the page index always increments relative to iteration direction.
+ * This means if you iterate backwards, page index 0 corresponds the the
+ * physically highest page and "increments" downwards.
+ *
  * @param start_addr    the page start address
  * @param end_addr      the page end address
- * @param page          the page index
+ * @param page          the page index relative to iteration direction
  * @retval 0            stop iteration after this callback.
  * @retval !0           continue iteration after this callback.
  */
 typedef int (*PageAllocatorIteratorCallback)(uint32_t start_addr, uint32_t end_addr, uint8_t page);
 
-/* Iterate over all pages belonging to the active box or box 0 and execute the callback.
- * @param callback  the function to execute on every page. May be NULL.
- * @return          number of active pages.
+/* Iterate over all pages belonging to the active box or box 0 and execute the callback.ss
+ *
+ * @param callback  the function to execute on every page. Returns number of active pages if `NULL`.
+ * @param direction forward or backwards direction.
+ * @return          number of callbacks, or if `NULL` passed as callback, number of active pages.
  */
-uint8_t page_allocator_iterate_active_pages(PageAllocatorIteratorCallback callback);
+uint8_t page_allocator_iterate_active_pages(PageAllocatorIteratorCallback callback, PageAllocatorIteratorDirection direction);
+
+/** Callback for iterating over 8-bit page masks.
+ *
+ * Note that the mask and the mask index are always aligned to the 8-bit boundary!
+ * This means that iterating forward starts indexing at the LSB of the map, and
+ * iterating  backwards starts indexing at the MSB of the map.
+ * The LSB is the lowest byte containing page owner bits.
+ *
+ * Example with 12 pages:
+ *  - map:  0b11111111'11110000
+ *      1. forward iteration callbacks:
+ *          1. mask=0xF0, index=0
+ *          2. mask=0xFF, index=1
+ *      2. backward iteration callbacks:
+ *          1. mask=0xFF, index=0
+ *          2. mask=0xF0, index=1
+ *
+ * @param mask          the page owner mask
+ * @param index         the index of the page mask
+ * @retval 0            stop iteration after this callback.
+ * @retval !0           continue iteration after this callback.
+ */
+typedef int (*PageAllocatorIteratorMaskCallback)(uint8_t mask, uint8_t index);
+
+/* Iterate over all page masks belonging to the active box or box 0 and execute the callback.
+ *
+ * @param callback  the function to execute on every page mask. Returns number of active page masks if `NULL`.
+ * @param direction forward or backwards direction.
+ * @return          number of callbacks, or if `NULL` passed as callback, number of active page masks.
+ */
+uint8_t page_allocator_iterate_active_page_masks(PageAllocatorIteratorMaskCallback callback, PageAllocatorIteratorDirection direction);
 
 #endif /* __PAGE_ALLOCATOR_FAULTS_H__ */

--- a/core/system/src/mpu/vmpu.c
+++ b/core/system/src/mpu/vmpu.c
@@ -21,6 +21,7 @@
 #include "memory_map.h"
 #include "svc.h"
 #include "vmpu.h"
+#include "vmpu_mpu.h"
 
 #ifndef MPU_MAX_PRIVATE_FUNCTIONS
 #define MPU_MAX_PRIVATE_FUNCTIONS 16
@@ -312,9 +313,9 @@ static void vmpu_load_boxes(void)
                 if (region->acl & UVISOR_TACL_IRQ) {
                     vmpu_acl_irq(box_id, region->param1, region->param2);
                 } else {
-                    vmpu_acl_add(
+                    vmpu_region_add_static_acl(
                         box_id,
-                        region->param1,
+                        (uint32_t) region->param1,
                         region->param2,
                         region->acl | UVISOR_TACL_USER
                     );

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -22,14 +22,13 @@
 #include "svc.h"
 #include "unvic.h"
 #include "vmpu.h"
+#include "vmpu_mpu.h"
+#include "page_allocator_faults.h"
+#include "page_allocator.h"
 
 /* This file contains the configuration-specific symbols. */
 #include "configurations.h"
 
-/* set default MPU region count */
-#ifndef ARMv7M_MPU_REGIONS
-#define ARMv7M_MPU_REGIONS 8
-#endif/*ARMv7M_MPU_REGIONS*/
 
 /* Sanity checks on SRAM boundaries */
 #if SRAM_LENGTH_MIN <= 0
@@ -39,104 +38,18 @@
 #error "HOST_SRAM_LENGTH_MAX must be strictly positive."
 #endif
 
-/* Automatically detect if the uVisor is placed in a standalone SRAM.
- * We need to check that the uVisor SRAM region and the host whole-SRAM region
- * do not overlap.
- * Two ranges A and B do not overlap if either A is fully after B or B is fully
- * after A. */
-#if ((SRAM_ORIGIN > (HOST_SRAM_ORIGIN_MIN + HOST_SRAM_LENGTH_MAX)) || \
-     ((SRAM_ORIGIN + SRAM_LENGTH_MIN) < HOST_SRAM_ORIGIN_MIN))
-#define UVISOR_IN_STANDALONE_SRAM
-#elif defined(UVISOR_IN_STANDALONE_SRAM)
-#error "UVISOR_IN_STANDALONE_SRAM is defined even if the host SRAM and the uVisor SRAM regions overlap."
-#endif
 
-/* Set number of statically configured regions.
- * It depends on whether the uVisor shares the SRAM with the host or not. */
-#if defined(UVISOR_IN_STANDALONE_SRAM)
-#define ARMv7M_MPU_RESERVED_REGIONS 2
-#else
-#define ARMv7M_MPU_RESERVED_REGIONS 3
-#endif /* defined(UVISOR_IN_STANDALONE_SRAM) */
-
-/* set default minimum region address alignment */
-#ifndef ARMv7M_MPU_ALIGNMENT_BITS
-#define ARMv7M_MPU_ALIGNMENT_BITS 5
-#endif/*ARMv7M_MPU_ALIGNMENT_BITS*/
-
-/* derieved region alignment settings */
-#define ARMv7M_MPU_ALIGNMENT (1UL<<ARMv7M_MPU_ALIGNMENT_BITS)
-#define ARMv7M_MPU_ALIGNMENT_MASK (ARMv7M_MPU_ALIGNMENT-1)
-
-/* MPU helper macros */
-#define MPU_RBAR(region,addr)   (((uint32_t)(region))|MPU_RBAR_VALID_Msk|addr)
-#define MPU_RBAR_RNR(addr)     (addr)
-#define MPU_STACK_GUARD_BAND_SIZE (UVISOR_SRAM_LENGTH_PROTECTED/8)
-
-/* various MPU flags */
-#define MPU_RASR_AP_PNO_UNO (0x00UL<<MPU_RASR_AP_Pos)
-#define MPU_RASR_AP_PRW_UNO (0x01UL<<MPU_RASR_AP_Pos)
-#define MPU_RASR_AP_PRW_URO (0x02UL<<MPU_RASR_AP_Pos)
-#define MPU_RASR_AP_PRW_URW (0x03UL<<MPU_RASR_AP_Pos)
-#define MPU_RASR_AP_PRO_UNO (0x05UL<<MPU_RASR_AP_Pos)
-#define MPU_RASR_AP_PRO_URO (0x06UL<<MPU_RASR_AP_Pos)
-#define MPU_RASR_XN         (0x01UL<<MPU_RASR_XN_Pos)
-#define MPU_RASR_CB_NOCACHE (0x00UL<<MPU_RASR_B_Pos)
-#define MPU_RASR_CB_WB_WRA  (0x01UL<<MPU_RASR_B_Pos)
-#define MPU_RASR_CB_WT      (0x02UL<<MPU_RASR_B_Pos)
-#define MPU_RASR_CB_WB      (0x03UL<<MPU_RASR_B_Pos)
-#define MPU_RASR_SRD(x)     (((uint32_t)(x))<<MPU_RASR_SRD_Pos)
-
-/* MPU region count */
-#ifndef MPU_REGION_COUNT
-#define MPU_REGION_COUNT 64
-#endif/*MPU_REGION_COUNT*/
-
-typedef struct {
-    uint32_t base;
-    uint32_t end;
-    uint32_t rasr;
-    uint32_t size;
-    uint32_t acl;
-} TMpuRegion;
-
-typedef struct {
-    TMpuRegion *region;
-    uint32_t count;
-} TMpuBox;
-
-static uint32_t g_mpu_region_count, g_box_mem_pos;
-static TMpuRegion g_mpu_list[MPU_REGION_COUNT];
-static TMpuBox g_mpu_box[UVISOR_MAX_BOXES];
-
-static const TMpuRegion* vmpu_fault_find_box_region(uint32_t fault_addr, const TMpuBox *box)
+static const MpuRegion* vmpu_fault_find_region(uint32_t fault_addr)
 {
-    int count;
-    const TMpuRegion *region;
-
-    count = box->count;
-    region = box->region;
-    while (count-- > 0) {
-        if ((fault_addr >= region->base) && (fault_addr < region->end))
-           return region;
-        else
-            region++;
-    }
-
-    return NULL;
-}
-
-static const TMpuRegion* vmpu_fault_find_region(uint32_t fault_addr)
-{
-    const TMpuRegion *region;
+    const MpuRegion *region;
 
     /* check current box if not base */
-    if ((g_active_box) && ((region = vmpu_fault_find_box_region(fault_addr, &g_mpu_box[g_active_box])) != NULL)) {
+    if ((g_active_box) && ((region = vmpu_region_find_for_address(g_active_box, fault_addr)) != NULL)) {
         return region;
     }
 
     /* check base-box */
-    if ((region = vmpu_fault_find_box_region(fault_addr, &g_mpu_box[0])) != NULL) {
+    if ((region = vmpu_region_find_for_address(0, fault_addr)) != NULL) {
         return region;
     }
 
@@ -146,60 +59,62 @@ static const TMpuRegion* vmpu_fault_find_region(uint32_t fault_addr)
 
 uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)
 {
-    const TMpuRegion *region;
+    const MpuRegion *region;
 
     /* return ACL if available */
-    switch (fault_addr) {
-        case (uint32_t) &SCB->SCR:
-            return UVISOR_TACL_UWRITE | UVISOR_TACL_UREAD;
-        default:
-            /* translate fault_addr into its physical address if it is in the bit-banding region */
-            if (fault_addr >= VMPU_PERIPH_BITBAND_START && fault_addr <= VMPU_PERIPH_BITBAND_END) {
-                fault_addr = VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(fault_addr);
-            }
-            else if (fault_addr >= VMPU_SRAM_BITBAND_START && fault_addr <= VMPU_SRAM_BITBAND_END) {
-                fault_addr = VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(fault_addr);
-            }
-
-            /* search base box and active box ACLs */
-            region = vmpu_fault_find_region(fault_addr);
-
-            /* ensure that data fits in selected region */
-            if((fault_addr+size)>region->end)
-                return 0;
-
-            return region ? region->acl : 0;
+    /* FIXME: Use SECURE_ACCESS for SCR! */
+    if (fault_addr == (uint32_t) &SCB->SCR) {
+        return UVISOR_TACL_UWRITE | UVISOR_TACL_UREAD;
     }
+
+    /* translate fault_addr into its physical address if it is in the bit-banding region */
+    if (fault_addr >= VMPU_PERIPH_BITBAND_START && fault_addr <= VMPU_PERIPH_BITBAND_END) {
+        fault_addr = VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(fault_addr);
+    }
+    else if (fault_addr >= VMPU_SRAM_BITBAND_START && fault_addr <= VMPU_SRAM_BITBAND_END) {
+        fault_addr = VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(fault_addr);
+    }
+
+    /* search base box and active box ACLs */
+    if (!(region = vmpu_fault_find_region(fault_addr))) {
+        return 0;
+    }
+
+    /* ensure that data fits in selected region */
+    if((fault_addr + size) > region->end) {
+        return 0;
+    }
+
+    return region->acl;
 }
+
+static int vmpu_mem_push_page_acl_iterator(uint8_t mask, uint8_t index);
 
 static int vmpu_fault_recovery_mpu(uint32_t pc, uint32_t sp, uint32_t fault_addr, uint32_t fault_status)
 {
-    const TMpuRegion *region;
-
-    /* Initialize the round-robin slot pointer. */
-    static uint32_t mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
+    const MpuRegion *region;
+    uint8_t mask, index, page;
 
     /* no recovery possible if the MPU syndrome register is not valid */
     if (fault_status != 0x82) {
         return 0;
     }
 
-    /* find region for faulting address */
-    if ((region = vmpu_fault_find_region(fault_addr)) == NULL)
-        return 0;
+    if (page_allocator_get_active_mask_for_address(fault_addr, &mask, &index, &page) == UVISOR_ERROR_PAGE_OK)
+    {
+        /* Remember this fault. */
+        page_allocator_register_fault(page);
 
-    /* In a secure box the first available region is for the stack, so it must
-     * be excluded from the round-robin. */
-    if (g_active_box != 0 && mpu_slot == ARMv7M_MPU_RESERVED_REGIONS) {
-        mpu_slot++;
+        vmpu_mem_push_page_acl_iterator(mask, UVISOR_PAGE_MAP_COUNT * 4 - 1 - index);
     }
+    else {
+        /* find region for faulting address */
+        if ((region = vmpu_fault_find_region(fault_addr)) == NULL) {
+            return 0;
+        }
 
-    /* FIXME: use random numbers for box number */
-    MPU->RBAR = region->base | mpu_slot++ | MPU_RBAR_VALID_Msk;
-    MPU->RASR = region->rasr;
-
-    if (mpu_slot >= ARMv7M_MPU_REGIONS)
-        mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
+        vmpu_mpu_push(region, 3);
+    }
 
     return 1;
 }
@@ -312,70 +227,62 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
     }
 }
 
+static int vmpu_mem_push_page_acl_iterator(uint8_t mask, uint8_t index)
+{
+    MpuRegion region;
+    uint32_t size = g_page_size * 8;
+    vmpu_region_translate_acl(
+        &region,
+        ((uint32_t) __uvisor_config.page_end - size * (index + 1)),
+        size,
+        UVISOR_TACLDEF_DATA | UVISOR_TACL_EXECUTE | UVISOR_TACL_SUBREGIONS(~mask)
+    );
+    vmpu_mpu_push(&region, 100);
+    /* We do not add more than one region for the page heap. */
+    return 0;
+}
+
 /* FIXME: added very simple MPU region switching - optimize! */
 void vmpu_switch(uint8_t src_box, uint8_t dst_box)
 {
-    int i, mpu_slot;
-    const TMpuBox *box;
-    const TMpuRegion *region;
+    uint32_t dst_count;
+    const MpuRegion * region;
 
     /* DPRINTF("switching from %i to %i\n\r", src_box, dst_box); */
-
     /* Sanity checks */
-    if (!g_mpu_region_count) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions left.\r\n");
-    }
     if (!vmpu_is_box_id_valid(dst_box)) {
         HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The destination box ID is out of range (%u).\r\n", dst_box);
     }
 
-    /* update target box first to make target stack available */
-    mpu_slot = ARMv7M_MPU_RESERVED_REGIONS;
+    vmpu_mpu_invalidate();
+
+    /* Update target box first to make target stack available. */
+    vmpu_region_get_for_box(dst_box, &region, &dst_count);
+
+    /* Only write stack and context ACL for secure boxes. */
     if (dst_box)
     {
-        /* handle target box next */
-        box = &g_mpu_box[dst_box];
-        region = box->region;
-
-        for (i = 0; i < box->count; i++)
-        {
-            if (mpu_slot >= ARMv7M_MPU_REGIONS)
-                 return;
-            MPU->RBAR = region->base | mpu_slot | MPU_RBAR_VALID_Msk;
-            MPU->RASR = region->rasr;
-
-            /* process next slot */
-            region++;
-            mpu_slot++;
-        }
-    }
-
-    /* handle main box last */
-    box = g_mpu_box;
-    region = box->region;
-
-    for (i=0; i<box->count; i++) {
-        if (mpu_slot>=ARMv7M_MPU_REGIONS)
-             return;
-        MPU->RBAR = region->base | mpu_slot | MPU_RBAR_VALID_Msk;
-        MPU->RASR = region->rasr;
-
-        /* process next slot */
+        assert(dst_count);
+        /* Push the stack and context protection ACL into ARMv7M_MPU_REGIONS_STATIC. */
+        vmpu_mpu_push(region, 255);
         region++;
-        mpu_slot++;
+        dst_count--;
     }
 
-    /* clear remaining slots */
-    while(mpu_slot<ARMv7M_MPU_REGIONS)
+    /* Push one ACL for the page heap into place. */
+    page_allocator_iterate_active_page_masks(vmpu_mem_push_page_acl_iterator, PAGE_ALLOCATOR_ITERATOR_DIRECTION_BACKWARD);
+    /* g_mpu_slot may now have been incremented by one, if page heap is used by this box. */
+
+    while (dst_count-- && vmpu_mpu_push(region++, 2)) ;
+
+    if (!dst_box)
     {
-        /* We need to make sure that we disable an enabled MPU region before any
-         * other modification, hence we cannot select the MPU region using the
-         * region number field in the RBAR register. */
-        MPU->RNR = mpu_slot;
-        MPU->RASR = 0;
-        MPU->RBAR = 0;
-        mpu_slot++;
+        /* Handle main box ACLs last. */
+        vmpu_region_get_for_box(0, &region, &dst_count);
+
+        while (dst_count-- && vmpu_mpu_push(region++, 1)) ;
     }
+
 }
 
 void vmpu_load_box(uint8_t box_id)
@@ -386,193 +293,17 @@ void vmpu_load_box(uint8_t box_id)
         HALT_ERROR(NOT_IMPLEMENTED, "currently only box 0 can be loaded");
 }
 
-static int vmpu_region_bits(uint32_t size)
-{
-    int bits;
-
-    bits = vmpu_bits(size)-1;
-
-    /* round up if needed */
-    if((1UL << bits) != size)
-        bits++;
-
-    /* minimum region size is 32 bytes */
-    if(bits<ARMv7M_MPU_ALIGNMENT_BITS)
-        bits=ARMv7M_MPU_ALIGNMENT_BITS;
-
-    assert(bits == UVISOR_REGION_BITS(size));
-    return bits;
-}
-
-static uint32_t vmpu_map_acl(UvisorBoxAcl acl)
-{
-    uint32_t flags;
-    UvisorBoxAcl acl_res;
-
-    /* map generic ACL's to internal ACL's */
-    if(acl & UVISOR_TACL_UWRITE)
-    {
-        acl_res =
-            UVISOR_TACL_UREAD | UVISOR_TACL_UWRITE |
-            UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE;
-        flags = MPU_RASR_AP_PRW_URW;
-    }
-    else
-        if(acl & UVISOR_TACL_UREAD)
-        {
-            if(acl & UVISOR_TACL_SWRITE)
-            {
-                acl_res =
-                    UVISOR_TACL_UREAD |
-                    UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE;
-                flags = MPU_RASR_AP_PRW_URO;
-            }
-            else
-            {
-                acl_res =
-                    UVISOR_TACL_UREAD |
-                    UVISOR_TACL_SREAD;
-                flags = MPU_RASR_AP_PRO_URO;
-            }
-        }
-        else
-            if(acl & UVISOR_TACL_SWRITE)
-            {
-                acl_res =
-                    UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE;
-                flags = MPU_RASR_AP_PRW_UNO;
-            }
-            else
-                if(acl & UVISOR_TACL_SREAD)
-                {
-                    acl_res = UVISOR_TACL_SREAD;
-                    flags = MPU_RASR_AP_PRO_UNO;
-                }
-                else
-                {
-                    acl_res = 0;
-                    flags = MPU_RASR_AP_PNO_UNO;
-                }
-
-    /* handle code-execute flag */
-    if( acl & (UVISOR_TACL_UEXECUTE|UVISOR_TACL_SEXECUTE) )
-        /* can't distinguish between user & supervisor execution */
-        acl_res |= UVISOR_TACL_UEXECUTE | UVISOR_TACL_SEXECUTE;
-    else
-        flags |= MPU_RASR_XN;
-
-    /* check if we meet the expected ACL's */
-    if( (acl_res) != (acl & UVISOR_TACL_ACCESS) )
-        HALT_ERROR(SANITY_CHECK_FAILED, "inferred ACL's (0x%04X) don't match exptected ACL's (0x%04X)\n\r", acl_res, (acl & UVISOR_TACL_ACCESS));
-
-    return flags;
-}
-
-static void vmpu_acl_update_box_region(TMpuRegion *region, uint8_t box_id, void* base, uint32_t size, UvisorBoxAcl acl)
-{
-    uint32_t flags, bits, mask, size_rounded, subregions;
-
-    DPRINTF("\tbox[%i] acl[%02i]={0x%08X,size=%05i,acl=0x%08X,",
-        box_id, g_mpu_region_count, base, size, acl);
-
-    /* verify region alignment */
-    bits = vmpu_region_bits(size);
-    size_rounded = 1UL << bits;
-    if(size_rounded != size)
-    {
-        if((acl & (UVISOR_TACL_SIZE_ROUND_UP|UVISOR_TACL_SIZE_ROUND_DOWN))==0)
-            HALT_ERROR(SANITY_CHECK_FAILED,
-                "box size (%i) not rounded, rounding disabled (rounded=%i)\n\r",
-                size, size_rounded
-            );
-
-        if(acl & UVISOR_TACL_SIZE_ROUND_DOWN)
-        {
-            bits--;
-            if(bits<ARMv7M_MPU_ALIGNMENT_BITS)
-                HALT_ERROR(SANITY_CHECK_FAILED,
-                    "region size (%i) can't be rounded down\n\r",
-                    size
-                );
-            size_rounded = 1UL << bits;
-        }
-    }
-
-    /* check for correctly aligned base address */
-    mask = size_rounded-1;
-    if(((uint32_t)base) & mask)
-        HALT_ERROR(SANITY_CHECK_FAILED, "base address 0x%08X and size"
-        " (%i) are inconsistent\n\r", base, size);
-
-    /* map generic ACL's to internal ACL's */
-    flags = vmpu_map_acl(acl);
-
-    /* calculate subregions from ACL */
-    subregions =
-        ((acl>>UVISOR_TACL_SUBREGIONS_POS) << MPU_RASR_SRD_Pos) &
-        MPU_RASR_SRD_Msk;
-
-    /* enable region & add size */
-    region->rasr =
-        flags | MPU_RASR_ENABLE_Msk |
-        ((uint32_t)(bits-1)<<MPU_RASR_SIZE_Pos) |
-        subregions;
-    region->base = (uint32_t) base;
-    region->end = (uint32_t) base + size_rounded;
-    region->size = size_rounded;
-    region->acl = acl;
-
-    DPRINTF("rounded=%05i}\n\r", size_rounded);
-}
-
-uint32_t vmpu_acl_static_region(uint8_t region, void* base, uint32_t size, UvisorBoxAcl acl)
-{
-    TMpuRegion res;
-
-    /* apply ACL's */
-    vmpu_acl_update_box_region(&res, 0, base, size, acl);
-
-    /* apply RASR & RBAR */
-    MPU->RBAR = res.base | (region & MPU_RBAR_REGION_Msk) | MPU_RBAR_VALID_Msk;
-    MPU->RASR = res.rasr;
-
-    return res.size;
-}
-
-void vmpu_acl_add(uint8_t box_id, void* addr, uint32_t size, UvisorBoxAcl acl)
-{
-    TMpuBox *box;
-    TMpuRegion *region;
-
-    if(g_mpu_region_count>=MPU_REGION_COUNT)
-        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_acl_add ran out of regions\n\r");
-
-    if (!vmpu_is_box_id_valid(box_id)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box id is out of range (%u).\r\n", box_id);
-    }
-
-    /* assign box region pointer */
-    box = &g_mpu_box[box_id];
-    if(!box->region)
-        box->region = &g_mpu_list[g_mpu_region_count];
-
-    /* allocate new MPU region */
-    region = &box->region[box->count];
-    if(region->rasr)
-        HALT_ERROR(SANITY_CHECK_FAILED, "unordered region allocation\n\r");
-
-    /* caclulate MPU RASR/BASR registers */
-    vmpu_acl_update_box_region(region, box_id, addr, size, acl);
-
-    /* take account for new region */
-    box->count++;
-    g_mpu_region_count++;
-}
+extern int vmpu_region_bits(uint32_t size);
 
 void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 {
     int bits, slots_ctx, slots_stack;
     uint32_t size, block_size;
+    static uint32_t box_mem_pos = 0;
+
+    if (box_mem_pos == 0) {
+        box_mem_pos = (uint32_t) __uvisor_config.bss_boxes_start;
+    }
 
     /* handle main box */
     if (box_id == 0)
@@ -594,99 +325,76 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 
     /* ensure that 2/8th are available for protecting stack from
      * context - include rounding error margin */
-    bits = vmpu_region_bits(((stack_size + bss_size)*8)/6);
+    bits = vmpu_region_bits(((stack_size + bss_size) * 8) / 6);
 
     /* ensure MPU region size of at least 256 bytes for
      * subregion support */
-    if(bits<8)
+    if(bits < 8) {
         bits = 8;
+    }
     size = 1UL << bits;
-    block_size = size/8;
+    block_size = size / 8;
 
-    DPRINTF("\tbox[%i] stack=%i bss=%i rounded=%i\n\r" , box_id,
-        stack_size, bss_size, size);
+    DPRINTF("\tbox[%i] stack=%i bss=%i rounded=%i\n\r", box_id, stack_size, bss_size, size);
 
     /* check for correct context address alignment:
      * alignment needs to be a muiltiple of the size */
-    if( (g_box_mem_pos & (size-1))!=0 )
-        g_box_mem_pos = (g_box_mem_pos & ~(size-1)) + size;
+    if( (box_mem_pos & (size - 1)) != 0 ) {
+        box_mem_pos = (box_mem_pos & ~(size - 1)) + size;
+    }
 
     /* check if we have enough memory left */
-    if((g_box_mem_pos + size) > ((uint32_t)__uvisor_config.bss_boxes_end))
-        HALT_ERROR(SANITY_CHECK_FAILED,
-            "memory overflow - increase uvisor memory "
-            "allocation\n\r");
+    if((box_mem_pos + size) > ((uint32_t) __uvisor_config.bss_boxes_end)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "memory overflow - increase uvisor memory allocation\n\r");
+    }
 
     /* round context sizes, leave one free slot */
-    slots_ctx = (bss_size + block_size - 1)/block_size;
-    slots_stack = slots_ctx ? (8-slots_ctx-1) : 8;
+    slots_ctx = (bss_size + block_size - 1) / block_size;
+    slots_stack = slots_ctx ? (8 - slots_ctx - 1) : 8;
 
     /* final sanity checks */
-    if( (slots_ctx * block_size) < bss_size )
+    if( (slots_ctx * block_size) < bss_size ) {
         HALT_ERROR(SANITY_CHECK_FAILED, "slots_ctx underrun\n\r");
-    if( (slots_stack * block_size) < stack_size )
+    }
+    if( (slots_stack * block_size) < stack_size ) {
         HALT_ERROR(SANITY_CHECK_FAILED, "slots_stack underrun\n\r");
+    }
 
     /* allocate context pointer */
-    g_context_current_states[box_id].bss =
-        slots_ctx ? g_box_mem_pos : (uint32_t) NULL;
+    g_context_current_states[box_id].bss = slots_ctx ? box_mem_pos : (uint32_t) NULL;
     /* ensure stack band on top for stack underflow dectection */
-    g_context_current_states[box_id].sp =
-        (g_box_mem_pos + size - UVISOR_STACK_BAND_SIZE);
+    g_context_current_states[box_id].sp = (box_mem_pos + size - UVISOR_STACK_BAND_SIZE);
 
     /* Reset uninitialized secured box context. */
     if (slots_ctx) {
-        memset((void *) g_box_mem_pos, 0, bss_size);
+        memset((void *) box_mem_pos, 0, bss_size);
     }
 
     /* create stack protection region */
-    vmpu_acl_add(
-        box_id, (void*)g_box_mem_pos, size,
-        UVISOR_TACLDEF_STACK | (slots_ctx ? UVISOR_TACL_SUBREGIONS(1UL<<slots_ctx) : 0)
+    size = vmpu_region_add_static_acl(
+        box_id,
+        box_mem_pos,
+        size,
+        UVISOR_TACLDEF_STACK | (slots_ctx ? UVISOR_TACL_SUBREGIONS(1UL << slots_ctx) : 0)
     );
 
     /* move on to the next memory block */
-    g_box_mem_pos += size;
+    box_mem_pos += size;
 }
 
 void vmpu_arch_init(void)
 {
-    uint32_t aligment_mask;
-
-    /* Disable the MPU. */
-    MPU->CTRL = 0;
-    /* Check MPU region alignment using region number zero. */
-    MPU->RNR = 0;
-    MPU->RBAR = MPU_RBAR_ADDR_Msk;
-    aligment_mask = ~MPU->RBAR;
-    MPU->RBAR = 0;
-
-    /* show basic mpu settings */
-    DPRINTF("MPU.REGIONS=%i\r\n", (uint8_t)(MPU->TYPE >> MPU_TYPE_DREGION_Pos));
-    DPRINTF("MPU.ALIGNMENT=0x%08X\r\n", aligment_mask);
-    DPRINTF("MPU.ALIGNMENT_BITS=%i\r\n", vmpu_bits(aligment_mask));
-
-    /* Perform sanity checks. */
-    if (ARMv7M_MPU_REGIONS != ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_REGIONS is inconsistent with actual region count.\n\r");
-    }
-    if (ARMv7M_MPU_ALIGNMENT_BITS != vmpu_bits(aligment_mask)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_ALIGNMENT_BITS are inconsistent with actual MPU alignment\n\r");
-    }
     /* Init protected box memory enumeration pointer. */
     DPRINTF("\n\rbox stack segment start=0x%08X end=0x%08X (length=%i)\n\r",
         __uvisor_config.bss_boxes_start, __uvisor_config.bss_boxes_start,
-        ((uint32_t)__uvisor_config.bss_boxes_end)-((uint32_t)__uvisor_config.bss_boxes_start));
-    g_box_mem_pos = (uint32_t)__uvisor_config.bss_boxes_start;
+        ((uint32_t) __uvisor_config.bss_boxes_end) - ((uint32_t) __uvisor_config.bss_boxes_start));
 
-    /* Enable mem, bus and usage faults. */
-    SCB->SHCSR |= 0x70000;
+    vmpu_mpu_init();
 
     /* Initialize static MPU regions. */
     vmpu_arch_init_hw();
 
-    /* Finally enable the MPU. */
-    MPU->CTRL = MPU_CTRL_ENABLE_Msk|MPU_CTRL_PRIVDEFENA_Msk;
+    vmpu_mpu_lock();
 
     /* Dump MPU configuration in debug mode. */
 #ifndef NDEBUG
@@ -697,89 +405,74 @@ void vmpu_arch_init(void)
 void vmpu_arch_init_hw(void)
 {
     /* Enable the public Flash. */
-    vmpu_acl_static_region(
+    vmpu_mpu_set_static_acl(
         0,
-        (void *) FLASH_ORIGIN,
+        FLASH_ORIGIN,
         ((uint32_t) __uvisor_config.secure_end) - FLASH_ORIGIN,
         UVISOR_TACLDEF_SECURE_CONST | UVISOR_TACL_EXECUTE
     );
 
-    /* Enable the public SRAM. */
-    /* Note: This region can be larger than the physical SRAM. */
-    /* Note: This uses the host-related symbols as uVisor might be placed in a
-     *       different SRAM. If the uVisor shares the SRAM with the host, these
-     *       symbols will be identical to the uVisor-related ones. */
-    vmpu_acl_static_region(
-        1,
-        (void *) HOST_SRAM_ORIGIN_MIN,
-        UVISOR_REGION_ROUND_UP(HOST_SRAM_LENGTH_MAX),
-        UVISOR_TACLDEF_DATA | UVISOR_TACL_EXECUTE
-    );
-
-#if !defined(UVISOR_IN_STANDALONE_SRAM)
-    /* Calculate the subregion mask based on the __uvisor_bss_end symbol.
-     * The BSS section occupied by uVisor in the host linker script must be
-     * aligned to an MPU subregion boundary, so that the maximum memory wasted
-     * for padding purposes is 1/8 of the total uVisor BSS section. */
-    uint32_t original_size = (uint32_t) __uvisor_config.bss_end - SRAM_ORIGIN;
-    uint32_t rounded_size = UVISOR_REGION_ROUND_UP(original_size);
-    uint32_t subregions_size = rounded_size / 8;
-    if (original_size % subregions_size != 0) {
+    /* Enable the public SRAM:
+     *
+     * We use one region for this, which start at SRAM origin (which is always
+     * aligned) and has a power-of-two size that is equal or _larger_ than SRAM.
+     * This means the region may end _behind_ the end of SRAM!
+     *
+     * At the beginning of SRAM uVisor places its private BSS section and behind
+     * that the page heap. In order to use only one region, we require the end of
+     * the page heap to align with 1/8th of the region size, so that we can use
+     * the subregion mask.
+     * The page heap reduces the memory wastage to less than one page size, by
+     * "growing" the page heap downwards from the subregion alignment towards
+     * the uVisor bss.
+     *
+     * Note: The correct alignment needs to be done in the host linkerscript.
+     *       Use `ALIGN( (1 << LOG2CEIL(LENGTH(SRAM)) / 8 )` for GNU linker.
+     *
+     *     2^n     <-- region end
+     *     ...
+     * .---------. <-- uvisor_config.sram_end
+     * |  box 0  |
+     * | public  |
+     * | memory  |
+     * +---------+ <-- uvisor_config.page_end: n/8th of _region_ size (not SRAM size)
+     * |  page   |
+     * |  heap   |
+     * +---------+ <-- aligned to page size
+     * | wastage | <-- wasted SRAM is less than 1 page size
+     * +---------+ <-- uvisor_config.page_start
+     * |  uVisor |
+     * |   bss   |
+     * '---------' <-- uvisor_config.sram_start, region start
+     *
+     * Example: The region size of a 96kB SRAM will be 128kB, and the page heap
+     *          end will have to be aligned to 16kB, _not_ 12kB (= 96kB / 8).
+     *
+     * Note: In case the uVisor bss section is moved to another memory region
+     *       (tightly-coupled memory for example), the page heap remains and
+     *       the same considerations apply. Therefore the uVisor bss section
+     *       location has no impact on this.
+     */
+    /* Calculate the region size by rounding up the SRAM size to the next power-of-two. */
+    const uint32_t total_size = (1 << vmpu_region_bits((uint32_t) __uvisor_config.sram_end - (uint32_t) __uvisor_config.sram_start));
+    /* The alignment is 1/8th of the region size = rounded up SRAM size. */
+    const uint32_t subregions_size = total_size / 8;
+    const uint32_t protected_size = (uint32_t) __uvisor_config.page_end - (uint32_t) __uvisor_config.sram_start;
+    /* The protected size must be aligned to the subregion size. */
+    if (protected_size % subregions_size != 0) {
         HALT_ERROR(SANITY_CHECK_FAILED,
-                   "The __uvisor_bss_end symbol (0x%08X)is not aligned to an MPU subregion boundary.",
-                   (uint32_t) __uvisor_config.bss_end);
+                   "The __uvisor_page_end symbol (0x%08X) is not aligned to an MPU subregion boundary.",
+                   (uint32_t) __uvisor_config.page_end);
     }
-    uint8_t subregions_mask = (uint8_t) ~(0xFFUL >> (8 - (original_size / subregions_size)));
+    /* Note: It's called the subregion _disable_ mask, so setting one bit in it _disables_ the
+     *       permissions in this subregion. Totally not confusing, amiright!? */
+    const uint8_t subregions_disable_mask = (uint8_t) ((1UL << (protected_size / subregions_size)) - 1UL);
 
-    /* Protect the uVisor SRAM.
-     * This region needs protection only if uVisor shares the SRAM with the
-     * host. The configuration requires that uVisor is right at the beginning of
-     * the SRAM. If not, uVisor would end up owning a memory regions that
-     * contains non-uVisor data. */
-    vmpu_acl_static_region(
-        2,
-        (void *) SRAM_ORIGIN,
-        rounded_size,
-        UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE | UVISOR_TACL_SUBREGIONS(subregions_mask)
+    /* Unlock the upper SRAM subregion only. */
+    vmpu_mpu_set_static_acl(
+        1,
+        (uint32_t) __uvisor_config.sram_start,
+        total_size,
+        UVISOR_TACLDEF_DATA | UVISOR_TACL_UEXECUTE | UVISOR_TACL_SUBREGIONS(subregions_disable_mask)
     );
-#endif /* !defined(UVISOR_IN_STANDALONE_SRAM) */
-}
-
-int vmpu_is_region_size_valid(uint32_t size)
-{
-    /* Get the MSB of the size. */
-    const int bits = vmpu_bits(size) - 1;
-    if (bits < ARMv7M_MPU_ALIGNMENT_BITS || 29 < bits) {
-        /* 2^5 == 32, which is the minimum region size. */
-        /* 2^29 == 512M, which is the maximum region size. */
-        return 0;
-    }
-    /* Compute the size from MSB. */
-    const int bit_size = (1UL << bits);
-    /* There is no round up. */
-
-    /* We only care about an exact match! */
-    return (bit_size == size);
-}
-
-uint32_t vmpu_round_up_region(uint32_t addr, uint32_t size)
-{
-    if (!vmpu_is_region_size_valid(size)) {
-        /* Region size must be valid! */
-        return 0;
-    }
-    /* Size is 2*N, can be used directly for alignment. */
-    /* Create the LSB mask: Example 0x80 -> 0x7F. */
-    const uint32_t mask = size - 1;
-    /* Mask is 31 <= mask <= (1 << 29) - 1. */
-
-    /* Adding the mask can overflow. */
-    const uint32_t rounded_addr = addr + mask;
-    /* Check for overflow. */
-    if (rounded_addr < addr) {
-        /* This means the address was too large to align. */
-        return 0;
-    }
-    /* Mask the rounded address to get the aligned address. */
-    return (rounded_addr & ~mask);
 }

--- a/core/system/src/mpu/vmpu_armv7m_mpu.c
+++ b/core/system/src/mpu/vmpu_armv7m_mpu.c
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <uvisor.h>
+#include "debug.h"
+#include "context.h"
+#include "halt.h"
+#include "memory_map.h"
+#include "vmpu.h"
+#include "vmpu_mpu.h"
+
+/* This file contains the configuration-specific symbols. */
+#include "configurations.h"
+
+/* MPU region count */
+#ifndef MPU_ACL_COUNT
+#define MPU_ACL_COUNT 64
+#endif/*MPU_ACL_COUNT*/
+
+/* set default minimum region address alignment */
+#ifndef ARMv7M_MPU_ALIGNMENT_BITS
+#define ARMv7M_MPU_ALIGNMENT_BITS 5
+#endif/*ARMv7M_MPU_ALIGNMENT_BITS*/
+
+typedef struct
+{
+    MpuRegion * regions;
+    uint32_t count;
+} MpuRegionSlice;
+
+static uint16_t g_mpu_region_count;
+static MpuRegion g_mpu_region[MPU_ACL_COUNT];
+static MpuRegionSlice g_mpu_box_region[UVISOR_MAX_BOXES];
+
+/* various MPU flags */
+#define MPU_RASR_AP_PNO_UNO (0x00UL<<MPU_RASR_AP_Pos)
+#define MPU_RASR_AP_PRW_UNO (0x01UL<<MPU_RASR_AP_Pos)
+#define MPU_RASR_AP_PRW_URO (0x02UL<<MPU_RASR_AP_Pos)
+#define MPU_RASR_AP_PRW_URW (0x03UL<<MPU_RASR_AP_Pos)
+#define MPU_RASR_AP_PRO_UNO (0x05UL<<MPU_RASR_AP_Pos)
+#define MPU_RASR_AP_PRO_URO (0x06UL<<MPU_RASR_AP_Pos)
+#define MPU_RASR_XN         (0x01UL<<MPU_RASR_XN_Pos)
+#define MPU_RASR_CB_NOCACHE (0x00UL<<MPU_RASR_B_Pos)
+#define MPU_RASR_CB_WB_WRA  (0x01UL<<MPU_RASR_B_Pos)
+#define MPU_RASR_CB_WT      (0x02UL<<MPU_RASR_B_Pos)
+#define MPU_RASR_CB_WB      (0x03UL<<MPU_RASR_B_Pos)
+#define MPU_RASR_SRD(x)     (((uint32_t)(x))<<MPU_RASR_SRD_Pos)
+
+int vmpu_is_region_size_valid(uint32_t size)
+{
+    /* Get the MSB of the size. */
+    const int bits = vmpu_bits(size) - 1;
+    if (bits < ARMv7M_MPU_ALIGNMENT_BITS || 29 < bits) {
+        /* 2^5 == 32, which is the minimum region size. */
+        /* 2^29 == 512M, which is the maximum region size. */
+        return 0;
+    }
+    /* Compute the size from MSB. */
+    const int bit_size = (1UL << bits);
+    /* There is no round up. */
+
+    /* We only care about an exact match! */
+    return (bit_size == size);
+}
+
+uint32_t vmpu_round_up_region(uint32_t addr, uint32_t size)
+{
+    if (!vmpu_is_region_size_valid(size)) {
+        /* Region size must be valid! */
+        return 0;
+    }
+    /* Size is 2*N, can be used directly for alignment. */
+    /* Create the LSB mask: Example 0x80 -> 0x7F. */
+    const uint32_t mask = size - 1;
+    /* Mask is 31 <= mask <= (1 << 29) - 1. */
+
+    /* Adding the mask can overflow. */
+    const uint32_t rounded_addr = addr + mask;
+    /* Check for overflow. */
+    if (rounded_addr < addr) {
+        /* This means the address was too large to align. */
+        return 0;
+    }
+    /* Mask the rounded address to get the aligned address. */
+    return (rounded_addr & ~mask);
+}
+
+uint8_t vmpu_region_bits(uint32_t size)
+{
+    uint8_t bits;
+
+    bits = vmpu_bits(size) - 1;
+
+    /* round up if needed */
+    if((1UL << bits) != size) {
+        bits++;
+    }
+
+    /* minimum region size is 32 bytes */
+    if(bits < ARMv7M_MPU_ALIGNMENT_BITS) {
+        bits = ARMv7M_MPU_ALIGNMENT_BITS;
+    }
+
+    assert(bits == UVISOR_REGION_BITS(size));
+    return bits;
+}
+
+static uint32_t vmpu_map_acl(UvisorBoxAcl acl)
+{
+    uint32_t flags;
+    UvisorBoxAcl acl_res;
+
+    /* Map generic ACLs to internal ACLs. */
+    if(acl & UVISOR_TACL_UWRITE) {
+        acl_res =
+            UVISOR_TACL_UREAD | UVISOR_TACL_UWRITE |
+            UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE;
+        flags = MPU_RASR_AP_PRW_URW;
+    }
+    else {
+        if(acl & UVISOR_TACL_UREAD) {
+            if(acl & UVISOR_TACL_SWRITE) {
+                acl_res =
+                    UVISOR_TACL_UREAD |
+                    UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE;
+                flags = MPU_RASR_AP_PRW_URO;
+            }
+            else {
+                acl_res =
+                    UVISOR_TACL_UREAD |
+                    UVISOR_TACL_SREAD;
+                flags = MPU_RASR_AP_PRO_URO;
+            }
+        }
+        else {
+            if(acl & UVISOR_TACL_SWRITE) {
+                acl_res =
+                    UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE;
+                flags = MPU_RASR_AP_PRW_UNO;
+            }
+            else {
+                if(acl & UVISOR_TACL_SREAD) {
+                    acl_res = UVISOR_TACL_SREAD;
+                    flags = MPU_RASR_AP_PRO_UNO;
+                }
+                else {
+                    acl_res = 0;
+                    flags = MPU_RASR_AP_PNO_UNO;
+                }
+            }
+        }
+    }
+
+    /* Handle code-execute flag. */
+    if( acl & (UVISOR_TACL_UEXECUTE | UVISOR_TACL_SEXECUTE) ) {
+        /* Can't distinguish between user & supervisor execution. */
+        acl_res |= UVISOR_TACL_UEXECUTE | UVISOR_TACL_SEXECUTE;
+    }
+    else {
+        flags |= MPU_RASR_XN;
+    }
+
+    /* Check if we meet the expected ACLs. */
+    if( acl_res != (acl & UVISOR_TACL_ACCESS) ) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "inferred ACL's (0x%04X) don't match exptected ACL's (0x%04X)\n", acl_res, (acl & UVISOR_TACL_ACCESS));
+    }
+
+    return flags;
+}
+
+uint32_t vmpu_region_translate_acl(MpuRegion * const region, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    uint32_t config, bits, mask, size_rounded, subregions;
+
+    /* verify region alignment */
+    bits = vmpu_region_bits(size);
+    size_rounded = 1UL << bits;
+
+    if(size_rounded != size) {
+        if ((acl & (UVISOR_TACL_SIZE_ROUND_UP | UVISOR_TACL_SIZE_ROUND_DOWN)) == 0) {
+            HALT_ERROR(SANITY_CHECK_FAILED, "box size (%i) not rounded, rounding disabled (rounded=%i)\n", size, size_rounded);
+        }
+
+        if (acl & UVISOR_TACL_SIZE_ROUND_DOWN) {
+            bits--;
+            if(bits < ARMv7M_MPU_ALIGNMENT_BITS) {
+                HALT_ERROR(SANITY_CHECK_FAILED, "region size (%i) can't be rounded down\n", size);
+            }
+            size_rounded = 1UL << bits;
+        }
+    }
+
+    /* check for correctly aligned base address */
+    mask = size_rounded - 1;
+
+    if(start & mask) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "start address 0x%08X and size (%i) are inconsistent\n", start, size);
+    }
+
+    /* map generic ACL's to internal ACL's */
+    config = vmpu_map_acl(acl);
+
+    /* calculate subregions from ACL */
+    subregions = ((acl >> UVISOR_TACL_SUBREGIONS_POS) << MPU_RASR_SRD_Pos) & MPU_RASR_SRD_Msk;
+
+    /* enable region & add size */
+    region->config = config | MPU_RASR_ENABLE_Msk | ((uint32_t) (bits - 1) << MPU_RASR_SIZE_Pos) | subregions;
+    region->start = start;
+    region->end = start + size_rounded;
+    region->acl = acl;
+
+    return size_rounded;
+}
+
+uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    MpuRegion * region;
+    MpuRegionSlice * box;
+    uint32_t rounded_size;
+
+    if(g_mpu_region_count >= MPU_ACL_COUNT) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_add_static_acl: No more regions to allocate!\n");
+    }
+
+    if (!vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_add_static_acl: The box id (%u) is out of range.\n", box_id);
+    }
+
+    box = &g_mpu_box_region[box_id];
+    if (!box->regions) {
+        box->regions = &g_mpu_region[g_mpu_region_count];
+    }
+
+    region = &box->regions[box->count];
+    if (region->config) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "unordered region allocation\n");
+    }
+
+    rounded_size = vmpu_region_translate_acl(region, start, size, acl);
+
+    box->count++;
+    g_mpu_region_count++;
+
+    return rounded_size;
+}
+
+bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, uint32_t * const count)
+{
+    if (!g_mpu_region_count) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions.\r\n");
+    }
+
+    if (box_id < UVISOR_MAX_BOXES) {
+        *count = g_mpu_box_region[box_id].count;
+        *region = *count ? g_mpu_box_region[box_id].regions : NULL;
+        return true;
+    }
+    return false;
+}
+
+MpuRegion * vmpu_region_find_for_address(uint8_t box_id, uint32_t address)
+{
+    int count;
+    MpuRegion * region;
+
+    count = g_mpu_box_region[box_id].count;
+    region = g_mpu_box_region[box_id].regions;
+    for (; count-- > 0; region++) {
+        if ((region->start <= address) && (address < region->end)) {
+            return region;
+        }
+    }
+
+    return NULL;
+}
+
+/* Region management */
+
+/* MPU access */
+
+/* set default MPU region count */
+#ifndef ARMv7M_MPU_REGIONS
+#define ARMv7M_MPU_REGIONS 8
+#endif/*ARMv7M_MPU_REGIONS*/
+
+/* The ARMv7-M MPU has 8 MPU regions plus one background region.
+ * Region 0 and 1 are used to unlock Application RAM and Flash.
+ * When switching into a secure box, region 2 is used to protect the boxes
+ * stack and context.
+ * If a box uses the page heap, the next region is used to protect it.
+ * This leaves 4 to 6 MPU regions for round robin scheduling:
+ *
+ *      8      <-- End of MPU regions, ARMv7M_MPU_REGIONS_MAX
+ * +---------+
+ * |    7    |
+ * |   ...   |
+ * |  2/3/4  | <-- Start of round robin
+ * +---------+
+ * |   2/3   | <-- Optional Box Pages
+ * +---------+
+ * |    2    | <-- Secure Box Stack + Context, ARMv7M_MPU_REGIONS_STATIC
+ * +---------+
+ * |    1    | <-- Application SRAM unlock
+ * |    0    | <-- Application Flash unlock
+ * +---------+
+ */
+#define ARMv7M_MPU_REGIONS_STATIC 2
+#define ARMv7M_MPU_REGIONS_MAX (ARMv7M_MPU_REGIONS)
+
+/* MPU helper macros */
+#define MPU_RBAR(region,addr)   (((uint32_t)(region))|MPU_RBAR_VALID_Msk|addr)
+#define MPU_RBAR_RNR(addr)     (addr)
+
+static uint8_t g_mpu_slot = ARMv7M_MPU_REGIONS_STATIC;
+static uint8_t g_mpu_priority[ARMv7M_MPU_REGIONS_MAX];
+
+void vmpu_mpu_init(void)
+{
+    uint32_t aligment_mask;
+
+    /* Disable the MPU. */
+    MPU->CTRL = 0;
+    /* Check MPU region alignment using region number zero. */
+    MPU->RNR = 0;
+    MPU->RBAR = MPU_RBAR_ADDR_Msk;
+    aligment_mask = ~MPU->RBAR;
+    MPU->RBAR = 0;
+
+    /* Enable mem, bus and usage faults. */
+    SCB->SHCSR |= 0x70000;
+
+    /* show basic mpu settings */
+    DPRINTF("MPU.REGIONS=%i\r\n", (uint8_t)(MPU->TYPE >> MPU_TYPE_DREGION_Pos));
+    DPRINTF("MPU.ALIGNMENT=0x%08X\r\n", aligment_mask);
+    DPRINTF("MPU.ALIGNMENT_BITS=%i\r\n", vmpu_bits(aligment_mask));
+
+    /* Perform sanity checks. */
+    if (ARMv7M_MPU_REGIONS != ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_REGIONS is inconsistent with actual region count.\n\r");
+    }
+    if (ARMv7M_MPU_ALIGNMENT_BITS != vmpu_bits(aligment_mask)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_ALIGNMENT_BITS are inconsistent with actual MPU alignment\n\r");
+    }
+}
+
+void vmpu_mpu_lock(void)
+{
+    /* Finally enable the MPU. */
+    MPU->CTRL = MPU_CTRL_ENABLE_Msk | MPU_CTRL_PRIVDEFENA_Msk;
+}
+
+uint32_t vmpu_mpu_set_static_acl(uint8_t index, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    MpuRegion region;
+    uint32_t rounded_size;
+
+    if (index >= ARMv7M_MPU_REGIONS_STATIC) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_mpu_set_static_region: Invalid region index (%u)!\n", index);
+        return 0;
+    }
+
+    rounded_size = vmpu_region_translate_acl(&region, start, size, acl);
+
+    /* apply RASR & RBAR */
+    MPU->RBAR = MPU_RBAR(index, region.start);
+    MPU->RASR = region.config;
+    g_mpu_priority[index] = 255;
+
+    return rounded_size;
+}
+
+void vmpu_mpu_invalidate(void)
+{
+    g_mpu_slot = ARMv7M_MPU_REGIONS_STATIC;
+    uint8_t slot = ARMv7M_MPU_REGIONS_STATIC;
+    while (slot < ARMv7M_MPU_REGIONS_MAX) {
+        /* We need to make sure that we disable an enabled MPU region before any
+         * other modification, hence we cannot select the MPU region using the
+         * region number field in the RBAR register. */
+        MPU->RNR = slot;
+        MPU->RASR = 0;
+        MPU->RBAR = 0;
+        g_mpu_priority[slot] = 0;
+        slot++;
+    }
+}
+
+bool vmpu_mpu_push(const MpuRegion * const region, uint8_t priority)
+{
+    if (!priority) priority = 1;
+
+    const uint8_t start_slot = g_mpu_slot;
+    uint8_t viable_slot = start_slot;
+
+    do {
+        if (++g_mpu_slot > ARMv7M_MPU_REGIONS_MAX) {
+            g_mpu_slot = ARMv7M_MPU_REGIONS_STATIC;
+        }
+
+        if (g_mpu_priority[g_mpu_slot] < priority) {
+            /* We can place this region in here. */
+            MPU->RBAR = MPU_RBAR(g_mpu_slot, region->start);
+            MPU->RASR = region->config;
+            g_mpu_priority[g_mpu_slot] = priority;
+            return true;
+        }
+        viable_slot = g_mpu_slot;
+    }
+    while (g_mpu_slot != start_slot);
+
+    /* We did not find a slot with a lower priority, so just take the next
+     * position that does not have the highest priority. */
+    MPU->RBAR = MPU_RBAR(viable_slot, region->start);
+    MPU->RASR = region->config;
+    g_mpu_priority[viable_slot] = priority;
+
+    return true;
+}

--- a/core/system/src/mpu/vmpu_freescale_k64_mem.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mem.c
@@ -17,360 +17,67 @@
 #include <uvisor.h>
 #include "halt.h"
 #include "vmpu.h"
+#include "vmpu_mpu.h"
+#include "context.h"
 #include "vmpu_freescale_k64_mem.h"
 #include "page_allocator_faults.h"
-
-/* The K64F has 12 MPU regions, however, we use region 0 as the background
- * region with `UVISOR_TACL_BACKGROUND` as permissions.
- * Region 1 and 2 are used to unlock Application SRAM and Flash.
- * Therefore 9 MPU regions are available for user ACLs.
- * Region 3 and 4 are used to protect the current box stack and context.
- * This leaves 6 MPU regions for round robin scheduling:
- *
- *     12      <-- End of MPU regions, K64F_MPU_REGIONS_MAX
- * +---------+
- * |   11    |
- * |   ...   |
- * |    5    | <-- Box Pages, K64F_MPU_REGIONS_USER
- * +---------+
- * |    4    | <-- Box Context
- * |    3    | <-- Box Stack, K64F_MPU_REGIONS_STATIC
- * +---------+
- * |    2    | <-- Application Flash unlock
- * |    1    | <-- Application SRAM unlock
- * |    0    | <-- Background region
- * +---------+
- */
-#define K64F_MPU_REGIONS_STATIC 3
-#define K64F_MPU_REGIONS_USER 5
-#define K64F_MPU_REGIONS_MAX 12
-
-typedef struct
-{
-    uint32_t start_addr;
-    uint32_t end_addr;
-    uint32_t permissions;
-    uint32_t acl;
-} TMemACL;
-
-typedef struct
-{
-    TMemACL *acl;
-    uint32_t count;
-} TBoxACL;
-
-uint32_t g_mem_acl_count, g_mpu_slot;
-static TMemACL g_mem_acl[UVISOR_MAX_ACLS];
-static TBoxACL g_mem_box[UVISOR_MAX_BOXES];
-
-int vmpu_mem_push_page_acl(uint32_t start_addr, uint32_t end_addr)
-{
-    MPU_Region * region;
-
-    /* Check that start and end address are aligned to 32-byte. */
-    if (start_addr & 0x1F || end_addr & 0x1F) {
-        return -1;
-    }
-
-    /* Insert into MPU regions in RR fashion. */
-    region = (MPU_Region *) MPU->WORD[g_mpu_slot];
-    region->STARTADDR = start_addr;
-    region->ENDADDR = end_addr;
-    /* Permissions are fixed to only allow unprivileged write/read/execute. Duh. */
-    region->PERMISSIONS = 0x1E;
-    region->CONTROL = 1;
-
-    /* DPRINTF("Inserting page region [0x%08x, 0x%08x] at MPU slot %u\n", start_addr, end_addr, g_mpu_slot); */
-    g_mpu_slot++;
-
-    /* Handle slot index overflow. */
-    if (g_mpu_slot >= K64F_MPU_REGIONS_MAX) {
-        g_mpu_slot = K64F_MPU_REGIONS_USER;
-    }
-    return 0;
-}
-
-/* FIXME - test for actual ACLs */
-uint32_t vmpu_fault_find_acl_mem(uint8_t box_id, uint32_t fault_addr, uint32_t size)
-{
-    return 0;
-}
 
 /* This is the iterator callback for inserting all page heap ACLs into to the
  * MPU during `vmpu_mem_switch()`. */
 static int vmpu_mem_push_page_acl_iterator(uint32_t start_addr, uint32_t end_addr, uint8_t page)
 {
-    /* Insert the MPU region at the `g_mpu_slot`. */
-    vmpu_mem_push_page_acl(start_addr, end_addr);
+    (void) page;
+    MpuRegion region = {.start = start_addr, .end = end_addr, .config = 0x1E};
     /* We only continue if we have not wrapped around the end of the MPU regions yet. */
-    return (g_mpu_slot > K64F_MPU_REGIONS_USER);
+    return vmpu_mpu_push(&region, 100);
 }
 
-void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box)
+int vmpu_mem_push_page_acl(uint32_t start_addr, uint32_t end_addr)
 {
-    uint32_t t, u, dst_count;
-    MPU_Region * region;
-    TBoxACL *box;
-    TMemACL *rgd;
-
-    /* Sanity checks. */
-    if (!vmpu_is_box_id_valid(src_box)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The source box ID is out of range (%u).\r\n", src_box);
-    }
-    if (!vmpu_is_box_id_valid(dst_box)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The destination box ID is out of range (%u).\n", dst_box);
+    /* Check that start and end address are aligned to 32-byte. */
+    if (start_addr & 0x1F || end_addr & 0x1F) {
+        return -1;
     }
 
-    box = &g_mem_box[dst_box];
-
-    /* For box zero, only copy the page heap ACLs, disable the remaining pages
-     * and then return. */
-    if(src_box && !dst_box) {
-        g_mpu_slot = K64F_MPU_REGIONS_STATIC;
-        t = K64F_MPU_REGIONS_MAX - K64F_MPU_REGIONS_STATIC;
-        if (page_allocator_iterate_active_pages(vmpu_mem_push_page_acl_iterator) < t) {
-            /* Disable all remaining regions. */
-            for (t = g_mpu_slot; t < K64F_MPU_REGIONS_MAX; t++) {
-                ((MPU_Region *) MPU->WORD[t])->CONTROL = 0;
-            }
-        }
-        return;
-    }
-
-    dst_count = g_mem_box[dst_box].count;
-    assert(dst_count);
-
-    /* already populated - ensure to fill boxes unfragmented */
-    rgd = box->acl;
-    assert(rgd);
-
-    /* Update MPU regions:
-     * We assume that the first two ACLs belonging to the box are the stack
-     * and context ACLs. Therefore we start at index K64F_MPU_REGIONS_STATIC.
-     * We opportunistically copy all remaining ACLs into the MPU regions, until
-     * the regions run out. The remaining ACLs are switched in on demand. */
-    u = K64F_MPU_REGIONS_STATIC + dst_count;
-    /* The round robin _starts_ at the first free MPU region _after_ the box
-     * ACLs have been copied. */
-    g_mpu_slot = u;
-    if (u >= K64F_MPU_REGIONS_MAX) {
-        /* Clamp u to K64F_MPU_REGIONS_MAX. */
-        u = K64F_MPU_REGIONS_MAX;
-        /* If no MPU regions are free anymore, set the RR marker at the
-         * of the USER MPU regions (leaving stack and context intact!). */
-        g_mpu_slot = K64F_MPU_REGIONS_USER;
-    } else {
-        /* Copy the active page heap ACLs into the MPU regions:
-         * This will start at index `g_mpu_slot` and continue to `K64F_MPU_REGIONS_MAX`. */
-        /* FIXME: Use page fault count to prioritize which pages are enabled! */
-        t = K64F_MPU_REGIONS_MAX - g_mpu_slot;
-        if (page_allocator_iterate_active_pages(vmpu_mem_push_page_acl_iterator) < t) {
-            /* Disable all remaining regions. */
-            for (t = g_mpu_slot; t < K64F_MPU_REGIONS_MAX; t++) {
-                ((MPU_Region *) MPU->WORD[t])->CONTROL = 0;
-            }
-        }
-    }
-    /* Copy the ACLs into the MPU regions. */
-    for (t = K64F_MPU_REGIONS_STATIC; t < u; t++, rgd++) {
-        region = (MPU_Region *) MPU->WORD[t];
-        region->STARTADDR = rgd->start_addr;
-        region->ENDADDR = rgd->end_addr;
-        region->PERMISSIONS = rgd->permissions;
-        region->CONTROL = 1;
-    }
-}
-
-static int vmpu_mem_overlap(uint32_t s1, uint32_t e1, uint32_t s2, uint32_t e2)
-{
-    return (
-        (s1>e1)                ||
-        (s2>e2)                || /* punish messing with overlap */
-        ((s1<=s2) && (e1> s2)) ||
-        ((s1< e2) && (e1>=e2)) ||
-        ((s1>=s2) && (e1<=e2))
-        );
-}
-
-static int vmpu_mem_add_int(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
-{
-    uint32_t perm, end, t;
-    TBoxACL *box;
-    TMemACL *rgd;
-
-    DPRINTF(" mem_acl[%i]: 0x%08X-0x%08X (size=%i, acl=0x%04X)\n",
-            g_mem_acl_count, start, ((uint32_t)start)+size, size, acl);
-
-    /* handle empty or fully protected regions */
-    if(!size || !(acl & (UVISOR_TACL_UACL|UVISOR_TACL_SACL)))
-        return 1;
-
-    /* ensure that ACL size can be rounded up to slot size */
-    if(size % 32)
-    {
-        if(acl & UVISOR_TACL_SIZE_ROUND_DOWN)
-            size = UVISOR_REGION_ROUND_DOWN(size);
-        else
-            if(acl & UVISOR_TACL_SIZE_ROUND_UP)
-                size = UVISOR_REGION_ROUND_UP(size);
-            else
-                {
-                    DPRINTF("use UVISOR_TACL_SIZE_ROUND_UP/*_DOWN to round ACL size\n");
-                    return -21;
-                }
-    }
-
-    /* ensure that ACL base is a multiple of 32 */
-    if((((uint32_t)start) % 32) != 0)
-    {
-        DPRINTF("start address needs to be aligned on a 32 bytes border\n");
-        return -22;
-    }
-
-    /* get box config */
-    if (!vmpu_is_box_id_valid(box_id)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The box ID is out of range (%u).\n", box_id);
-    }
-    box = &g_mem_box[box_id];
-
-    /* initialize acl pointer */
-    if(!box->acl)
-    {
-        /* check for integer overflow */
-        if( g_mem_acl_count >= UVISOR_MAX_ACLS )
-            return -24;
-        box->acl = &g_mem_acl[g_mem_acl_count];
-    }
-
-    /* check for precise overflow */
-    if( (&box->acl[box->count] - g_mem_acl)>=(UVISOR_MAX_ACLS-1) )
-        return -25;
-
-    /* check if region overlaps */
-    end = ((uint32_t) start) + size;
-    rgd = g_mem_acl;
-    for(t=0; t<g_mem_acl_count; t++, rgd++)
-        if(vmpu_mem_overlap((uint32_t) start, end, rgd->start_addr, rgd->end_addr))
-        {
-            DPRINTF("detected overlap with ACL %i (0x%08X-0x%08X)\n",
-                t, rgd->start_addr, rgd->end_addr);
-
-            /* handle permitted overlaps */
-            if(!((rgd->acl & UVISOR_TACL_SHARED) &&
-                (acl & UVISOR_TACL_SHARED)))
-                return -26;
-        }
-
-    /* get mem ACL */
-    rgd = &box->acl[box->count];
-    /* already populated - ensure to fill boxes unfragmented */
-    if(rgd->acl)
-        return -27;
-
-    /* remember original ACL */
-    rgd->acl = acl;
-    /* start address, aligned tro 32 bytes */
-    rgd->start_addr = (uint32_t) start;
-    /* end address, aligned tro 32 bytes */
-    rgd->end_addr = end;
-
-    /* handle user permissions */
-    perm = (acl & UVISOR_TACL_USER) ?  acl & UVISOR_TACL_UACL : 0;
-
-    /* if S-perms are identical to U-perms, refer from S to U */
-    if(((acl & UVISOR_TACL_SACL)>>3) == perm)
-        perm |= 3UL << 3;
-    else
-        /* handle detailed supervisor permissions */
-        switch(acl & UVISOR_TACL_SACL)
-        {
-            case UVISOR_TACL_SREAD|UVISOR_TACL_SWRITE|UVISOR_TACL_SEXECUTE:
-                perm |= 0UL << 3;
-                break;
-
-            case UVISOR_TACL_SREAD|UVISOR_TACL_SEXECUTE:
-                perm |= 1UL << 3;
-                break;
-
-            case UVISOR_TACL_SREAD|UVISOR_TACL_SWRITE:
-                perm |= 2UL << 3;
-                break;
-
-            default:
-                DPRINTF("chosen supervisor ACL's are not supported by hardware (0x%08X)\n", acl);
-                return -7;
-        }
-    rgd->permissions = perm;
-
-    /* increment ACL count */
-    box->count++;
-    /* increment total ACL count */
-    g_mem_acl_count++;
-
-    return 1;
-}
-
-int vmpu_mem_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
-{
-    if(    (((uint32_t*)start)>=__uvisor_config.bss_boxes_start) &&
-        ((((uint32_t)start)+size)<=(uint32_t)__uvisor_config.bss_boxes_end) )
-    {
-        DPRINTF("\t\tSECURE_STACK\n");
-
-        /* disallow user to provide stack region ACL's */
-        if(acl & UVISOR_TACL_USER)
-            return -1;
-
-        return vmpu_mem_add_int(box_id, start, size,
-                                (acl & UVISOR_TACLDEF_STACK) | UVISOR_TACL_STACK | UVISOR_TACL_USER);
-    }
+    vmpu_mem_push_page_acl_iterator(start_addr, end_addr, g_active_box);
 
     return 0;
 }
 
-void vmpu_mem_init(void)
+void vmpu_mem_switch(uint8_t src_box, uint8_t dst_box)
 {
-    int res;
-    uint32_t t;
-    TMemACL * rgd;
-    MPU_Region * region;
+    uint32_t dst_count;
+    const MpuRegion * region;
 
-    /* rest of SRAM, accessible to mbed - non-executable for uvisor */
-    res = vmpu_mem_add_int(0, __uvisor_config.bss_end,
-        UVISOR_REGION_ROUND_UP((uint32_t) __uvisor_config.page_start) - ((uint32_t) __uvisor_config.bss_end),
-        UVISOR_TACL_SREAD|
-        UVISOR_TACL_SWRITE|
-        UVISOR_TACL_UREAD|
-        UVISOR_TACL_UWRITE|
-        UVISOR_TACL_UEXECUTE|
-        UVISOR_TACL_USER
-        );
-    if( res<0 )
-        HALT_ERROR(SANITY_CHECK_FAILED, "failed setting up box 0 SRAM (%i)\n", res);
+    vmpu_mpu_invalidate();
 
-    /* enable read access to unsecure flash regions - allow execution */
-    res = vmpu_mem_add_int(0, (void*)FLASH_ORIGIN, ((uint32_t)__uvisor_config.secure_end)-FLASH_ORIGIN,
-        UVISOR_TACL_SREAD|
-        UVISOR_TACL_SEXECUTE|
-        UVISOR_TACL_UREAD|
-        UVISOR_TACL_UEXECUTE|
-        UVISOR_TACL_USER);
-    if( res<0 )
-        HALT_ERROR(SANITY_CHECK_FAILED, "failed setting up box FLASH (%i)\n", res);
+    if(dst_box) {
+        /* Update target box first to make target stack available. */
+        vmpu_region_get_for_box(dst_box, &region, &dst_count);
 
-    /* initial primary box ACL's */
-    rgd = g_mem_box[0].acl;
-    /* Copy ACLs [0, 1] into MPU regions [_1_, _2_]. Region 0 is the background region! */
-    for(t = 1; t < K64F_MPU_REGIONS_STATIC; t++, rgd++) {
-        region = (MPU_Region *) MPU->WORD[t];
-        region->STARTADDR = rgd->start_addr;
-        region->ENDADDR = rgd->end_addr;
-        region->PERMISSIONS = rgd->permissions;
-        region->CONTROL = 1;
+        while (dst_count-- && vmpu_mpu_push(region++, 255)) ;
     }
 
-    /* MPU background region permission mask
-     *   this mask must be set as last one, since the background region gives no
-     *   executable privileges to neither user nor supervisor modes */
-    MPU->RGDAAC[0] = UVISOR_TACL_BACKGROUND;
+    page_allocator_iterate_active_pages(vmpu_mem_push_page_acl_iterator, PAGE_ALLOCATOR_ITERATOR_DIRECTION_FORWARD);
+}
+
+void vmpu_mem_init(void)
+{
+    /* enable read access to unsecure flash regions - allow execution */
+    vmpu_mpu_set_static_acl(1, FLASH_ORIGIN, (uint32_t) __uvisor_config.secure_end - FLASH_ORIGIN,
+        UVISOR_TACL_SREAD |
+        UVISOR_TACL_SEXECUTE |
+        UVISOR_TACL_UREAD |
+        UVISOR_TACL_UEXECUTE |
+        UVISOR_TACL_USER);
+
+    /* rest of SRAM, accessible to mbed - non-executable for uvisor */
+    vmpu_mpu_set_static_acl(2, (uint32_t) __uvisor_config.page_end,
+        (uint32_t) __uvisor_config.sram_end - (uint32_t) __uvisor_config.page_end,
+        UVISOR_TACL_SREAD |
+        UVISOR_TACL_SWRITE |
+        UVISOR_TACL_UREAD |
+        UVISOR_TACL_UWRITE |
+        UVISOR_TACL_UEXECUTE |
+        UVISOR_TACL_USER);
 }

--- a/core/system/src/mpu/vmpu_freescale_k64_mpu.c
+++ b/core/system/src/mpu/vmpu_freescale_k64_mpu.c
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <uvisor.h>
+#include "debug.h"
+#include "context.h"
+#include "halt.h"
+#include "memory_map.h"
+#include "vmpu.h"
+#include "vmpu_mpu.h"
+#include "vmpu_freescale_k64_aips.h"
+#include "vmpu_freescale_k64_mem.h"
+
+/* This file contains the configuration-specific symbols. */
+#include "configurations.h"
+
+typedef struct
+{
+    MpuRegion * regions;
+    uint32_t count;
+} MpuRegionSlice;
+
+static uint16_t g_mpu_region_count;
+static MpuRegion g_mpu_region[UVISOR_MAX_ACLS];
+static MpuRegionSlice g_mpu_box_region[UVISOR_MAX_BOXES];
+
+int vmpu_is_region_size_valid(uint32_t size)
+{
+    /* Align size to 32B. */
+    const uint32_t masked_size = size & ~31;
+    if (masked_size < 32 || (1 << 29) < masked_size) {
+        /* 2^5 == 32, which is the minimum region size. */
+        /* 2^29 == 512M, which is the maximum region size. */
+        return 0;
+    }
+    /* There is no rounding, we only care about an exact match! */
+    return (masked_size == size);
+}
+
+uint32_t vmpu_round_up_region(uint32_t addr, uint32_t size)
+{
+    if (!vmpu_is_region_size_valid(size)) {
+        /* Region size must be valid! */
+        return 0;
+    }
+    /* Alignment is always 32B. */
+    const uint32_t mask = 31;
+
+    /* Adding the mask can overflow. */
+    const uint32_t rounded_addr = addr + mask;
+    /* Check for overflow. */
+    if (rounded_addr < addr) {
+        /* This means the address was too large to align. */
+        return 0;
+    }
+    /* Mask the rounded address to get the aligned address. */
+    return (rounded_addr & ~mask);
+}
+
+static uint32_t vmpu_map_acl(UvisorBoxAcl acl)
+{
+    /* handle user permissions */
+    uint32_t perm = (acl & UVISOR_TACL_USER) ? (acl & UVISOR_TACL_UACL) : 0;
+
+    /* if S-perms are identical to U-perms, refer from S to U */
+    if(((acl & UVISOR_TACL_SACL) >> 3) == perm) {
+        perm |= 3UL << 3;
+    }
+    else {
+        /* handle detailed supervisor permissions */
+        switch(acl & UVISOR_TACL_SACL)
+        {
+            case UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE | UVISOR_TACL_SEXECUTE:
+                perm |= 0UL << 3;
+                break;
+
+            case UVISOR_TACL_SREAD | UVISOR_TACL_SEXECUTE:
+                perm |= 1UL << 3;
+                break;
+
+            case UVISOR_TACL_SREAD | UVISOR_TACL_SWRITE:
+                perm |= 2UL << 3;
+                break;
+
+            default:
+                DPRINTF("chosen supervisor ACL's are not supported by hardware (0x%08X)\n", acl);
+                return 0;
+        }
+    }
+    return perm;
+}
+
+uint32_t vmpu_region_translate_acl(MpuRegion * const region, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    /* ensure that ACL size can be rounded up to slot size */
+    if(size % 32)
+    {
+        if(acl & UVISOR_TACL_SIZE_ROUND_DOWN) {
+            size = UVISOR_REGION_ROUND_DOWN(size);
+        }
+        else if(acl & UVISOR_TACL_SIZE_ROUND_UP) {
+            size = UVISOR_REGION_ROUND_UP(size);
+        }
+        else {
+            DPRINTF("use UVISOR_TACL_SIZE_ROUND_UP/*_DOWN to round ACL size\n");
+            return 0;
+        }
+    }
+
+    /* ensure that ACL base is a multiple of 32 */
+    if(start % 32) {
+        DPRINTF("start address needs to be aligned on a 32 bytes border\n");
+        return 0;
+    }
+
+    region->config = vmpu_map_acl(acl);
+    region->start = start;
+    region->end = start + size;
+    region->acl = acl;
+
+    return size;
+
+}
+
+
+
+static int vmpu_mem_overlap(uint32_t s1, uint32_t e1, uint32_t s2, uint32_t e2)
+{
+    return (
+        (s1 > e1)                  ||
+        (s2 > e2)                  || /* punish messing with overlap */
+        ((s1 <= s2) && (e1 >  s2)) ||
+        ((s1 <  e2) && (e1 >= e2)) ||
+        ((s1 >= s2) && (e1 <= e2)) );
+}
+
+static uint32_t vmpu_region_add_static_acl_internal(uint8_t box_id, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    MpuRegion * region;
+    MpuRegionSlice * box;
+    uint32_t rounded_size, end, t;
+
+    DPRINTF(" mem_acl[%i]: 0x%08X-0x%08X (size=%i, acl=0x%04X)\n",
+            g_mpu_region_count, start, ((uint32_t)start)+size, size, acl);
+
+    /* handle empty or fully protected regions */
+    if(!size || !(acl & (UVISOR_TACL_UACL|UVISOR_TACL_SACL)))
+        return 1;
+
+    if(g_mpu_region_count >= UVISOR_MAX_ACLS) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_add_static_acl: No more regions to allocate!\n");
+    }
+
+    if (!vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_add_static_acl: The box id (%u) is out of range.\n", box_id);
+    }
+
+    /* check if region overlaps */
+    end = start + size;
+    region = g_mpu_region;
+
+    for (t=0; t < g_mpu_region_count; t++, region++)
+    {
+        if (vmpu_mem_overlap(start, end, region->start, region->end)) {
+            DPRINTF("detected overlap with ACL %i (0x%08X-0x%08X)\n",
+                t, region->start, region->end);
+
+            /* handle permitted overlaps */
+            if(!((region->acl & UVISOR_TACL_SHARED) && (acl & UVISOR_TACL_SHARED))) {
+                return 0;
+            }
+        }
+    }
+
+    box = &g_mpu_box_region[box_id];
+    if (!box->regions) {
+        box->regions = &g_mpu_region[g_mpu_region_count];
+    }
+
+    region = &box->regions[box->count];
+    if (region->config) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "unordered region allocation\n");
+    }
+
+    rounded_size = vmpu_region_translate_acl(region, start, size, acl);
+
+    box->count++;
+    g_mpu_region_count++;
+
+    return rounded_size;
+}
+
+uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    int res;
+
+#ifndef NDEBUG
+    const MemMap *map;
+#endif/*NDEBUG*/
+
+    /* check for maximum box ID */
+    if (!vmpu_is_box_id_valid(box_id)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box ID is out of range (%u).\r\n", box_id);
+    }
+
+    /* check for alignment to 32 bytes */
+    if(start & 0x1F) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL start address is not aligned [0x%08X]\n", start);
+    }
+
+    DPRINTF("\t@0x%08X size=%06i acl=0x%04X [%s]\n", start, size, acl,
+        (map = memory_map_name(start)) ? map->name : "unknown");
+
+    /* check for peripheral memory, proceed with general memory */
+    if(acl & UVISOR_TACL_PERIPHERAL) {
+        res = vmpu_aips_add(box_id, (void *) start, size, acl);
+    }
+    else {
+        size = vmpu_region_add_static_acl_internal(box_id, start, size,
+            (acl & UVISOR_TACLDEF_STACK) | UVISOR_TACL_STACK | UVISOR_TACL_USER);
+        res = size ? 1 : 0;
+    }
+
+    if(!res) {
+        HALT_ERROR(NOT_ALLOWED, "ACL in unhandled memory area\n");
+    }
+    else if(res < 0) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL sanity check failed [%i]\n", res);
+    }
+
+    return size;
+}
+
+bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, uint32_t * const count)
+{
+    if (!g_mpu_region_count) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions.\r\n");
+    }
+
+    if (box_id < UVISOR_MAX_BOXES) {
+        *count = g_mpu_box_region[box_id].count;
+        *region = *count ? g_mpu_box_region[box_id].regions : NULL;
+        return true;
+    }
+    return false;
+}
+
+MpuRegion * vmpu_region_find_for_address(uint8_t box_id, uint32_t address)
+{
+    int count;
+    MpuRegion * region;
+
+    count = g_mpu_box_region[box_id].count;
+    region = g_mpu_box_region[box_id].regions;
+    for (; count-- > 0; region++) {
+        if ((region->start <= address) && (address < region->end)) {
+            return region;
+        }
+    }
+
+    return NULL;
+}
+
+/* Region management */
+
+/* MPU access */
+
+/* The K64F has 12 MPU regions, however, we use region 0 as the background
+ * region with `UVISOR_TACL_BACKGROUND` as permissions.
+ * Region 1 and 2 are used to unlock Application SRAM and Flash.
+ * Therefore 9 MPU regions are available for user ACLs.
+ * Region 3 and 4 are used to protect the current box stack and context.
+ * This leaves 6 MPU regions for round robin scheduling:
+ *
+ *     12      <-- End of MPU regions, K64F_MPU_REGIONS_MAX
+ * .---------.
+ * |   11    |
+ * |   ...   |
+ * |    5    | <-- Box Pages, K64F_MPU_REGIONS_USER
+ * +---------+
+ * |    4    | <-- Box Context
+ * |    3    | <-- Box Stack, K64F_MPU_REGIONS_STATIC
+ * +---------+
+ * |    2    | <-- Application SRAM unlock
+ * |    1    | <-- Application Flash unlock
+ * |    0    | <-- Background region
+ * '---------'
+ */
+#define K64F_MPU_REGIONS_STATIC 3
+#define K64F_MPU_REGIONS_USER 5
+#define K64F_MPU_REGIONS_MAX 12
+
+static uint8_t g_mpu_slot = K64F_MPU_REGIONS_STATIC;
+static uint8_t g_mpu_priority[K64F_MPU_REGIONS_MAX];
+
+void vmpu_mpu_init(void)
+{
+    /* Enable mem, bus and usage faults. */
+    SCB->SHCSR |= 0x70000;
+}
+
+void vmpu_mpu_lock(void)
+{
+    /* MPU background region permission mask
+     *   this mask must be set as last one, since the background region gives no
+     *   executable privileges to neither user nor supervisor modes */
+    MPU->RGDAAC[0] = UVISOR_TACL_BACKGROUND;
+}
+
+uint32_t vmpu_mpu_set_static_acl(uint8_t index, uint32_t start, uint32_t size, UvisorBoxAcl acl)
+{
+    MpuRegion region;
+    MPU_Region * mpu_region;
+    uint32_t rounded_size;
+
+    if (index >= K64F_MPU_REGIONS_STATIC) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "vmpu_mpu_set_static_region: Invalid region index (%u)!\n", index);
+        return 0;
+    }
+
+    rounded_size = vmpu_region_translate_acl(&region, start, size, acl);
+
+    mpu_region = (MPU_Region *) MPU->WORD[index];
+    mpu_region->STARTADDR = region.start;
+    mpu_region->ENDADDR = region.end;
+    mpu_region->PERMISSIONS = region.config;
+    mpu_region->CONTROL = 1;
+    g_mpu_priority[index] = 255;
+
+    return rounded_size;
+}
+
+void vmpu_mpu_invalidate(void)
+{
+    g_mpu_slot = K64F_MPU_REGIONS_STATIC;
+    uint8_t slot = K64F_MPU_REGIONS_STATIC;
+    while (slot < K64F_MPU_REGIONS_MAX) {
+        /* We need to make sure that we disable an enabled MPU region before any
+         * other modification, hence we cannot select the MPU region using the
+         * region number field in the RBAR register. */
+        ((MPU_Region *) MPU->WORD[slot])->CONTROL = 0;
+        g_mpu_priority[slot] = 0;
+        slot++;
+    }
+}
+
+bool vmpu_mpu_push(const MpuRegion * const region, uint8_t priority)
+{
+    MPU_Region * mpu_region;
+    if (!priority) priority = 1;
+
+    const uint8_t start_slot = g_mpu_slot;
+    uint8_t viable_slot = start_slot;
+
+    do {
+        if (g_mpu_priority[g_mpu_slot] < priority) {
+            /* We can place this region in here. */
+            mpu_region = (MPU_Region *) MPU->WORD[g_mpu_slot];
+            mpu_region->STARTADDR = region->start;
+            mpu_region->ENDADDR = region->end;
+            mpu_region->PERMISSIONS = region->config;
+            mpu_region->CONTROL = 1;
+
+            g_mpu_priority[g_mpu_slot] = priority;
+
+            if (++g_mpu_slot > K64F_MPU_REGIONS_MAX) {
+                g_mpu_slot = K64F_MPU_REGIONS_STATIC;
+            }
+            return true;
+        }
+        viable_slot = g_mpu_slot;
+        if (++g_mpu_slot > K64F_MPU_REGIONS_MAX) {
+            g_mpu_slot = K64F_MPU_REGIONS_STATIC;
+        }
+    }
+    while (g_mpu_slot != start_slot);
+
+    /* We did not find a slot with a lower priority, so just take the next
+     * position that does not have the highest priority. */
+    mpu_region = (MPU_Region *) MPU->WORD[viable_slot];
+    mpu_region->STARTADDR = region->start;
+    mpu_region->ENDADDR = region->end;
+    mpu_region->PERMISSIONS = region->config;
+    mpu_region->CONTROL = 1;
+
+    g_mpu_priority[viable_slot] = priority;
+
+    return true;
+}

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -22,7 +22,7 @@
 #include "context.h"
 
 /* Maps the number of faults to a page. */
-uint32_t g_page_fault_table[UVISOR_PAGE_TABLE_MAX_COUNT];
+uint32_t g_page_fault_table[UVISOR_PAGE_MAX_COUNT];
 
 void page_allocator_reset_faults(uint8_t page)
 {
@@ -56,8 +56,8 @@ int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * st
         /* This address does not correspond to any page. */
         return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
     }
-    /* Check that the page actually belongs to this box or box 0. */
-    if ((g_page_owner_table[p] != 0) && (g_page_owner_table[p] != box_id)) {
+    /* Then check if the page is set. */
+    if (!page_allocator_map_get(g_page_owner_map[box_id], p)) {
         return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
     }
     /* Compute the page start and end address */
@@ -68,24 +68,76 @@ int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * st
     return UVISOR_ERROR_PAGE_OK;
 }
 
-uint8_t page_allocator_iterate_active_pages(int (*callback)(uint32_t start_addr, uint32_t end_addr, uint8_t page))
+int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask, uint8_t * index, uint8_t * page)
 {
-    uint8_t ii, count = 0;
+    const page_owner_t box_id = g_active_box;
+    /* Compute the page id. */
+    uint8_t p = page_allocator_get_page_from_address(address);
+    if (p == UVISOR_PAGE_UNUSED) {
+        /* This address does not correspond to any page. */
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
+    }
+    /* Then check if the page is set. */
+    if (!page_allocator_map_get(g_page_owner_map[box_id], p)) {
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
+    }
+    *page = p;
+    /* Compute the page mask and index. */
+    p += UVISOR_PAGE_MAP_COUNT * 32 - g_page_count_total;
+    *mask = (uint8_t) (g_page_owner_map[box_id][p / 32] >> ((p % 32) & ~7));
+    *index = p / 8;
+
+    return UVISOR_ERROR_PAGE_OK;
+}
+
+uint8_t page_allocator_iterate_active_pages(PageAllocatorIteratorCallback callback, PageAllocatorIteratorDirection direction)
+{
+    uint8_t ii, index, count = 0;
     uint32_t start_addr, end_addr;
+    const page_owner_t box_id = g_active_box;
 
     /* Iterate over all pages. */
-    /* FIXME: Use bit masks for this to make this page enabling more efficient.
-     * By storing the pages as a bit mask in an array indexed by box id, the lookup
-     * is O(1) and it can be OR-ed with box 0 and then all pages can be enabled at once. */
     for (ii = 0; ii < g_page_count_total; ii++) {
-        if (g_page_owner_table[ii] == g_active_box || g_page_owner_table[ii] == 0) {
+        if (direction < 0) {
+            index = (g_page_count_total - 1) - ii;
+        } else {
+            index = ii;
+        }
+        if (page_allocator_map_get(g_page_owner_map[box_id], index)) {
             count++;
             if (callback) {
                 /* Compute start and end addresses. */
-                start_addr = (uint32_t) g_page_heap_start + g_page_size * ii;
+                start_addr = (uint32_t) g_page_heap_start + g_page_size * index;
                 end_addr = start_addr + g_page_size;
                 /* Call the callback. */
                 if (!callback(start_addr, end_addr, ii)) {
+                    return count;
+                }
+            }
+        }
+    }
+
+    return count;
+}
+
+uint8_t page_allocator_iterate_active_page_masks(PageAllocatorIteratorMaskCallback callback, PageAllocatorIteratorDirection direction)
+{
+    uint8_t ii, index, mask, count = 0;
+    const page_owner_t box_id = g_active_box;
+    const uint8_t page_count_octets = ((g_page_count_total + 7) / 8);
+
+    for (ii = 0; ii < page_count_octets; ii++) {
+        if (direction < 0) {
+            index = UVISOR_PAGE_MAP_COUNT * 4 - 1 - ii;
+        } else {
+            index = (UVISOR_PAGE_MAP_COUNT * 4 - page_count_octets) + ii;
+        }
+        mask = (uint8_t) (g_page_owner_map[box_id][index / 4] >> ((index % 4) * 8));
+        if (mask) {
+            count++;
+            if (callback) {
+                /* Call the callback. */
+                if (!callback(mask, ii)) {
                     return count;
                 }
             }


### PR DESCRIPTION
This adds a common interface for the implementation of the MPU region storage and scheduling.
Tested on both K64F and EFM32.

This also adds the necessary changes to use subregions to access the page heap.
Changes include accessing the page owner bitmap efficiently to map it directly to MPU subregions and moving the page heap to behind the uVisor .bss section and aligning it's end with a subregion of the SRAM access region.

@AlessandroA 