### PR TITLE
Save some flash space by consolidating halts

### DIFF
--- a/core/debug/src/debug.c
+++ b/core/debug/src/debug.c
@@ -163,14 +163,11 @@ static void debug_die(void)
 
 void debug_reboot(TResetReason reason)
 {
-    if (!g_debug_box.initialized || g_active_box != g_debug_box.box_id) {
-        HALT_ERROR(NOT_ALLOWED, "This function can only be called from the context of an initialized debug box.\n\r");
+    if (!g_debug_box.initialized || g_active_box != g_debug_box.box_id || reason >= __TRESETREASON_MAX) {
+        halt(NOT_ALLOWED);
     }
 
     /* Note: Currently we do not act differently based on the reset reason. */
-    if (reason >= __TRESETREASON_MAX) {
-        HALT_ERROR(NOT_ALLOWED, "Invalid reset reason: %d.\r\n", reason);
-    }
 
     /* Reboot.
      * If called from unprivileged code, NVIC_SystemReset causes a fault. */


### PR DESCRIPTION
This helps reduce the flash size of our debug build at the expense of
the suitability of the debug build for debugging.

An issue at https://github.com/ARMmbed/uvisor/issues/337 tracks our
progress towards solving this problem in a way that does not reduce the
suitability of the debug build for debugging.

@AlessandroA