### PR TITLE
First box to call NVIC owns the interrupt

### DIFF
--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -27,6 +27,9 @@
  * terminating NULL. */
 #define UVISOR_MAX_BOX_NAMESPACE_LENGTH 37
 
+/** Invalid box id for use in marking objects with invalid ownership. */
+#define UVISOR_BOX_ID_INVALID ((uint8_t) -1)
+
 /* supervisor user access modes */
 #define UVISOR_TACL_UEXECUTE        0x0001UL
 #define UVISOR_TACL_UWRITE          0x0002UL

--- a/core/system/inc/page_allocator_config.h
+++ b/core/system/inc/page_allocator_config.h
@@ -44,8 +44,6 @@
 
 /* The page box_id is the box id which is 8-bit large. */
 typedef uint8_t page_owner_t;
-/* Define a unused value for the page table. */
-#define UVISOR_PAGE_UNUSED ((page_owner_t) (-1))
 /* Contains the total number of available pages. */
 extern uint8_t g_page_count_total;
 /* Contains the shift of the page owner mask. */

--- a/core/system/inc/unvic.h
+++ b/core/system/inc/unvic.h
@@ -52,7 +52,7 @@ extern uint32_t unvic_irq_priority_get(uint32_t irqn);
 extern int      unvic_irq_level_get(void);
 extern int      unvic_default(uint32_t isr_id);
 
-extern void unvic_init(void);
+extern void unvic_init(uint32_t const * const user_vtor);
 
 /** Perform a context switch-in as a result of an interrupt request.
  *

--- a/core/system/src/main.c
+++ b/core/system/src/main.c
@@ -21,7 +21,7 @@
 #include "unvic.h"
 #include "vmpu.h"
 
-UVISOR_NOINLINE void uvisor_init_pre(void)
+UVISOR_NOINLINE void uvisor_init_pre(uint32_t const * const user_vtor)
 {
     /* Reset the uVisor own BSS section. */
     memset(&__bss_start__, 0, VMPU_REGION_SIZE(&__bss_start__, &__bss_end__));
@@ -30,7 +30,7 @@ UVISOR_NOINLINE void uvisor_init_pre(void)
     memcpy(&__data_start__, &__data_start_src__, VMPU_REGION_SIZE(&__data_start__, &__data_end__));
 
     /* Initialize the unprivileged NVIC module. */
-    unvic_init();
+    unvic_init(user_vtor);
 
     /* Initialize the debugging features. */
     DEBUG_INIT();
@@ -135,7 +135,7 @@ void main_entry(void)
     }
 
     /* Early uVisor initialization. */
-    uvisor_init_pre();
+    uvisor_init_pre((uint32_t *) SCB->VTOR);
 
     /* Run basic sanity checks. */
     if (vmpu_init_pre() == 0) {

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -36,6 +36,7 @@
  * SVC call, which automagically serializes access to it. */
 #define UVISOR_PAGE_ALLOCATOR_MUTEX_AQUIRE  {}
 #define UVISOR_PAGE_ALLOCATOR_MUTEX_RELEASE {}
+#define UVISOR_PAGE_UNUSED UVISOR_BOX_ID_INVALID
 
 #endif /* defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1) */
 
@@ -73,12 +74,6 @@ uint8_t page_allocator_get_page_from_address(uint32_t address)
 
 void page_allocator_init(void * const heap_start, void * const heap_end, const uint32_t * const page_size)
 {
-    /* Make sure the UVISOR_PAGE_UNUSED is definitely NOT a valid box id. */
-    if (vmpu_is_box_id_valid(UVISOR_PAGE_UNUSED)) {
-        HALT_ERROR(SANITY_CHECK_FAILED,
-            "UVISOR_PAGE_UNUSED (%u) must not be a valid box id!\n",
-            UVISOR_PAGE_UNUSED);
-    }
     if (!page_size || !vmpu_public_flash_addr((uint32_t) page_size)) {
         HALT_ERROR(SANITY_CHECK_FAILED,
             "Page size pointer (0x%08x) is not in flash memory.\n",

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -16,6 +16,7 @@
  */
 
 #include <uvisor.h>
+#include "api/inc/vmpu_exports.h"
 #include "page_allocator.h"
 #include "page_allocator_faults.h"
 #include "page_allocator_config.h"
@@ -23,6 +24,7 @@
 
 /* Maps the number of faults to a page. */
 uint32_t g_page_fault_table[UVISOR_PAGE_MAX_COUNT];
+#define UVISOR_PAGE_UNUSED UVISOR_BOX_ID_INVALID
 
 void page_allocator_reset_faults(uint8_t page)
 {

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -43,6 +43,13 @@ static int vmpu_sanity_checks(void)
             &__uvisor_config, __uvisor_config.magic, UVISOR_MAGIC);
     }
 
+    /* Make sure the UVISOR_BOX_ID_INVALID is definitely NOT a valid box id. */
+    if (vmpu_is_box_id_valid(UVISOR_BOX_ID_INVALID)) {
+        HALT_ERROR(SANITY_CHECK_FAILED,
+            "UVISOR_BOX_ID_INVALID (%u) must not be a valid box id!\n",
+            UVISOR_BOX_ID_INVALID);
+    }
+
     /* Verify basic assumptions about vmpu_bits/__builtin_clz. */
     assert(__builtin_clz(0) == 32);
     assert(__builtin_clz(1UL << 31) == 0);

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -297,7 +297,7 @@ void vIRQ_SetVector(uint32_t irqn, uint32_t vector)
 <table>
   <tr>
     <td>Description</td>
-    <td colspan="2">Register an ISR to the currently active box</td>
+    <td colspan="2">Set an ISR for IRQn</td>
   <tr>
     <td rowspan="2">Parameters</td>
     <td><pre>uint32_t irqn<code></td>
@@ -305,7 +305,7 @@ void vIRQ_SetVector(uint32_t irqn, uint32_t vector)
   </tr>
   <tr>
     <td><pre>uint32_t vector<code></td>
-    <td>Interrupt handler; if 0 the IRQn slot is de-registered for the current
+    <td>Interrupt handler
         box</td>
   </tr>
 </table>

--- a/docs/api/QUICKSTART.md
+++ b/docs/api/QUICKSTART.md
@@ -344,7 +344,8 @@ When the uVisor is enabled, all NVIC APIs are rerouted to the corresponding uVis
 
 * The uVisor owns the interrupt vector table.
 * All ISRs are relocated to SRAM.
-* Code in a box can only change the state of an IRQ (enable it, change its priority, etc.) if the box registered that IRQ with uVisor at runtime, using the `NVIC_SetVector` API.
+* The first call to any NVIC API will register the IRQ for exclusive use with the active box. IRQs cannot be unregistered.
+* Code in a box can only change the state of an IRQ (enable it, change its priority, etc.) if the box registered that IRQ with uVisor at runtime first.
 * An IRQ that belongs to a box can only be modified when that box context is active.
 
 Although this behaviour is different from the original NVIC one, it is backward compatible. This means that legacy code (like a device HAL) will still work after uVisor is enabled. The general use case is the following:
@@ -363,7 +364,7 @@ NVIC_SetPriority(MY_IRQ, 3);
 NVIC_EnableIRQ(MY_IRQ);
 ```
 
-> **Note**: In this model a call to `NVIC_SetVector` must always happen before an IRQ state is changed. In platforms that don't relocate the interrupt vector table such a call might be originally absent and must be added to work with uVisor.
+> **Note**: When enabling the IRQ before setting the vector, uVisor uses the handler specified in the original vector table. This mirrors the NVIC hardware behavior.
 
 For more information on the uVisor APIs, see the [uVisor API documentation](API.md) document.
 


### PR DESCRIPTION
This also copies the initial VTOR table from flash to ram and sets correct priority. That way, statically allocated interrupts are preserved and need only be enabled.

cc @AlessandroA @Patater 