### PR TITLE
Reintroduce the debug box

### DIFF
--- a/api/inc/priv_sys_hook_exports.h
+++ b/api/inc/priv_sys_hook_exports.h
@@ -14,28 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __UVISOR_API_PRIV_SYS_IRQ_HOOK_EXPORTS_H__
-#define __UVISOR_API_PRIV_SYS_IRQ_HOOK_EXPORTS_H__
+#ifndef __UVISOR_API_PRIV_SYS_HOOK_EXPORTS_H__
+#define __UVISOR_API_PRIV_SYS_HOOK_EXPORTS_H__
 
 /*
- * Privileged system interrupt hooks
+ * Privileged system hooks
  *
  * In this version of uVisor, uVisor lives alongside an RTOS that requires
  * running privileged code. In order for the RTOS to run any privileged code,
  * uVisor must allow the RTOS to handle a subset of privileged system
- * interrupts. Only the following system interrupts are hookable. Code called
- * by these hooks circumvents uVisor security. HANDLE WITH CARE. */
+ * interrupts or system calls. Only the following system interrupts and system
+ * calls are hookable. Code called by these hooks circumvents uVisor security.
+ * HANDLE WITH CARE. */
 typedef struct {
     void (*priv_svc_0)(void);
     void (*priv_pendsv)(void);
     void (*priv_systick)(void);
-} UvisorPrivSystemIRQHooks;
+} UvisorPrivSystemHooks;
 
 /* Use this macro to register privileged system IRQ hooks. If you don't want to
  * register a particular privileged system IRQ hook, you can supply NULL for
  * that hook parameter. */
-#define UVISOR_SET_PRIV_SYS_IRQ_HOOKS(priv_svc_0_, priv_pendsv_, priv_systick_) \
-    UVISOR_EXTERN const UvisorPrivSystemIRQHooks __uvisor_priv_sys_irq_hooks = { \
+#define UVISOR_SET_PRIV_SYS_HOOKS(priv_svc_0_, priv_pendsv_, priv_systick_) \
+    UVISOR_EXTERN const UvisorPrivSystemHooks __uvisor_priv_sys_hooks = { \
         .priv_svc_0 = priv_svc_0_, \
         .priv_pendsv = priv_pendsv_, \
         .priv_systick = priv_systick_, \

--- a/api/inc/priv_sys_hook_exports.h
+++ b/api/inc/priv_sys_hook_exports.h
@@ -30,16 +30,18 @@ typedef struct {
     void (*priv_svc_0)(void);
     void (*priv_pendsv)(void);
     void (*priv_systick)(void);
+    uint32_t (*priv_os_suspend)(void);
 } UvisorPrivSystemHooks;
 
 /* Use this macro to register privileged system IRQ hooks. If you don't want to
  * register a particular privileged system IRQ hook, you can supply NULL for
  * that hook parameter. */
-#define UVISOR_SET_PRIV_SYS_HOOKS(priv_svc_0_, priv_pendsv_, priv_systick_) \
+#define UVISOR_SET_PRIV_SYS_HOOKS(priv_svc_0_, priv_pendsv_, priv_systick_, priv_os_suspend_) \
     UVISOR_EXTERN const UvisorPrivSystemHooks __uvisor_priv_sys_hooks = { \
         .priv_svc_0 = priv_svc_0_, \
         .priv_pendsv = priv_pendsv_, \
         .priv_systick = priv_systick_, \
+        .priv_os_suspend = priv_os_suspend_, \
     };
 
 #endif

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -59,7 +59,7 @@ UVISOR_EXTERN int uvisor_lib_init(void);
 #include "api/inc/register_gateway_exports.h"
 #include "api/inc/rpc_gateway_exports.h"
 #include "api/inc/svc_exports.h"
-#include "api/inc/priv_sys_irq_hook_exports.h"
+#include "api/inc/priv_sys_hook_exports.h"
 #include "api/inc/unvic_exports.h"
 #include "api/inc/uvisor_exports.h"
 #include "api/inc/vmpu_exports.h"

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -21,7 +21,7 @@
 .type  uvisor_init, %function
 .weak  __uvisor_mode
 .weak  __uvisor_page_size
-.globl __uvisor_priv_sys_irq_hooks
+.globl __uvisor_priv_sys_hooks
 
 .section .uvisor.main, "x"
     .thumb
@@ -104,8 +104,8 @@ uvisor_config:
     .long __uvisor_sram_start;
     .long __uvisor_sram_end;
 
-    /* Privileged system IRQ hooks */
-    .long __uvisor_priv_sys_irq_hooks
+    /* Privileged system hooks */
+    .long __uvisor_priv_sys_hooks
 
     /* Functions provided by uVisor Lib for use by uVisor in unprivileged mode
      * */

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -17,7 +17,7 @@
 #ifndef __LINKER_H__
 #define __LINKER_H__
 
-#include "api/inc/priv_sys_irq_hook_exports.h"
+#include "api/inc/priv_sys_hook_exports.h"
 
 extern uint32_t const __code_end__;
 extern uint32_t const __stack_start__;
@@ -93,8 +93,8 @@ typedef struct {
     uint32_t * sram_start;
     uint32_t * sram_end;
 
-    /* Privileged system IRQ hooks */
-    UvisorPrivSystemIRQHooks const * const priv_sys_irq_hooks;
+    /* Privileged system hooks */
+    UvisorPrivSystemHooks const * const priv_sys_hooks;
 
     /* Functions provided by uVisor Lib for use by uVisor in unprivileged mode
      * */

--- a/core/system/inc/system.h
+++ b/core/system/inc/system.h
@@ -23,8 +23,8 @@
 /* Default vector table (placed in Flash) */
 extern const TIsrVector g_isr_vector[ISR_VECTORS];
 
-/* Default system IRQ hooks (placed in SRAM) */
-extern UvisorPrivSystemIRQHooks g_priv_sys_irq_hooks;
+/* Default system hooks (placed in SRAM) */
+extern UvisorPrivSystemHooks g_priv_sys_hooks;
 
 /* Default ISRs prototypes */
 void isr_default_sys_handler(void);

--- a/core/system/src/main.c
+++ b/core/system/src/main.c
@@ -120,21 +120,21 @@ static void load_priv_sys_hooks(void)
 
 UVISOR_NOINLINE void uvisor_init_post(void)
 {
-        /* init MPU */
-        vmpu_init_post();
+    /* Init MPU. */
+    vmpu_init_post();
 
-        /* Init page allocator */
-        page_allocator_init(__uvisor_config.page_start,
-                            __uvisor_config.page_end,
-                            __uvisor_config.page_size);
+    /* Init page allocator. */
+    page_allocator_init(__uvisor_config.page_start,
+                        __uvisor_config.page_end,
+                        __uvisor_config.page_size);
 
-        /* init SVC call interface */
-        svc_init();
+    /* Init SVC call interface. */
+    svc_init();
 
-        /* Load privileged system hooks. */
-        load_priv_sys_hooks();
+    /* Load privileged system hooks. */
+    load_priv_sys_hooks();
 
-        DPRINTF("uvisor initialized\n");
+    DPRINTF("uvisor initialized\n");
 }
 
 void main_entry(void)

--- a/core/system/src/main.c
+++ b/core/system/src/main.c
@@ -82,6 +82,14 @@ static void sanity_check_priv_sys_hooks(const UvisorPrivSystemHooks *priv_sys_ho
             __uvisor_config.priv_sys_hooks->priv_pendsv
             );
     }
+
+    if (__uvisor_config.priv_sys_hooks->priv_os_suspend &&
+            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_hooks->priv_os_suspend)) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "priv_os_suspend (0x%08x) not entirely in public flash\n",
+            __uvisor_config.priv_sys_hooks->priv_os_suspend
+            );
+    }
 }
 
 static void load_priv_sys_hooks(void)
@@ -102,6 +110,11 @@ static void load_priv_sys_hooks(void)
 
     if (__uvisor_config.priv_sys_hooks->priv_systick) {
         g_priv_sys_hooks.priv_systick = __uvisor_config.priv_sys_hooks->priv_systick;
+    }
+
+    if (__uvisor_config.priv_sys_hooks->priv_os_suspend) {
+        g_priv_sys_hooks.priv_os_suspend =
+            __uvisor_config.priv_sys_hooks->priv_os_suspend;
     }
 }
 

--- a/core/system/src/main.c
+++ b/core/system/src/main.c
@@ -46,62 +46,62 @@ UVISOR_NOINLINE void uvisor_init_pre(void)
     DEBUG_INIT();
 }
 
-static void sanity_check_priv_sys_irq_hooks(const UvisorPrivSystemIRQHooks *priv_sys_irq_hooks)
+static void sanity_check_priv_sys_hooks(const UvisorPrivSystemHooks *priv_sys_hooks)
 {
     /* Check that the table is in flash. */
-    if (!vmpu_public_flash_addr((uint32_t) priv_sys_irq_hooks) ||
-        !vmpu_public_flash_addr((uint32_t) priv_sys_irq_hooks +
-            sizeof(priv_sys_irq_hooks))) {
+    if (!vmpu_public_flash_addr((uint32_t) priv_sys_hooks) ||
+        !vmpu_public_flash_addr((uint32_t) priv_sys_hooks +
+            sizeof(priv_sys_hooks))) {
         HALT_ERROR(SANITY_CHECK_FAILED,
-            "priv_sys_irq_hooks (0x%08x) not entirely in public flash\n",
-            priv_sys_irq_hooks
+            "priv_sys_hooks (0x%08x) not entirely in public flash\n",
+            priv_sys_hooks
         );
     }
 
     /*
      * Check that each hook is in flash, if the hook is non-0.
      */
-    if (__uvisor_config.priv_sys_irq_hooks->priv_svc_0 &&
-            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_irq_hooks->priv_svc_0)) {
+    if (__uvisor_config.priv_sys_hooks->priv_svc_0 &&
+            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_hooks->priv_svc_0)) {
         HALT_ERROR(SANITY_CHECK_FAILED,
             "priv_svc_0 (0x%08x) not entirely in public flash\n",
-            __uvisor_config.priv_sys_irq_hooks->priv_svc_0);
+            __uvisor_config.priv_sys_hooks->priv_svc_0);
     }
 
-    if (__uvisor_config.priv_sys_irq_hooks->priv_pendsv &&
-            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_irq_hooks->priv_pendsv)) {
+    if (__uvisor_config.priv_sys_hooks->priv_pendsv &&
+            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_hooks->priv_pendsv)) {
         HALT_ERROR(SANITY_CHECK_FAILED,
             "priv_pendsv (0x%08x) not entirely in public flash\n",
-            __uvisor_config.priv_sys_irq_hooks->priv_pendsv);
+            __uvisor_config.priv_sys_hooks->priv_pendsv);
     }
 
-    if (__uvisor_config.priv_sys_irq_hooks->priv_systick &&
-            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_irq_hooks->priv_systick)) {
+    if (__uvisor_config.priv_sys_hooks->priv_systick &&
+            !vmpu_public_flash_addr((uint32_t) __uvisor_config.priv_sys_hooks->priv_systick)) {
         HALT_ERROR(SANITY_CHECK_FAILED,
             "priv_systick (0x%08x) not entirely in public flash\n",
-            __uvisor_config.priv_sys_irq_hooks->priv_pendsv
+            __uvisor_config.priv_sys_hooks->priv_pendsv
             );
     }
 }
 
-static void load_priv_sys_irq_hooks(void)
+static void load_priv_sys_hooks(void)
 {
     /* Make sure the hook table is sane. */
-    sanity_check_priv_sys_irq_hooks(__uvisor_config.priv_sys_irq_hooks);
+    sanity_check_priv_sys_hooks(__uvisor_config.priv_sys_hooks);
 
     /*
      * Register each hook.
      */
-    if (__uvisor_config.priv_sys_irq_hooks->priv_svc_0) {
-        g_priv_sys_irq_hooks.priv_svc_0 = __uvisor_config.priv_sys_irq_hooks->priv_svc_0;
+    if (__uvisor_config.priv_sys_hooks->priv_svc_0) {
+        g_priv_sys_hooks.priv_svc_0 = __uvisor_config.priv_sys_hooks->priv_svc_0;
     }
 
-    if (__uvisor_config.priv_sys_irq_hooks->priv_pendsv) {
-        g_priv_sys_irq_hooks.priv_pendsv = __uvisor_config.priv_sys_irq_hooks->priv_pendsv;
+    if (__uvisor_config.priv_sys_hooks->priv_pendsv) {
+        g_priv_sys_hooks.priv_pendsv = __uvisor_config.priv_sys_hooks->priv_pendsv;
     }
 
-    if (__uvisor_config.priv_sys_irq_hooks->priv_systick) {
-        g_priv_sys_irq_hooks.priv_systick = __uvisor_config.priv_sys_irq_hooks->priv_systick;
+    if (__uvisor_config.priv_sys_hooks->priv_systick) {
+        g_priv_sys_hooks.priv_systick = __uvisor_config.priv_sys_hooks->priv_systick;
     }
 }
 
@@ -118,8 +118,8 @@ UVISOR_NOINLINE void uvisor_init_post(void)
         /* init SVC call interface */
         svc_init();
 
-        /* Load privileged system IRQ hooks. */
-        load_priv_sys_irq_hooks();
+        /* Load privileged system hooks. */
+        load_priv_sys_hooks();
 
         DPRINTF("uvisor initialized\n");
 }

--- a/core/system/src/svc.c
+++ b/core/system/src/svc.c
@@ -248,7 +248,7 @@ void UVISOR_NAKED SVCall_IRQn_Handler(void)
         :: [svc_mode_mask]       "I" ((UVISOR_SVC_MODE_MASK) & 0xFF),
            [svc_fast_index_mask] "I" ((UVISOR_SVC_FAST_INDEX_MASK) & 0xFF),
            [svc_vtor_tbl_count]  "i" (UVISOR_ARRAY_COUNT(g_svc_vtor_tbl) - 1),
-           [priv_svc_0]          "m" (g_priv_sys_irq_hooks.priv_svc_0)
+           [priv_svc_0]          "m" (g_priv_sys_hooks.priv_svc_0)
     );
 }
 

--- a/core/system/src/system.c
+++ b/core/system/src/system.c
@@ -36,7 +36,7 @@ void UVISOR_NAKED PendSV_IRQn_Handler(void)
     asm volatile(
         "ldr  r0, %[priv_pendsv]\n"  /* Load the hook from the hook table. */
         "bx   r0\n"                  /* Branch to the hook (without link). */
-        :: [priv_pendsv] "m" (g_priv_sys_irq_hooks.priv_pendsv)
+        :: [priv_pendsv] "m" (g_priv_sys_hooks.priv_pendsv)
     );
 }
 
@@ -45,7 +45,7 @@ void UVISOR_NAKED SysTick_IRQn_Handler(void)
     asm volatile(
         "ldr  r0, %[priv_systick]\n" /* Load the hook from the hook table. */
         "bx   r0\n"                  /* Branch to the hook (without link). */
-        :: [priv_systick] "m" (g_priv_sys_irq_hooks.priv_systick)
+        :: [priv_systick] "m" (g_priv_sys_hooks.priv_systick)
     );
 }
 
@@ -77,8 +77,8 @@ __attribute__((section(".isr"))) const TIsrVector g_isr_vector[ISR_VECTORS] =
     [NVIC_OFFSET ... (ISR_VECTORS - 1)] = isr_default_handler
 };
 
-/* Default privileged system IRQ hooks (placed in SRAM) */
-UvisorPrivSystemIRQHooks g_priv_sys_irq_hooks = {
+/* Default privileged system hooks (placed in SRAM) */
+UvisorPrivSystemHooks g_priv_sys_hooks = {
     .priv_svc_0 = __svc_not_implemented,
     .priv_pendsv = isr_default_sys_handler,
     .priv_systick = isr_default_sys_handler,

--- a/docs/api/DEBUGGING.md
+++ b/docs/api/DEBUGGING.md
@@ -106,8 +106,6 @@ Currently the following messages are printed:
 
 ## The debug box
 
-> Warning: We are currently working on porting the debug box to the new version of mbed OS. Coming soon.
-
 > Warning: The debug box feature is an early prototype. The APIs and procedures described here might change several times in non-backwards-compatible ways.
 
 The uVisor code is instrumented to output debug information when it is relevant. In order to keep the uVisor as simple and hardware-independent as possible, some of this information is not handled and interpreted directly by uVisor.
@@ -131,9 +129,20 @@ The following is an example of how to implement and configure a debug box.
 #include "mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
+struct box_context {
+    uint32_t unused;
+};
+
+static const UvisorBoxAclItem acl[] = {
+};
+
+static void box_debug_main(const void *);
+
 /* Configure the debug box. */
 UVISOR_BOX_NAMESPACE(NULL);
 UVISOR_BOX_CONFIG(box_debug, UVISOR_BOX_STACK_SIZE);
+UVISOR_BOX_MAIN(box_debug_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
+UVISOR_BOX_CONFIG(box_debug, acl, UVISOR_BOX_STACK_SIZE, box_context);
 
 static uint32_t get_version(void) {
     return 0;
@@ -144,7 +153,8 @@ static void halt_error(int reason) {
     /* We will now reboot. */
 }
 
-UVISOR_EXTERN void __box_debug_init(void) {
+static void box_debug_main(const void *)
+{
     /* Debug box driver -- Version 0 */
     static const TUvisorDebugDriver driver = {
         get_version,
@@ -153,11 +163,6 @@ UVISOR_EXTERN void __box_debug_init(void) {
 
     /* Register the debug box with uVisor. */
     uvisor_debug_init(&driver);
-}
-
-void box_debug::init(void) {
-    /* The debug box is initialized from the context of box_debug. */
-    secure_gateway(box_debug, __box_debug_init);
 }
 ```
 

--- a/docs/api/QUICKSTART.md
+++ b/docs/api/QUICKSTART.md
@@ -93,14 +93,14 @@ To enable the uVisor on the app, just add the following lines at the beginning o
 #include "rtos.h"
 #include "uvisor-lib/uvisor-lib.h"
 
-/* Register privleged system IRQ hooks.
+/* Register privleged system hooks.
  * This is a system-wide configuration and it is independent from the app, but
  * for the moment it needs to be specified in the app. This will change in a
  * later version: The configuration will be provided by the OS. */
 extern "C" void SVC_Handler(void);
 extern "C" void PendSV_Handler(void);
 extern "C" void SysTick_Handler(void);
-UVISOR_SET_PRIV_SYS_IRQ_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler);
+UVISOR_SET_PRIV_SYS_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler);
 
 /* Main box Access Control Lists (ACLs). */
 /* Note: These are specific to the NXP FRDM-K64F board. See the section below
@@ -125,7 +125,7 @@ UVISOR_SET_MODE_ACL(UVISOR_ENABLED, g_main_box_acls);
 
 In the code above we specified 3 elements:
 
-1. System-wide uVisor configurations: `UVISOR_SET_PRIV_SYS_IRQ_HOOKS`. Application authors currently need to specify the privileged system IRQ hooks at the application level with this macro, but in the future the operating system will register the privileged system IRQ hooks on its own.
+1. System-wide uVisor configurations: `UVISOR_SET_PRIV_SYS_HOOKS`. Application authors currently need to specify the privileged system hooks at the application level with this macro, but in the future the operating system will register the privileged system hooks on its own.
 1. Main box Access Control Lists (ACLs). Since with uVisor enabled everything runs in unprivileged mode, we need to make sure that peripherals that are accessed by the OS and the main box are allowed. These peripherals are specified using a list like the one in the snippet above. For the purpose of this example we provide you the list of all the ACLs that we know you will need. For other platforms or other applications you need to determine those ACLs following a process that is described in a [section](#the-main-box-acls) below.
 1. App-specific uVisor configurations: `UVISOR_SET_MODE_ACL`. This macro sets the uVisor mode (enabled) and associates the list of ACLs we just created with the main box.
 


### PR DESCRIPTION
This PR re-introduces the debug box feature.

* Use the latest context switch APIs.
* Add hook to suspend the RTOS from uVisor.

The PR requires applications built with uVisor enabled to add the `rt_suspend` hook to the sys-hooks configuration:

```diff
-UVISOR_SET_PRIV_SYS_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler);
+UVISOR_SET_PRIV_SYS_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler, rt_suspend);
```

@meriac @Patater 