### PR TITLE
Adding files for publishing on docs.mbed

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+!{https://raw.githubusercontent.com/ARMmbed/uvisor/master/docs/README.md}
+
+!{https://raw.githubusercontent.com/ARMmbed/uvisor/master/README.md}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: uVisor Guides
+
+docs_dir: Docs
+
+pages:
+- ['index.md','uVisor Documentation']
+- ['api/QUICKSTART.md', 'uVisor', 'Quick start guide']
+- ['core/DEVELOPING_LOCALLY.md', 'uVisor', 'Developing Locally']
+- ['api/DEBUGGING.md', 'uVisor', 'Debugging uVisor']
+- ['core/PORTING.md', 'Porting uVisor', 'Porting uVisor']
+
+copyright: © ARM Ltd. Copyright 2016 – ARM mbed IoT Device Platform


### PR DESCRIPTION
Since we no longer use uvisor_lib, there's no point not using uvisor as the docs source for docs.mbed, instead of uvisor_docs (which merged uvisor_lib and uvisor).

However, this requires adding the YML and an index.md to the repo. I've added them; they shouldn't get in your way too much.