### PR TITLE
Stm32f4 support

### DIFF
--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -94,6 +94,12 @@ uvisor_config:
     .long __uvisor_sram_start;
     .long __uvisor_sram_end;
 
+    /* Physical memory boundaries of the public SRAM.
+     * This is usually the same as the other SRAM symbols above, but it's
+     * different when uVisor uses a TCM as its own SRAM. */
+    .long __uvisor_public_sram_start;
+    .long __uvisor_public_sram_end;
+
     /* Privileged system hooks */
     .long __uvisor_priv_sys_hooks
 

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -94,6 +94,13 @@ typedef struct {
     uint32_t * sram_start;
     uint32_t * sram_end;
 
+    /* Physical memory boundaries of the public SRAM, the one where the public
+     * box and the page heap space is. When a TCM is available, what uVisor
+     * regards as "SRAM" is the memory where its own memories and the
+     * compile-time defined memories for the private boxes are. */
+    uint32_t * public_sram_start;
+    uint32_t * public_sram_end;
+
     /* Privileged system hooks */
     UvisorPrivSystemHooks const * const priv_sys_hooks;
 

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -84,12 +84,12 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
             "Page size pointer (0x%08x) is not in flash memory.\n",
             (unsigned int) page_size);
     }
-    if (!heap_start || !vmpu_sram_addr((uint32_t) heap_start)) {
+    if (!heap_start || !vmpu_public_sram_addr((uint32_t) heap_start)) {
         HALT_ERROR(SANITY_CHECK_FAILED,
             "Page heap start pointer (0x%08x) is not in sram memory.\n",
             (unsigned int) heap_start);
     }
-    if (!heap_end || !vmpu_sram_addr((uint32_t) heap_end)) {
+    if (!heap_end || !vmpu_public_sram_addr((uint32_t) heap_end)) {
         HALT_ERROR(SANITY_CHECK_FAILED,
             "Page heap end pointer (0x%08x) is not in sram memory.\n",
             (unsigned int) heap_end);

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -461,11 +461,13 @@ void vmpu_arch_init_hw(void)
      *       the same considerations apply. Therefore the uVisor bss section
      *       location has no impact on this.
      */
+
     /* Calculate the region size by rounding up the SRAM size to the next power-of-two. */
-    const uint32_t total_size = (1 << vmpu_region_bits((uint32_t) __uvisor_config.sram_end - (uint32_t) __uvisor_config.sram_start));
+    const uint32_t total_size = (1 << vmpu_region_bits((uint32_t) __uvisor_config.public_sram_end -
+                                                       (uint32_t) __uvisor_config.public_sram_start));
     /* The alignment is 1/8th of the region size = rounded up SRAM size. */
     const uint32_t subregions_size = total_size / 8;
-    const uint32_t protected_size = (uint32_t) __uvisor_config.page_end - (uint32_t) __uvisor_config.sram_start;
+    const uint32_t protected_size = (uint32_t) __uvisor_config.page_end - (uint32_t) __uvisor_config.public_sram_start;
     /* The protected size must be aligned to the subregion size. */
     if (protected_size % subregions_size != 0) {
         HALT_ERROR(SANITY_CHECK_FAILED,
@@ -482,7 +484,7 @@ void vmpu_arch_init_hw(void)
      *       distinguish between the two. */
     vmpu_mpu_set_static_acl(
         1,
-        (uint32_t) __uvisor_config.sram_start,
+        (uint32_t) __uvisor_config.public_sram_start,
         total_size,
         UVISOR_TACLDEF_DATA | UVISOR_TACL_EXECUTE,
         subregions_disable_mask


### PR DESCRIPTION
In the past a tightly-coupled memory (TCM) could be used easily in place
of the SRAM because what uVisor expected in SRAM was simply moved to the
TCM itself.

Now that we have the page heap the situation is different: If uVisor
uses the TCM then only uVisor own memories and the compile-time-defined
boxes private memories are put in the TCM, whereas the page heap stays
in the actual SRAM.

This commit updates the uVisor codebase as follows:

* Generalize range-checking functions for physical/public SRAM.
* Make sure that sanity checks apply to the correct memory.
* Adapt the static MPU region settings for the SRAM to only cover the
  public SRAM.

This commit requires an update to our linker scripts, where the
public SRAM start and end addresses are specified. The changes required
will be introduced in a different PR and are captured in the
updated porting guide.

@meriac @Patater @niklas-arm 