### PR TITLE
Stack fault recovery

### DIFF
--- a/api/inc/unvic_exports.h
+++ b/api/inc/unvic_exports.h
@@ -21,7 +21,7 @@
 
 /* this value refers to the minimum allowable priority in the physical NVIC
  * module, but not in the virtualised one (vIRQ) */
-#define __UVISOR_NVIC_MIN_PRIORITY ((uint32_t) 1)
+#define __UVISOR_NVIC_MIN_PRIORITY ((uint32_t) 2)
 
 /* this is the maximum priority allowed for the vIRQ module */
 /* users of uVisor APIs can use this to determine the maximum level of

--- a/core/debug/inc/debug.h
+++ b/core/debug/inc/debug.h
@@ -42,6 +42,13 @@ uint32_t debug_get_version(void);
 void debug_halt_error(THaltError reason);
 void debug_reboot(TResetReason reason);
 
+/* Enter the debug box from a privileged mode exception handler. This function
+ * requires the caller to have already switched the PSP to the debug box stack.
+ * We currently only call this on MPU faults and Hard Faults in
+ * vmpu_sys_mux_handler. If called from outside a privileged mode exception
+ * handler, this function does nothing. */
+uint32_t debug_box_enter_from_priv(uint32_t lr);
+
 #ifdef  NDEBUG
 
 #define DEBUG_INIT(...)          {}

--- a/core/debug/src/debug_box.c
+++ b/core/debug/src/debug_box.c
@@ -47,14 +47,14 @@ static void debug_deprivilege_and_return(void * debug_handler, void * return_han
 {
     /* Source box: Get the current stack pointer. */
     /* Note: The source stack pointer is only used to assess the stack
-     *       alignment. */
+     *       alignment and to read the xpsr. */
     uint32_t src_sp = context_validate_exc_sf(__get_PSP());
 
     /* Destination box: The debug box. */
     uint8_t dst_id = g_debug_box.box_id;
 
     /* Copy the xPSR from the source exception stack frame. */
-    uint32_t xpsr = ((uint32_t *) src_sp)[7];
+    uint32_t xpsr = vmpu_unpriv_uint32_read((uint32_t) &((uint32_t *) src_sp)[7]);
 
     /* Destination box: Forge the destination stack frame. */
     /* Note: We manually have to set the 4 parameters on the destination stack,

--- a/core/system/src/system.c
+++ b/core/system/src/system.c
@@ -91,9 +91,8 @@ void UVISOR_NAKED UVISOR_NORETURN isr_default_sys_handler(void)
     asm volatile(
         "mov r0, lr\n"
         "mrs r1, MSP\n"
-        "push {lr}\n"
-        "blx vmpu_sys_mux_handler\n"
-        "pop {pc}\n"
+        "bl vmpu_sys_mux_handler\n"
+        "bx r0\n"
     );
 }
 

--- a/core/system/src/unvic.c
+++ b/core/system/src/unvic.c
@@ -579,15 +579,14 @@ void unvic_init(void)
     /* Verify that the priority bits read at runtime are realistic. */
     assert(g_nvic_prio_bits > 0 && g_nvic_prio_bits <= 8);
 
-    /* check that minimum priority is still in the range of possible priority
-     * levels */
+    /* Check that minimum priority is still in the range of possible priority
+     * levels. */
     assert(__UVISOR_NVIC_MIN_PRIORITY < UVISOR_VIRQ_MAX_PRIORITY);
 
-    /* by setting the priority group to 0 we make sure that all priority levels
+    /* By setting the priority group to 0 we make sure that all priority levels
      * are available for pre-emption and that interrupts with the same priority
      * level occurring at the same time are served in the default way, that is,
-     * by IRQ number
-     * for example, IRQ 0 has precedence over IRQ 1 if both have the same
-     * priority level */
+     * by IRQ number. For example, IRQ 0 has precedence over IRQ 1 if both have
+     * the same priority level. */
     NVIC_SetPriorityGrouping(0);
 }

--- a/core/system/src/unvic.c
+++ b/core/system/src/unvic.c
@@ -583,6 +583,21 @@ void unvic_init(void)
      * levels. */
     assert(__UVISOR_NVIC_MIN_PRIORITY < UVISOR_VIRQ_MAX_PRIORITY);
 
+    /* Set the priority of each exception. SVC is lower priority than
+     * MemManage, BusFault, and UsageFault, so that we can recover from
+     * stacking MemManage faults more simply. */
+    static const uint32_t priority_0 = __UVISOR_NVIC_MIN_PRIORITY - 2;
+    static const uint32_t priority_1 = __UVISOR_NVIC_MIN_PRIORITY - 1;
+    assert(priority_0 < __UVISOR_NVIC_MIN_PRIORITY);
+    assert(priority_1 < __UVISOR_NVIC_MIN_PRIORITY);
+    NVIC_SetPriority(MemoryManagement_IRQn, priority_0);
+    NVIC_SetPriority(BusFault_IRQn, priority_0);
+    NVIC_SetPriority(UsageFault_IRQn, priority_0);
+    NVIC_SetPriority(SVCall_IRQn, priority_1);
+    NVIC_SetPriority(DebugMonitor_IRQn, __UVISOR_NVIC_MIN_PRIORITY);
+    NVIC_SetPriority(PendSV_IRQn, UVISOR_VIRQ_MAX_PRIORITY);
+    NVIC_SetPriority(SysTick_IRQn, UVISOR_VIRQ_MAX_PRIORITY);
+
     /* By setting the priority group to 0 we make sure that all priority levels
      * are available for pre-emption and that interrupts with the same priority
      * level occurring at the same time are served in the default way, that is,

--- a/core/vmpu/inc/vmpu.h
+++ b/core/vmpu/inc/vmpu.h
@@ -155,7 +155,9 @@ extern void vmpu_arch_init_hw(void);
 extern int  vmpu_init_pre(void);
 extern void vmpu_init_post(void);
 
-extern void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp);
+/* Handle system exceptions and interrupts. Return the EXC_RETURN desired for
+ * returning from exception mode. */
+extern uint32_t vmpu_sys_mux_handler(uint32_t lr, uint32_t msp);
 
 /* contains the total number of boxes
  * boxes are enumerated from 0 to (g_vmpu_box_count - 1) and the following

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -91,7 +91,7 @@ static int vmpu_fault_recovery_mpu(uint32_t pc, uint32_t sp, uint32_t fault_addr
     uint8_t mask, index, page;
 
     /* No recovery is possible if the MPU syndrome register is not valid. */
-    if (fault_status != 0x82) {
+    if (fault_status == (SCB_CFSR_MMARVALID_Msk | SCB_CFSR_DACCVIOL_Msk)) {
         return 0;
     }
 

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -209,7 +209,7 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
             break;
 
         default:
-            HALT_ERROR(NOT_ALLOWED, "Active IRQn is not a system interrupt");
+            HALT_ERROR(NOT_ALLOWED, "Active IRQn(%i) is not a system interrupt", ipsr);
             break;
     }
 }

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -35,7 +35,7 @@ static int vmpu_fault_recovery_mpu(uint32_t pc, uint32_t sp, uint32_t fault_addr
     uint32_t start_addr, end_addr;
     uint8_t page;
 
-    /* Check if fault address is a page */
+    /* Check if the fault address is a page. */
     if (page_allocator_get_active_region_for_address(fault_addr, &start_addr, &end_addr, &page) == UVISOR_ERROR_PAGE_OK)
     {
         /* Remember this fault. */
@@ -55,36 +55,34 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
     uint32_t psp, pc;
     uint32_t fault_addr, fault_status;
 
-    /* the IPSR enumerates interrupt numbers from 0 up, while *_IRQn numbers are
-     * both positive (hardware IRQn) and negative (system IRQn); here we convert
-     * the IPSR value to this latter encoding */
+    /* The IPSR enumerates interrupt numbers from 0 up, while *_IRQn numbers
+     * are both positive (hardware IRQn) and negative (system IRQn); here we
+     * convert the IPSR value to this latter encoding */
     int ipsr = ((int) (__get_IPSR() & 0x1FF)) - NVIC_OFFSET;
 
     /* PSP at fault */
     psp = __get_PSP();
 
-    switch(ipsr)
-    {
+    switch (ipsr) {
         case MemoryManagement_IRQn:
             DEBUG_FAULT(FAULT_MEMMANAGE, lr, lr & 0x4 ? psp : msp);
             break;
 
         case BusFault_IRQn:
-            /* where a Freescale MPU is used, bus faults can originate both as
+            /* Where a Freescale MPU is used, bus faults can originate both as
              * pure bus faults or as MPU faults; in addition, they can be both
-             * precise and imprecise
-             * there is also an additional corner case: some registers (MK64F)
+             * precise and imprecise.
+             * There is also an additional corner case: some registers (MK64F)
              * cannot be accessed in unprivileged mode even if an MPU region is
              * created for them and the corresponding bit in PACRx is set. In
-             * some cases we want to allow access for them (with ACLs), hence we
-             * use a function that looks for a specially crafted opcode */
+             * some cases we want to allow access for them (with ACLs), hence
+             * we use a function that looks for a specially crafted opcode. */
 
-            /* note: all recovery functions update the stacked stack pointer so
-             * that exception return points to the correct instruction */
+            /* Note: All recovery functions update the stacked stack pointer so
+             * that exception return points to the correct instruction. */
 
-            /* currently we only support recovery from unprivileged mode */
-            if(lr & 0x4)
-            {
+            /* Currently we only support recovery from unprivileged mode. */
+            if (lr & 0x4) {
                 /* pc at fault */
                 pc = vmpu_unpriv_uint32_read(psp + (6 * 4));
 
@@ -92,7 +90,7 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
                 fault_addr = SCB->BFAR;
                 fault_status = VMPU_SCB_BFSR;
 
-                /* check if the fault is an MPU fault */
+                /* Check if the fault is an MPU fault. */
                 int slave_port = vmpu_fault_get_slave_port();
                 if (slave_port >= 0) {
                     /* If the fault comes from the MPU module, we don't use the
@@ -114,19 +112,17 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
                     DPRINTF("Multiple MPU violations found.\r\n");
                 }
 
-                /* check if the fault is the special register corner case */
+                /* Check if the fault is the special register corner case. */
                 if (!vmpu_fault_recovery_bus(pc, psp, fault_addr, fault_status)) {
                     VMPU_SCB_BFSR = fault_status;
                     return;
                 }
 
-                /* if recovery was not successful, throw an error and halt */
+                /* If recovery was not successful, throw an error and halt. */
                 DEBUG_FAULT(FAULT_BUS, lr, psp);
                 VMPU_SCB_BFSR = fault_status;
                 HALT_ERROR(PERMISSION_DENIED, "Access to restricted resource denied");
-            }
-            else
-            {
+            } else {
                 DEBUG_FAULT(FAULT_BUS, lr, msp);
                 HALT_ERROR(FAULT_BUS, "Cannot recover from privileged bus fault");
             }
@@ -162,15 +158,14 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 {
     static uint32_t g_box_mem_pos = 0;
 
-    /* handle main box */
-    if (box_id == 0)
-    {
+    /* Handle main box. */
+    if (box_id == 0) {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
         assert(stack_size == 0);
 
-        /* assign main box stack pointer to existing
-         * unprivileged stack pointer */
+        /* Assign main box stack pointer to existing unprivileged stack
+         * pointer. */
         g_context_current_states[0].sp = __get_PSP();
         /* Box 0 still uses the main heap to be backwards compatible. */
         g_context_current_states[0].bss = (uint32_t) __uvisor_config.heap_start;
@@ -178,16 +173,16 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
     }
 
     if (!g_box_mem_pos) {
-        /* initialize box memories, leave stack-band sized gap */
+        /* Initialize box memories. Leave stack-band sized gap. */
         g_box_mem_pos = UVISOR_REGION_ROUND_UP(
             (uint32_t)__uvisor_config.bss_boxes_start) +
             UVISOR_STACK_BAND_SIZE;
     }
 
-    /* ensure stack & context alignment */
+    /* Ensure stack & context alignment. */
     stack_size = UVISOR_REGION_ROUND_UP(UVISOR_MIN_STACK(stack_size));
 
-    /* add stack ACL */
+    /* Add stack ACL. */
     vmpu_region_add_static_acl(
         box_id,
         g_box_mem_pos,
@@ -196,13 +191,13 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
         0
     );
 
-    /* set stack pointer to box stack size minus guard band */
+    /* Set stack pointer to box stack size minus guard band. */
     g_box_mem_pos += stack_size;
     g_context_current_states[box_id].sp = g_box_mem_pos;
-    /* add stack protection band */
+    /* Add stack protection band. */
     g_box_mem_pos += UVISOR_STACK_BAND_SIZE;
 
-    /* add context ACL */
+    /* Add context ACL. */
     assert(bss_size != 0);
     bss_size = UVISOR_REGION_ROUND_UP(bss_size);
     g_context_current_states[box_id].bss = g_box_mem_pos;
@@ -212,14 +207,14 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
         bss_size
     );
 
-    /* reset uninitialized secured box context */
+    /* Reset uninitialized secured box context. */
     memset(
         (void *) g_box_mem_pos,
         0,
         bss_size
     );
 
-    /* add context ACL */
+    /* Add context ACL. */
     vmpu_region_add_static_acl(
         box_id,
         g_box_mem_pos,
@@ -233,7 +228,7 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 
 void vmpu_switch(uint8_t src_box, uint8_t dst_box)
 {
-    /* check for errors */
+    /* Check for errors. */
     if (!vmpu_is_box_id_valid(src_box)) {
         HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The source box ID is out of range (%u).\r\n", src_box);
     }
@@ -241,31 +236,30 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
         HALT_ERROR(SANITY_CHECK_FAILED, "vMPU switch: The destination box ID is out of range (%u).\r\n", dst_box);
     }
 
-    /* switch ACLs for peripherals */
+    /* Switch ACLs for peripherals. */
     vmpu_aips_switch(src_box, dst_box);
 
-    /* switch ACLs for memory regions */
+    /* Switch ACLs for memory regions. */
     vmpu_mem_switch(src_box, dst_box);
 }
 
 uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)
 {
-    /* only support peripheral access and corner cases for now */
+    /* Only support peripheral access and corner cases for now. */
     /* FIXME: Use SECURE_ACCESS for SCR! */
     if (fault_addr == (uint32_t) &SCB->SCR) {
         return UVISOR_TACL_UWRITE | UVISOR_TACL_UREAD;
     }
 
-    /* translate fault_addr into its physical address if it is in the bit-banding region */
+    /* Translate fault_addr into its physical address if it is in the bit-banding region. */
     if (VMPU_PERIPH_BITBAND_START <= fault_addr && fault_addr <= VMPU_PERIPH_BITBAND_END) {
         fault_addr = VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(fault_addr);
-    }
-    else if (VMPU_SRAM_BITBAND_START <= fault_addr && fault_addr <= VMPU_SRAM_BITBAND_END) {
+    } else if (VMPU_SRAM_BITBAND_START <= fault_addr && fault_addr <= VMPU_SRAM_BITBAND_END) {
         fault_addr = VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(fault_addr);
     }
 
-    /* look for ACL */
-    if( (AIPS0_BASE <= fault_addr) && (fault_addr < (AIPS0_BASE + 0xFEUL * AIPSx_SLOT_SIZE)) ) {
+    /* Look for ACL. */
+    if ((AIPS0_BASE <= fault_addr) && (fault_addr < (AIPS0_BASE + 0xFEUL * AIPSx_SLOT_SIZE))) {
         return vmpu_fault_find_acl_aips(g_active_box, fault_addr, size);
     }
 
@@ -274,7 +268,7 @@ uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size)
 
 void vmpu_load_box(uint8_t box_id)
 {
-    if(box_id != 0) {
+    if (box_id != 0) {
         HALT_ERROR(NOT_IMPLEMENTED, "currently only box 0 can be loaded");
     }
     vmpu_aips_switch(box_id, box_id);
@@ -285,7 +279,7 @@ void vmpu_arch_init(void)
 {
     vmpu_mpu_init();
 
-    /* init memory protection */
+    /* Init memory protection. */
     vmpu_mem_init();
 
     vmpu_mpu_lock();

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -66,6 +66,7 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
     switch (ipsr) {
         case MemoryManagement_IRQn:
             DEBUG_FAULT(FAULT_MEMMANAGE, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_MEMMANAGE, "Cannot recover from a memmanage fault");
             break;
 
         case BusFault_IRQn:
@@ -130,14 +131,17 @@ void vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
 
         case UsageFault_IRQn:
             DEBUG_FAULT(FAULT_USAGE, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_USAGE, "Cannot recover from a usage fault.");
             break;
 
         case HardFault_IRQn:
             DEBUG_FAULT(FAULT_HARD, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_HARD, "Cannot recover from a hard fault.");
             break;
 
         case DebugMonitor_IRQn:
             DEBUG_FAULT(FAULT_DEBUG, lr, lr & 0x4 ? psp : msp);
+            HALT_ERROR(FAULT_DEBUG, "Cannot recover from a debug fault.");
             break;
 
         case PendSV_IRQn:


### PR DESCRIPTION
Recover from stacking and unstacking faults. Reprioritize faults relative to SVC, so we can recover from more faults and also, as a bonus, get better debug messages. (Other miscellaneous fixes are also included.)

Tested on EFM32GG and K64F with a test that fails before this PR's commits are applied and passes after this PR's commits are applied.

@AlessandroA @meriac @niklas-arm
