### PR TITLE
Docs: Fix sample code for debug box

### DIFF
--- a/core/debug/src/debug_box.c
+++ b/core/debug/src/debug_box.c
@@ -92,9 +92,7 @@ void debug_halt_error(THaltError reason)
     if (!g_debug_box.initialized || debugged_once_before) {
         while (1);
     } else {
-        /* Remember that debug_deprivilege_and_return() has been called once.
-         * We'll reboot after the debug handler is run, so this will go back to
-         * zero after the reboot. */
+        /* Remember that debug_deprivilege_and_return() has been called once. */
         debugged_once_before = 1;
 
         /* The following arguments are passed to the destination function:

--- a/docs/api/DEBUGGING.md
+++ b/docs/api/DEBUGGING.md
@@ -173,12 +173,7 @@ static void box_debug_main(const void *)
 
 ## Platform-specific details
 
-Currently the following platforms are officially supported by uVisor:
-
-* [NXP FRDM-K64F](http://developer.mbed.org/platforms/FRDM-K64F/).
-* [STMicorelectronics STM32F429I-DISCO](http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/PF259090).
-
-This section provides details on how to enable debug on these platforms.
+This section provides details on how to enable debug on some specific hardware platforms.
 
 #### NXP FRDM-K64F
 

--- a/docs/api/DEBUGGING.md
+++ b/docs/api/DEBUGGING.md
@@ -137,20 +137,17 @@ The following is an example of how to implement and configure a debug box.
 #include "mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
-struct box_context {
-    uint32_t unused;
-};
-
 static const UvisorBoxAclItem acl[] = {
+    /* No specific ACL required. */
 };
 
 static void box_debug_main(const void *);
 
 /* Configure the debug box. */
 UVISOR_BOX_NAMESPACE(NULL);
-UVISOR_BOX_CONFIG(box_debug, UVISOR_BOX_STACK_SIZE);
-UVISOR_BOX_MAIN(box_debug_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
-UVISOR_BOX_CONFIG(box_debug, acl, UVISOR_BOX_STACK_SIZE, box_context);
+UVISOR_BOX_HEAPSIZE(2048);
+UVISOR_BOX_MAIN(box_debug_main, osPriorityNormal, 1024);
+UVISOR_BOX_CONFIG(box_debug, 1024);
 
 static uint32_t get_version(void) {
     return 0;


### PR DESCRIPTION
Fixes:
* #392: "A quick change in debugging documentation"

@niklas-arm @Patater 

Thanks @asensaoui @janjongboom for also reporting this.