### PR TITLE
Make the main box config pointer extern

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 UVISOR_EXTERN const uint32_t __uvisor_mode;
+UVISOR_EXTERN void const * const main_cfg_ptr;
 
 #define UVISOR_DISABLED   0
 #define UVISOR_PERMISSIVE 1


### PR DESCRIPTION
This allows macros or APIs to use the main box as a target for security
operations. A common example is using the SECURE_ACCESS() APIs targeting
box 0.

After this PR is merged, we can remove [this commit](https://github.com/Patater/mbed-os/commit/c184e18fca8a7c0417da73bdf7dfb0e252812cb0) from the EFM32GG port.

@meriac @Patater @niklas-arm 