### PR TITLE
Fix out-by-one error in vmpu_mpu_push

### DIFF
--- a/core/vmpu/src/armv7m/vmpu_armv7m_mpu.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m_mpu.c
@@ -411,7 +411,7 @@ bool vmpu_mpu_push(const MpuRegion * const region, uint8_t priority)
     uint8_t viable_slot = start_slot;
 
     do {
-        if (++g_mpu_slot > ARMv7M_MPU_REGIONS_MAX) {
+        if (++g_mpu_slot >= ARMv7M_MPU_REGIONS_MAX) {
             g_mpu_slot = ARMv7M_MPU_REGIONS_STATIC;
         }
 


### PR DESCRIPTION
See issue #369.

This function pushes a slot/region into the v7M MPU. If `g_mpu_slot` is equal to `ARMv7M_MPU_REGIONS_MAX` (say 8) then the overflow check

```
  (++g_mpu_slot > ARMv7M_MPU_REGIONS_MAX)
    ==
  (8 > 8)
    ==
  false
```

does not fire (when it should) and the function will access the array `g_mpu_priority[8]` out-of-bounds and write to an unsupported region number.