### PR TITLE
CMSIS: Fix case-sensitive file inclusions

### DIFF
--- a/core/cmsis/inc/core_cm0.h
+++ b/core/cmsis/inc/core_cm0.h
@@ -203,8 +203,8 @@
 
 #endif
 
-#include "core_cminstr.h"                /* Core Instruction Access */
-#include "core_cmfunc.h"                 /* Core Function Access */
+#include "core_cmInstr.h"                /* Core Instruction Access */
+#include "core_cmFunc.h"                 /* Core Function Access */
 
 #ifdef __cplusplus
 }

--- a/core/cmsis/inc/core_cm0plus.h
+++ b/core/cmsis/inc/core_cm0plus.h
@@ -203,8 +203,8 @@
 
 #endif
 
-#include "core_cminstr.h"                /* Core Instruction Access */
-#include "core_cmfunc.h"                 /* Core Function Access */
+#include "core_cmInstr.h"                /* Core Instruction Access */
+#include "core_cmFunc.h"                 /* Core Function Access */
 
 #ifdef __cplusplus
 }

--- a/core/cmsis/inc/core_cm7.h
+++ b/core/cmsis/inc/core_cm7.h
@@ -250,9 +250,9 @@
 
 #endif
 
-#include "core_cminstr.h"                /* Core Instruction Access */
-#include "core_cmfunc.h"                 /* Core Function Access */
-#include "core_cmsimd.h"                 /* Compiler specific SIMD Intrinsics */
+#include "core_cmInstr.h"                /* Core Instruction Access */
+#include "core_cmFunc.h"                 /* Core Function Access */
+#include "core_cmSimd.h"                 /* Compiler specific SIMD Intrinsics */
 
 #ifdef __cplusplus
 }

--- a/core/cmsis/inc/core_cmFunc.h
+++ b/core/cmsis/inc/core_cmFunc.h
@@ -1,5 +1,5 @@
 /**************************************************************************//**
- * @file     core_cmfunc.h
+ * @file     core_cmFunc.h
  * @brief    CMSIS Cortex-M Core Function Access Header File
  * @version  V5.00
  * @date     02. March 2016

--- a/core/cmsis/inc/core_cmInstr.h
+++ b/core/cmsis/inc/core_cmInstr.h
@@ -1,5 +1,5 @@
 /**************************************************************************//**
- * @file     core_cminstr.h
+ * @file     core_cmInstr.h
  * @brief    CMSIS Cortex-M Core Instruction Access Header File
  * @version  V5.00
  * @date     02. March 2016

--- a/core/cmsis/inc/core_cmSimd.h
+++ b/core/cmsis/inc/core_cmSimd.h
@@ -1,5 +1,5 @@
 /**************************************************************************//**
- * @file     core_cmsimd.h
+ * @file     core_cmSimd.h
  * @brief    CMSIS Cortex-M SIMD Header File
  * @version  V5.00
  * @date     02. March 2016

--- a/core/cmsis/inc/core_sc000.h
+++ b/core/cmsis/inc/core_sc000.h
@@ -203,8 +203,8 @@
 
 #endif
 
-#include "core_cminstr.h"                /* Core Instruction Access */
-#include "core_cmfunc.h"                 /* Core Function Access */
+#include "core_cmInstr.h"                /* Core Instruction Access */
+#include "core_cmFunc.h"                 /* Core Function Access */
 
 #ifdef __cplusplus
 }

--- a/core/cmsis/inc/core_sc300.h
+++ b/core/cmsis/inc/core_sc300.h
@@ -203,8 +203,8 @@
 
 #endif
 
-#include "core_cminstr.h"                /* Core Instruction Access */
-#include "core_cmfunc.h"                 /* Core Function Access */
+#include "core_cmInstr.h"                /* Core Instruction Access */
+#include "core_cmFunc.h"                 /* Core Function Access */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This applies the same fix of
a46ded2 "Fix case sensitive file names in headers"
to all CMSIS header files, including those that are currently unused by uVisor.

@meriac 