### PR TITLE
Fix enabling v7M MPU too early

### DIFF
--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -401,8 +401,6 @@ void vmpu_arch_init(void)
     /* Initialize static MPU regions. */
     vmpu_arch_init_hw();
 
-    vmpu_mpu_lock();
-
     /* Dump MPU configuration in debug mode. */
 #ifndef NDEBUG
     debug_mpu_config();

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -517,6 +517,9 @@ void vmpu_init_post(void)
 
     /* load boxes */
     vmpu_load_boxes();
+
+    /* enable mpu */
+    vmpu_mpu_lock();
 }
 
 static int copy_box_namespace(const char *src, char *dst)


### PR DESCRIPTION
See issue #380.

Move call to` vmpu_mpu_lock()` after `vmpu_load_box()`. This guarantees that all RBAR/RASR registers have been written-to (by `vmpu_mpu_invalidate()`) before the MPU is enabled.

My only concern is whether this change is compatible with the Kinetis MPU.