### PR TITLE
Fix page heap alignment issues and ISR stack pointer issues

### DIFF
--- a/core/debug/src/debug.c
+++ b/core/debug/src/debug.c
@@ -65,7 +65,7 @@ void debug_exception_frame(uint32_t lr, uint32_t sp)
     int i;
     int mode = lr & 0x4;
 
-    char exc_sf_verbose[CONTEXT_SWITCH_EXC_SF_SIZE + 1][6] = {
+    char exc_sf_verbose[CONTEXT_SWITCH_EXC_SF_WORDS + 1][6] = {
         "r0", "r1", "r2", "r3", "r12",
         "lr", "pc", "xPSR", "align"
     };
@@ -77,12 +77,12 @@ void debug_exception_frame(uint32_t lr, uint32_t sp)
 
     /* print exception stack frame */
     dprintf("  Exception stack frame:\n");
-    i = CONTEXT_SWITCH_EXC_SF_SIZE;
+    i = CONTEXT_SWITCH_EXC_SF_WORDS;
     if(((uint32_t *) sp)[8] & (1 << 9))
     {
         dprintf("    %csp[%02d]: 0x%08X | %s\n", mode ? 'p' : 'm', i, ((uint32_t *) sp)[i], exc_sf_verbose[i]);
     }
-    for(i = CONTEXT_SWITCH_EXC_SF_SIZE - 1; i >= 0; --i)
+    for(i = CONTEXT_SWITCH_EXC_SF_WORDS - 1; i >= 0; --i)
     {
         dprintf("    %csp[%02d]: 0x%08X | %s\n", mode ? 'p' : 'm', i, ((uint32_t *) sp)[i], exc_sf_verbose[i]);
     }

--- a/core/system/inc/context.h
+++ b/core/system/inc/context.h
@@ -25,7 +25,8 @@
  *
  * @warning Currently only the FPU-disabled case is supported. Exceptions that
  * generates when the FPU is enabled will escalate to a hard fault. */
-#define CONTEXT_SWITCH_EXC_SF_SIZE 8
+#define CONTEXT_SWITCH_EXC_SF_WORDS 8
+#define CONTEXT_SWITCH_EXC_SF_BYTES (CONTEXT_SWITCH_EXC_SF_WORDS * sizeof(uint32_t))
 
 /** Maximum number of arguments that can be passed to a function-bound context
  * switch. */

--- a/core/system/src/context.c
+++ b/core/system/src/context.c
@@ -98,21 +98,12 @@ TContextPreviousState * context_state_previous(void)
 /* Forge a new exception stack frame and copy arguments from an old one. */
 uint32_t context_forge_exc_sf(uint32_t src_sp, uint8_t dst_id, uint32_t dst_fn, uint32_t dst_lr, uint32_t xpsr, int nargs)
 {
-    uint8_t src_id;
     uint32_t dst_sp;
     uint32_t exc_sf_alignment_words;
 
-    /* Source box: Gather information from the current state. */
-    src_id = g_active_box;
-
     /* Destination box: Gather information from the current state. */
-    /* Note: Here we allow source and destination box IDs to be the same, as
-     * this function is used also for IRQs. */
-    if (src_id == dst_id) {
-        dst_sp = src_sp;
-    } else {
-        dst_sp = g_context_current_states[dst_id].sp;
-    }
+    /* FIXME: This prevents IRQ interrupt nesting. */
+    dst_sp = g_context_current_states[dst_id].sp;
 
     /* Forge an exception stack frame in the destination box stack. */
     exc_sf_alignment_words = (dst_sp & 0x4) ? 1 : 0;

--- a/core/system/src/mpu/vmpu_armv7m.c
+++ b/core/system/src/mpu/vmpu_armv7m.c
@@ -359,8 +359,10 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 
     /* allocate context pointer */
     g_context_current_states[box_id].bss = slots_ctx ? box_mem_pos : (uint32_t) NULL;
-    /* ensure stack band on top for stack underflow dectection */
-    g_context_current_states[box_id].sp = (box_mem_pos + size - UVISOR_STACK_BAND_SIZE);
+    /* `(box_mem_pos + size)` is already outside the memory protected by the
+     * MPU region, so a pointer 8B below stack top is chosen (8B due to stack
+     * alignment requirements). */
+    g_context_current_states[box_id].sp = (box_mem_pos + size) - 8;
 
     /* Reset uninitialized secured box context. */
     if (slots_ctx) {

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -83,7 +83,7 @@ int page_allocator_get_active_mask_for_address(uint32_t address, uint8_t * mask,
     }
     *page = p;
     /* Compute the page mask and index. */
-    p += UVISOR_PAGE_MAP_COUNT * 32 - g_page_count_total;
+    p += g_page_map_shift;
     *mask = (uint8_t) (g_page_owner_map[box_id][p / 32] >> ((p % 32) & ~7));
     *index = p / 8;
 


### PR DESCRIPTION
This fixes the alignment issues on the page heap MPU region with the introduction of an additional shift.

This also fixes one issue with the ISR stack pointer on v7-M MPU on my experimental EFM32GG port, as described in #326.
However, I still get Hardfaults for an unstack error within 10mins, but only if IRQ2 (used by `us_ticker`) is registered. Other IRQs including GPIO interrupts do not trigger this behavior.

cc @AlessandroA @meriac @Patater 