### PR TITLE
Replace main -> public_box in secure access macros

### DIFF
--- a/core/cmsis/inc/core_cmSecureAccess.h
+++ b/core/cmsis/inc/core_cmSecureAccess.h
@@ -53,7 +53,7 @@
  * @param value[in]    Value to write at the address location.
  */
 #define SECURE_WRITE(address, value) \
-    uvisor_write(main, UVISOR_RGW_SHARED, address, value, UVISOR_RGW_OP_WRITE, 0xFFFFFFFFUL)
+    uvisor_write(public_box, UVISOR_RGW_SHARED, address, value, UVISOR_RGW_OP_WRITE, 0xFFFFFFFFUL)
 
 /** Get the value at the target address.
  *
@@ -61,7 +61,7 @@
  * @returns The value `*address`.
  */
 #define SECURE_READ(address) \
-    uvisor_read(main, UVISOR_RGW_SHARED, address, UVISOR_RGW_OP_READ, 0xFFFFFFFFUL)
+    uvisor_read(public_box, UVISOR_RGW_SHARED, address, UVISOR_RGW_OP_READ, 0xFFFFFFFFUL)
 
 /** Get the selected bits at the target address.
  *
@@ -70,7 +70,7 @@
  * @returns The value `*address & mask`.
  */
 #define SECURE_BITS_GET(address, mask) \
-    UVISOR_BITS_GET(main, UVISOR_RGW_SHARED, address, mask)
+    UVISOR_BITS_GET(public_box, UVISOR_RGW_SHARED, address, mask)
 
 /** Check the selected bits at the target address.
  *
@@ -79,7 +79,7 @@
  * @returns The value `((*address & mask) == mask)`.
  */
 #define SECURE_BITS_CHECK(address, mask) \
-    UVISOR_BITS_CHECK(main, UVISOR_RGW_SHARED, address, mask)
+    UVISOR_BITS_CHECK(public_box, UVISOR_RGW_SHARED, address, mask)
 
 /** Set the selected bits to 1 at the target address.
  *
@@ -88,7 +88,7 @@
  * @param mask[in]     Bits to select out of the target address
  */
 #define SECURE_BITS_SET(address, mask) \
-    UVISOR_BITS_SET(main, UVISOR_RGW_SHARED, address, mask)
+    UVISOR_BITS_SET(public_box, UVISOR_RGW_SHARED, address, mask)
 
 /** Clear the selected bits at the target address.
  *
@@ -97,7 +97,7 @@
  * @param mask[in]     Bits to select out of the target address
  */
 #define SECURE_BITS_CLEAR(address, mask) \
-    UVISOR_BITS_CLEAR(main, UVISOR_RGW_SHARED, address, mask)
+    UVISOR_BITS_CLEAR(public_box, UVISOR_RGW_SHARED, address, mask)
 
 /** Set the selected bits at the target address to the given value.
  *
@@ -108,7 +108,7 @@
  *                     must be already shifted to the correct bit position
  */
 #define SECURE_BITS_SET_VALUE(address, mask, value) \
-    UVISOR_BITS_SET_VALUE(main, UVISOR_RGW_SHARED, address, mask, value)
+    UVISOR_BITS_SET_VALUE(public_box, UVISOR_RGW_SHARED, address, mask, value)
 
 /** Toggle the selected bits at the target address.
  *
@@ -117,7 +117,7 @@
  * @param mask[in]     Bits to select out of the target address
  */
 #define SECURE_BITS_TOGGLE(address, mask) \
-    UVISOR_BITS_TOGGLE(main, UVISOR_RGW_SHARED, address, mask)
+    UVISOR_BITS_TOGGLE(public_box, UVISOR_RGW_SHARED, address, mask)
 
 #else
 


### PR DESCRIPTION
The same fix will need to go into mbed OS when we export uVisor.

@Patater 