### PR TITLE
Quickstart example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Different memory layouts can be used on different platforms, depending on the im
 
 The uVisor secures two main memory blocks, in flash and SRAM respectively. In both cases, it protects its own data and the data of the secure boxes it manages for the unprivileged code. For a more detailed view please refer to our interactive [linker section visualization](https://meriac.github.io/mbed-os-linker-report/)).
 
-All the unprivileged code that is not protected in a secure domain is referred to as the *main box*.
+All the unprivileged code that is not protected in a secure domain is referred to as the *public box*.
 
 The main memory sections that the uVisor protects are detailed in the following table:
 
@@ -151,7 +151,7 @@ The uVisor is initialised right after device start-up and takes ownership of its
 1. Privileged and unprivileged stack pointers are initialised.
 1. Execution is de-privileged and handed over to the unprivileged code.
 
-From this moment on, the operating system/application runs in unprivileged mode and in the default context, which is the one of the main box.
+From this moment on, the operating system/application runs in unprivileged mode and in the default context, which is the one of the public box.
 
 ### Context switching
 

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 UVISOR_EXTERN const uint32_t __uvisor_mode;
-UVISOR_EXTERN void const * const main_cfg_ptr;
+UVISOR_EXTERN void const * const public_box_cfg_ptr;
 
 #define UVISOR_DISABLED   0
 #define UVISOR_PERMISSIVE 1
@@ -41,7 +41,7 @@ UVISOR_EXTERN void const * const main_cfg_ptr;
     \
     UVISOR_EXTERN const uint32_t __uvisor_mode = (mode); \
     \
-    static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig main_cfg = { \
+    static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig public_box_cfg = { \
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
         0, \
@@ -59,14 +59,14 @@ UVISOR_EXTERN void const * const main_cfg_ptr;
         acl_list_count \
     }; \
     \
-    UVISOR_EXTERN const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_cfg;
+    UVISOR_EXTERN const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const public_box_cfg_ptr = &public_box_cfg;
 
 /* Creates a global page heap with at least `minimum_number_of_pages` each of size `page_size` in bytes.
  * The total page heap size is at least `minimum_number_of_pages * page_size`. */
 #define UVISOR_SET_PAGE_HEAP(page_size, minimum_number_of_pages) \
     const uint32_t __uvisor_page_size = (page_size); \
     uint8_t __attribute__((section(".keep.uvisor.page_heap"))) \
-        main_page_heap_reserved[ (page_size) * (minimum_number_of_pages) ]
+        public_page_heap_reserved[ (page_size) * (minimum_number_of_pages) ]
 
 
 /* this macro selects an overloaded macro (variable number of arguments) */

--- a/api/inc/unsupported.h
+++ b/api/inc/unsupported.h
@@ -42,8 +42,8 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 
 #define UVISOR_SET_MODE_ACL_COUNT(mode, acl_list, acl_list_count) \
     UVISOR_EXTERN const uint32_t __uvisor_mode = UVISOR_DISABLED; \
-    static const void *main_acl = acl_list; \
-    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const main_cfg_ptr = &main_acl;
+    static const void *public_box_acl = acl_list; \
+    extern const __attribute__((section(".keep.uvisor.cfgtbl_ptr_first"), aligned(4))) void * const public_box_cfg_ptr = &public_box_acl;
 
 #define __UVISOR_BOX_CONFIG_NOCONTEXT(box_name, acl_list, stack_size) \
     static const void *box_acl_ ## box_name = acl_list; \

--- a/api/rtx/src/unsupported_malloc.c
+++ b/api/rtx/src/unsupported_malloc.c
@@ -59,18 +59,18 @@ static void box_index_init(void *box_bss, uint32_t heap_size)
 
 void secure_malloc_init(void)
 {
-    /* get the main heap size from the linker script */
+    /* get the public heap size from the linker script */
     uint32_t heap_size = ((uint32_t) __HeapLimit -
                           (uint32_t) __end__);
-    /* Main heap size is aligned to page boundaries n*UVISOR_PAGE_SIZE */
+    /* Public heap size is aligned to page boundaries n*UVISOR_PAGE_SIZE */
     uint32_t heap_start = (uint32_t) __StackLimit - heap_size;
-    /* align the start address of the main heap to a page boundary */
+    /* align the start address of the public heap to a page boundary */
     heap_start &= ~(UVISOR_PAGE_SIZE - 1);
     /* adjust the heap size to the new heap start address */
     heap_size = (uint32_t) __StackLimit - heap_start;
 
-    /* page heap now extends from the previous main heap start address
-     * to the new main heap start address */
+    /* page heap now extends from the previous public heap start address
+     * to the new public heap start address */
     extern uint32_t __uvisor_page_size;
     page_allocator_init(__end__, (void *) heap_start, &__uvisor_page_size);
     box_index_init((void *) heap_start, heap_size);

--- a/api/src/uvisor-input.S
+++ b/api/src/uvisor-input.S
@@ -77,7 +77,7 @@ uvisor_config:
     /* Address of __uvisor_box_context */
     .long __uvisor_box_context
 
-    /* Main heap for box 0 */
+    /* Public heap (used by the public box) */
     .long __uvisor_heap_start
     .long __uvisor_heap_end
 

--- a/core/system/inc/linker.h
+++ b/core/system/inc/linker.h
@@ -77,7 +77,7 @@ typedef struct {
     /* Address of __uvisor_box_context */
     uint32_t * * uvisor_box_context;
 
-    /* Main heap for box 0 */
+    /* Public heap (used by the public box) */
     uint32_t * heap_start;
     uint32_t * heap_end;
 

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -282,7 +282,7 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
     while (dst_count-- && vmpu_mpu_push(region++, 2));
 
     if (!dst_box) {
-        /* Handle main box ACLs last. */
+        /* Handle public box ACLs last. */
         vmpu_region_get_for_box(0, &region, &dst_count);
 
         while (dst_count-- && vmpu_mpu_push(region++, 1));
@@ -310,17 +310,17 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
         box_mem_pos = (uint32_t) __uvisor_config.bss_boxes_start;
     }
 
-    /* Handle main box. */
+    /* Handle public box. */
     if (box_id == 0)
     {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* Non-important sanity checks */
         assert(stack_size == 0);
 
-        /* Assign main box stack pointer to existing unprivileged stack
+        /* Assign public box stack pointer to existing unprivileged stack
          * pointer. */
         g_context_current_states[0].sp = __get_PSP();
-        /* Box 0 still uses the main heap to be backwards compatible. */
+        /* Box 0 still uses the public heap to be backwards compatible. */
         g_context_current_states[0].bss = (uint32_t) __uvisor_config.heap_start;
         return;
     }

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -181,16 +181,16 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size)
 {
     static uint32_t g_box_mem_pos = 0;
 
-    /* Handle main box. */
+    /* Handle public box. */
     if (box_id == 0) {
         DPRINTF("ctx=%i stack=%i\n\r", bss_size, stack_size);
         /* non-important sanity checks */
         assert(stack_size == 0);
 
-        /* Assign main box stack pointer to existing unprivileged stack
+        /* Assign public box stack pointer to existing unprivileged stack
          * pointer. */
         g_context_current_states[0].sp = __get_PSP();
-        /* Box 0 still uses the main heap to be backwards compatible. */
+        /* Box 0 still uses the public heap to be backwards compatible. */
         g_context_current_states[0].bss = (uint32_t) __uvisor_config.heap_start;
         return;
     }

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -210,7 +210,7 @@ static void vmpu_box_index_init(uint8_t box_id, const UvisorBoxConfig * const co
     int i;
 
     if (box_id == 0) {
-        /* Box 0 still uses the main heap to be backwards compatible. */
+        /* Box 0 still uses the public heap to be backwards compatible. */
         const uint32_t heap_end = (uint32_t) __uvisor_config.heap_end;
         const uint32_t heap_start = (uint32_t) __uvisor_config.heap_start;
         heap_size = (heap_end - heap_start) - config->index_size;

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -116,14 +116,14 @@ UVISOR_SET_MODE(UVISOR_ENABLED);
 ---
 
 ```C
-UVISOR_SET_MODE_ACL(uvisor_mode, const UvBoxAcl *main_box_acl_list);
+UVISOR_SET_MODE_ACL(uvisor_mode, const UvBoxAcl *public_box_acl_list);
 ```
 
 <table>
   <tr>
     <td>Description</td>
     <td colspan="2">[temporary] Set mode for the uVisor and provide background
-                    ACLs for the main box
+                    ACLs for the public box
     </td>
   </tr>
   <tr>
@@ -141,8 +141,8 @@ UVISOR_SET_MODE_ACL(uvisor_mode, const UvBoxAcl *main_box_acl_list);
   <tr>
     <td><pre>UVISOR_ENABLED<code> = enabled</td>
   <tr>
-    <td><pre>const UvBoxAclItem *main_box_acl_list<code></td>
-    <td>List of ACLs for the main box (background ACLs)</td>
+    <td><pre>const UvBoxAclItem *public_box_acl_list<code></td>
+    <td>List of ACLs for the public box (background ACLs)</td>
   </tr>
 </table>
 
@@ -150,7 +150,7 @@ Example:
 ```C
 #include "uvisor-lib/uvisor-lib.h"
 
-/* Create background ACLs for the main box. */
+/* Create background ACLs for the public box. */
 static const UvBoxAclItem g_background_acl[] = {
     {UART0,       sizeof(*UART0), UVISOR_TACL_PERIPHERAL},
     {UART1,       sizeof(*UART1), UVISOR_TACL_PERIPHERAL},

--- a/docs/api/manual/Technical.md
+++ b/docs/api/manual/Technical.md
@@ -24,7 +24,7 @@ Each process gets at compile-time a fixed memory pool assigned which will be use
 
 The uVisor secures two main memory blocks, in flash and SRAM respectively. In both cases, it protects its own data and the data of the secure boxes it manages for the unprivileged code.
 
-All the unprivileged code that is not protected in a secure domain is referred to as the *main process*.
+All the unprivileged code that is not protected in a secure domain is referred to as the *public box*.
 
 The main memory sections protected by uVisor are detailed in the following table:
 

--- a/docs/api/manual/UseCases.md
+++ b/docs/api/manual/UseCases.md
@@ -396,7 +396,7 @@ Three new capabilities are added to uVisor to support RTOS integration.
 
 #### Ability for a box to specify a main thread
 
-A box's main thread is where code execution begins in that box. Each box has one main thread, with the exception of the main box (box 0). The box's "Box Config" specifies the function to use for that box's main thread.
+A box's main thread is where code execution begins in that box. Each box has one main thread, with the exception of the public box (box 0). The box's "Box Config" specifies the function to use for that box's main thread.
 
 The following is an example of box configuration. Note the use of the `UVISOR_BOX_MAIN` macro to specify the function to use as the body of the box's main thread.
 ```C
@@ -410,9 +410,9 @@ UVISOR_BOX_MAIN(example_box_main, osPriorityNormal);
 UVISOR_BOX_CONFIG(example_box, acl, UVISOR_BOX_STACK_SIZE, box_context);
 ```
 
-The main box's code execution starts the same way that it starts when uVisor is not present.
+The public box's code execution starts the same way that it starts when uVisor is not present.
 
-For all boxes other than the main box: after libc, the RTOS, and C++ statically constructed objects are initialized, and the RTOS is about to start, the RTOS asks uVisor to handle the "pre-start" event. uVisor then creates main threads for each box. The main threads use the box stack as their stack. These threads do not start until after the RTOS scheduler starts (which is after pre-start is finished).
+For all boxes other than the public box: after libc, the RTOS, and C++ statically constructed objects are initialized, and the RTOS is about to start, the RTOS asks uVisor to handle the "pre-start" event. uVisor then creates main threads for each box. The main threads use the box stack as their stack. These threads do not start until after the RTOS scheduler starts (which is after pre-start is finished).
 
 #### Ability for a privileged mode RTOS to call uVisor without an SVC
 


### PR DESCRIPTION
This PR updates the quickstart guide with a more practical example. The features presented are the same but the code is simpler.

The PR also includes a commit that updates our semantics from `main box` to `public box`.

@AnotherButler could you please review the changes?

@Patater @niklas-arm let me know if you think the step-by-step example could be made easier/more meaningful.