### PR TITLE
Docker: Fix missing .gitconfig

### DIFF
--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -46,6 +46,6 @@ RUN \
 RUN useradd -c "mbed Developer" -m mbed
 
 # configure git
-COPY .gitconfig /home/mbed/
+COPY mbed-gitconfig /home/mbed/.gitconfig
 
 CMD ["/usr/bin/su","-l","mbed"]

--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -39,6 +39,7 @@ RUN \
 ENV CCACHE_DIR=/usr/lib64/ccache
 ENV CCACHE_BIN=../../bin/ccache
 RUN \
+	ln -s `which arm-none-eabi-objcopy` ${CCACHE_DIR}/arm-none-eabi-objcopy &&\
 	ln -s ${CCACHE_BIN} ${CCACHE_DIR}/arm-none-eabi-g++ && \
 	ln -s ${CCACHE_BIN} ${CCACHE_DIR}/arm-none-eabi-c++
 

--- a/tools/docker/base/mbed-gitconfig
+++ b/tools/docker/base/mbed-gitconfig
@@ -1,0 +1,10 @@
+[credential]
+	helper = store
+[color]
+	ui = true
+[push]
+	default = matching
+[merge]
+	conflictstyle = merge
+[core]
+	editor = /usr/bin/vim


### PR DESCRIPTION
Add back missing git configuration file for docker build.
- enable password storing
- 'matching' push style
- use vim as default editor

@AlessandroA 
