### PR TITLE
Add MPU invalidation API and semaphore timeouts

### DIFF
--- a/api/inc/api.h
+++ b/api/inc/api.h
@@ -60,6 +60,7 @@ typedef struct {
 
     void (*debug_init)(const TUvisorDebugDriver * const driver);
     void (*error)(THaltUserError reason);
+    void (*vmpu_mem_invalidate)(void);
 
     int                (*pool_init)(uvisor_pool_t *, void *, size_t, size_t, int);
     int                (*pool_queue_init)(uvisor_pool_queue_t *, uvisor_pool_t *, void *, size_t, size_t, int);

--- a/api/inc/halt_exports.h
+++ b/api/inc/halt_exports.h
@@ -25,6 +25,7 @@
 #define UVISOR_ERROR_OUT_OF_STRUCTURES          (-7)
 #define UVISOR_ERROR_INVALID_PARAMETERS         (-8)
 #define UVISOR_ERROR_NOT_IMPLEMENTED            (-9)
+#define UVISOR_ERROR_TIMEOUT                    (-10)
 
 
 #define UVISOR_ERROR_CLASS_MASK     (0xFFFF0000UL)

--- a/api/inc/uvisor-lib.h
+++ b/api/inc/uvisor-lib.h
@@ -37,6 +37,7 @@
 #include "api/inc/rpc_gateway.h"
 #include "api/inc/secure_access.h"
 #include "api/inc/uvisor_semaphore.h"
+#include "api/inc/vmpu.h"
 
 #else /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
 

--- a/api/inc/vmpu.h
+++ b/api/inc/vmpu.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_API_VMPU_H__
+#define __UVISOR_API_VMPU_H__
+
+#include "api/inc/uvisor_exports.h"
+#include "api/inc/api.h"
+
+UVISOR_EXTERN_C_BEGIN
+
+/* Invalidate all regions in the MPU, forcing subsequent memory accesses to
+ * fault. */
+static UVISOR_FORCEINLINE void uvisor_vmpu_mem_invalidate(void)
+{
+    uvisor_api.vmpu_mem_invalidate();
+}
+
+UVISOR_EXTERN_C_END
+
+#endif /* __UVISOR_API_VMPU_H__ */

--- a/api/rtx/src/uvisor_semaphore.c
+++ b/api/rtx/src/uvisor_semaphore.c
@@ -35,7 +35,7 @@ int __uvisor_semaphore_pend(UvisorSemaphore * s, uint32_t timeout_ms)
     }
 
     if (num_available_tokens == 0) {
-        return UVISOR_ERROR_OUT_OF_STRUCTURES;
+        return UVISOR_ERROR_TIMEOUT;
     }
 
     return 0;

--- a/core/system/inc/svc.h
+++ b/core/system/inc/svc.h
@@ -45,6 +45,7 @@ typedef struct {
 
     void (*debug_init)(const TUvisorDebugDriver * const driver);
     void (*error)(THaltUserError reason);
+    void (*vmpu_mem_invalidate)(void);
 } UVISOR_PACKED UvisorSvcTarget;
 
 /* macro to execute an SVCall; additional metadata can be provided, which will

--- a/core/system/src/api.c
+++ b/core/system/src/api.c
@@ -52,6 +52,8 @@ transition_np_to_p(debug_init,       void, debug_register_driver, const TUvisorD
 transition_np_to_p(irq_system_reset, void, debug_reboot,          TResetReason reason);
 transition_np_to_p(error,            void, halt_user_error,       THaltUserError reason);
 
+transition_np_to_p(vmpu_mem_invalidate, void, vmpu_mem_invalidate, void);
+
 transition_np_to_p(box_namespace, int,  vmpu_box_namespace_from_id, int box_id, char * box_namespace, size_t length);
 
 transition_np_to_p(page_malloc, int,  page_allocator_malloc,       UvisorPageTable * const table);
@@ -110,6 +112,8 @@ const UvisorApi __uvisor_api = {
 
     .debug_init = debug_init_transition,
     .error = error_transition,
+
+    .vmpu_mem_invalidate = vmpu_mem_invalidate_transition,
 
     .pool_init = uvisor_pool_init,
     .pool_queue_init = uvisor_pool_queue_init,

--- a/core/system/src/svc.c
+++ b/core/system/src/svc.c
@@ -21,6 +21,7 @@
 #include "svc.h"
 #include "unvic.h"
 #include "vmpu.h"
+#include "vmpu_mpu.h"
 #include "page_allocator.h"
 
 /* these symbols are linked in this scope from the ASM code in __svc_irq and
@@ -61,6 +62,8 @@ const UvisorSvcTarget g_svc_vtor_tbl = {
 
     .debug_init = debug_register_driver,
     .error = halt_user_error,
+
+    .vmpu_mem_invalidate = vmpu_mpu_invalidate,
 };
 
 /*******************************************************************************


### PR DESCRIPTION
This is useful for testing as we can use it to force memory faults to
occur at controlled locations.

Also add semaphore timeout reporting, so that `rpc_fncall_waitfor` can report timeouts properly.

@AlessandroA @meriac @niklas-arm
