### PR TITLE
rtx: Register with uVisor

### DIFF
--- a/api/inc/priv_sys_hook_exports.h
+++ b/api/inc/priv_sys_hook_exports.h
@@ -37,11 +37,13 @@ typedef struct {
  * register a particular privileged system IRQ hook, you can supply NULL for
  * that hook parameter. */
 #define UVISOR_SET_PRIV_SYS_HOOKS(priv_svc_0_, priv_pendsv_, priv_systick_, priv_os_suspend_) \
-    UVISOR_EXTERN const UvisorPrivSystemHooks __uvisor_priv_sys_hooks = { \
+    UVISOR_EXTERN_C_BEGIN \
+    const UvisorPrivSystemHooks __uvisor_priv_sys_hooks = { \
         .priv_svc_0 = priv_svc_0_, \
         .priv_pendsv = priv_pendsv_, \
         .priv_systick = priv_systick_, \
         .priv_os_suspend = priv_os_suspend_, \
-    };
+    }; \
+    UVISOR_EXTERN_C_END
 
 #endif

--- a/api/rtx/src/box_init.c
+++ b/api/rtx/src/box_init.c
@@ -20,6 +20,14 @@
 #include <stdint.h>
 #include <string.h>
 
+/* Register the OS with uVisor */
+extern void SVC_Handler(void);
+extern void PendSV_Handler(void);
+extern void SysTick_Handler(void);
+extern uint32_t rt_suspend(void);
+
+UVISOR_SET_PRIV_SYS_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler, rt_suspend);
+
 /* This function is called by uVisor in unprivileged mode. On this OS, we
  * create box main threads for the box. */
 void __uvisor_lib_box_init(void * lib_config)


### PR DESCRIPTION
Each application shouldn't need to register the privileged system handlers. We can register the OS with uVisor in uvisor-lib.

@AlessandroA @meriac @niklas-arm
