### PR TITLE
Virtualize NVIC_SystemReset

### DIFF
--- a/api/inc/cmsis_nvic_virtual.h
+++ b/api/inc/cmsis_nvic_virtual.h
@@ -18,6 +18,7 @@
 #define __UVISOR_API_NVIC_VIRTUAL_H__
 
 #include "api/inc/interrupts.h"
+#include "api/inc/unvic_exports.h"
 
 #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
 #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
@@ -29,6 +30,6 @@
 #define NVIC_GetActive              __NVIC_GetActive
 #define NVIC_SetPriority            vIRQ_SetPriority
 #define NVIC_GetPriority            vIRQ_GetPriority
-#define NVIC_SystemReset            vIRQ_SystemReset
+#define NVIC_SystemReset()          vIRQ_SystemReset(RESET_REASON_NO_REASON)
 
 #endif /* __UVISOR_API_NVIC_VIRTUAL_H__ */

--- a/api/inc/cmsis_nvic_virtual.h
+++ b/api/inc/cmsis_nvic_virtual.h
@@ -29,5 +29,6 @@
 #define NVIC_GetActive              __NVIC_GetActive
 #define NVIC_SetPriority            vIRQ_SetPriority
 #define NVIC_GetPriority            vIRQ_GetPriority
+#define NVIC_SystemReset            vIRQ_SystemReset
 
 #endif /* __UVISOR_API_NVIC_VIRTUAL_H__ */

--- a/api/inc/halt_exports.h
+++ b/api/inc/halt_exports.h
@@ -29,6 +29,7 @@
 
 typedef enum {
     USER_NOT_ALLOWED = 1,
+    DEBUG_BOX_HALT,
 } THaltUserError;
 
 typedef enum {

--- a/api/inc/interrupts.h
+++ b/api/inc/interrupts.h
@@ -60,4 +60,9 @@ UVISOR_EXTERN void vIRQ_DisableAll(void);
  * ::vIRQ_DisableAll for more information. */
 UVISOR_EXTERN void vIRQ_EnableAll(void);
 
+/** Reset the device.
+ * @warning Currently only the debug box can reset the device.
+ */
+UVISOR_EXTERN void vIRQ_SystemReset(void);
+
 #endif /* __UVISOR_API_INTERRUPTS_H__ */

--- a/api/inc/interrupts.h
+++ b/api/inc/interrupts.h
@@ -17,6 +17,7 @@
 #ifndef __UVISOR_API_INTERRUPTS_H__
 #define __UVISOR_API_INTERRUPTS_H__
 
+#include "api/inc/unvic_exports.h"
 #include "api/inc/uvisor_exports.h"
 #include <stdint.h>
 
@@ -62,7 +63,8 @@ UVISOR_EXTERN void vIRQ_EnableAll(void);
 
 /** Reset the device.
  * @warning Currently only the debug box can reset the device.
+ * @param reason[in]    Reason for rebooting. Currently not used.
  */
-UVISOR_EXTERN void vIRQ_SystemReset(void);
+UVISOR_EXTERN void vIRQ_SystemReset(TResetReason reason);
 
 #endif /* __UVISOR_API_INTERRUPTS_H__ */

--- a/api/inc/unvic_exports.h
+++ b/api/inc/unvic_exports.h
@@ -28,6 +28,13 @@
  * priorities available to them */
 #define UVISOR_VIRQ_MAX_PRIORITY ((uint32_t) (1 << __NVIC_PRIO_BITS) - 1 - __UVISOR_NVIC_MIN_PRIORITY)
 
+/* Reasons for rebooting */
+typedef enum {
+    RESET_REASON_NO_REASON = 0,
+    RESET_REASON_HALT,
+    __TRESETREASON_MAX /* Always keep the last element of the enum. */
+} TResetReason;
+
 /* Offset of NVIC interrupts with respect to handler 0 */
 #define NVIC_OFFSET 16
 

--- a/api/src/interrupts.c
+++ b/api/src/interrupts.c
@@ -166,12 +166,12 @@ int vIRQ_GetLevel(void)
     }
 }
 
-void vIRQ_SystemReset(void)
+void vIRQ_SystemReset(TResetReason reason)
 {
     if(__uvisor_mode == 0) {
         NVIC_SystemReset();
     }
     else {
-        UVISOR_SVC(UVISOR_SVC_ID_DEBUG_REBOOT, "");
+        UVISOR_SVC(UVISOR_SVC_ID_DEBUG_REBOOT, "", reason);
     }
 }

--- a/api/src/interrupts.c
+++ b/api/src/interrupts.c
@@ -165,3 +165,13 @@ int vIRQ_GetLevel(void)
         return UVISOR_SVC(UVISOR_SVC_ID_IRQ_LEVEL_GET, "");
     }
 }
+
+void vIRQ_SystemReset(void)
+{
+    if(__uvisor_mode == 0) {
+        NVIC_SystemReset();
+    }
+    else {
+        UVISOR_SVC(UVISOR_SVC_ID_DEBUG_REBOOT, "");
+    }
+}

--- a/core/debug/inc/debug.h
+++ b/core/debug/inc/debug.h
@@ -47,7 +47,7 @@ void debug_map_addr_to_periph(uint32_t address);
 void debug_register_driver(const TUvisorDebugDriver * const driver);
 uint32_t debug_get_version(void);
 void debug_halt_error(THaltError reason);
-void debug_reboot(void);
+void debug_reboot(TResetReason reason);
 
 #define DEBUG_PRINT_HEAD(x) {\
     DPRINTF("\n***********************************************************\n");\

--- a/core/debug/src/debug.c
+++ b/core/debug/src/debug.c
@@ -161,12 +161,15 @@ static void debug_die(void)
     UVISOR_SVC(UVISOR_SVC_ID_HALT_USER_ERR, "", DEBUG_BOX_HALT);
 }
 
-/* FIXME: The halt will be replaced with a proper return code. An ACL will be
- *        created to allow single boxes to reset the device. */
-void debug_reboot(void)
+void debug_reboot(TResetReason reason)
 {
     if (!g_debug_box.initialized || g_active_box != g_debug_box.box_id) {
         HALT_ERROR(NOT_ALLOWED, "This function can only be called from the context of an initialized debug box.\n\r");
+    }
+
+    /* Note: Currently we do not act differently based on the reset reason. */
+    if (reason >= __TRESETREASON_MAX) {
+        HALT_ERROR(NOT_ALLOWED, "Invalid reset reason: %d.\r\n", reason);
     }
 
     /* Reboot.


### PR DESCRIPTION
This PR virtualizes the `NVIC_SystemReset` API.

> **Note**: The API can be used only by the debug box.

Upon merge, we need to update mbed OS and the version of CMSIS 5 it contains (there is a PR ready for that).

I'm also proposing the following change: The `halt_error` handler in a debug box should not trigger a reset automatically, as it is counterintuitive. Instead, uVisor will halt upon return.

The debug box can still call `NVIC_SystemReset` if it wants to.

@meriac @Patater @niklas-arm 