### PR TITLE
vMPU refactoring

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -47,9 +47,7 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
         { \
             sizeof(RtxBoxIndex), \
             0, \
-            sizeof(uvisor_rpc_outgoing_message_queue_t), \
-            sizeof(uvisor_rpc_incoming_message_queue_t), \
-            sizeof(uvisor_rpc_fn_group_queue_t), \
+            sizeof(uvisor_rpc_t), \
             0, \
         }, \
         0, \
@@ -95,9 +93,7 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
         { \
             sizeof(RtxBoxIndex), \
             context_size, \
-            sizeof(uvisor_rpc_outgoing_message_queue_t), \
-            sizeof(uvisor_rpc_incoming_message_queue_t), \
-            sizeof(uvisor_rpc_fn_group_queue_t), \
+            sizeof(uvisor_rpc_t), \
             __uvisor_box_heapsize, \
         }, \
         UVISOR_MIN_STACK(stack_size), \

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -44,15 +44,15 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
     static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig public_box_cfg = { \
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
-        0, \
-        0, \
-        sizeof(RtxBoxIndex), \
         { \
+            sizeof(RtxBoxIndex), \
             0, \
             sizeof(uvisor_rpc_outgoing_message_queue_t), \
             sizeof(uvisor_rpc_incoming_message_queue_t), \
             sizeof(uvisor_rpc_fn_group_queue_t), \
+            0, \
         }, \
+        0, \
         NULL, \
         NULL, \
         acl_list, \
@@ -92,15 +92,15 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
     static const __attribute__((section(".keep.uvisor.cfgtbl"), aligned(4))) UvisorBoxConfig box_name ## _cfg = { \
         UVISOR_BOX_MAGIC, \
         UVISOR_BOX_VERSION, \
-        UVISOR_MIN_STACK(stack_size), \
-        __uvisor_box_heapsize, \
-        sizeof(RtxBoxIndex), \
         { \
+            sizeof(RtxBoxIndex), \
             context_size, \
             sizeof(uvisor_rpc_outgoing_message_queue_t), \
             sizeof(uvisor_rpc_incoming_message_queue_t), \
             sizeof(uvisor_rpc_fn_group_queue_t), \
+            __uvisor_box_heapsize, \
         }, \
+        UVISOR_MIN_STACK(stack_size), \
         __uvisor_box_lib_config, \
         __uvisor_box_namespace, \
         acl_list, \
@@ -155,6 +155,6 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
 #define UVISOR_BOX_HEAPSIZE(heap_size) \
     static const uint32_t __uvisor_box_heapsize = heap_size;
 
-#define uvisor_ctx (*__uvisor_ps)
+#define uvisor_ctx (*__uvisor_ps + offsetof(UvisorBssSections, context))
 
 #endif /* __UVISOR_API_BOX_CONFIG_H__ */

--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -155,6 +155,6 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
 #define UVISOR_BOX_HEAPSIZE(heap_size) \
     static const uint32_t __uvisor_box_heapsize = heap_size;
 
-#define uvisor_ctx (*__uvisor_ps + offsetof(UvisorBssSections, context))
+#define __uvisor_ctx (((UvisorBoxIndex *) __uvisor_ps)->bss.address_of.context)
 
 #endif /* __UVISOR_API_BOX_CONFIG_H__ */

--- a/api/inc/rpc_exports.h
+++ b/api/inc/rpc_exports.h
@@ -20,6 +20,7 @@
 #include "api/inc/pool_queue_exports.h"
 #include "api/inc/uvisor_semaphore_exports.h"
 #include "api/inc/rpc_gateway_exports.h"
+#include "api/inc/vmpu_exports.h"
 
 typedef uint32_t (*TFN_Ptr)(uint32_t, uint32_t, uint32_t, uint32_t);
 
@@ -136,5 +137,24 @@ typedef struct uvisor_rpc_fn_group {
 typedef UVISOR_RPC_OUTGOING_MESSAGE_TYPE(UVISOR_RPC_OUTGOING_MESSAGE_SLOTS) uvisor_rpc_outgoing_message_queue_t;
 typedef UVISOR_RPC_INCOMING_MESSAGE_TYPE(UVISOR_RPC_INCOMING_MESSAGE_SLOTS) uvisor_rpc_incoming_message_queue_t;
 typedef UVISOR_RPC_FN_GROUP_TYPE(UVISOR_RPC_FN_GROUP_SLOTS) uvisor_rpc_fn_group_queue_t;
+
+typedef struct uvisor_rpc_t {
+    /* Outgoing message queue */
+    uvisor_rpc_outgoing_message_queue_t outgoing_message_queue;
+
+    /* Incoming message queue */
+    uvisor_rpc_incoming_message_queue_t incoming_message_queue;
+
+    /* Function group queue */
+    uvisor_rpc_fn_group_queue_t fn_group_queue;
+
+    /* Counter to avoid waiting on the same RPC result twice by accident. */
+    uint32_t result_counter;
+} uvisor_rpc_t;
+
+static inline uvisor_rpc_t * uvisor_rpc(UvisorBoxIndex * const index)
+{
+    return (uvisor_rpc_t *) index->bss.address_of.rpc;
+}
 
 #endif

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -19,7 +19,6 @@
 
 #include "api/inc/uvisor_exports.h"
 #include "api/inc/pool_queue_exports.h"
-#include "api/inc/rpc_exports.h"
 #include <stdint.h>
 
 /* The maximum box namespace length is 37 so that it is exactly big enough for
@@ -158,9 +157,7 @@ typedef struct {
 typedef struct uvisor_bss_sections_t {
     uint32_t index;
     uint32_t context;
-    uint32_t rpc_outgoing_message_queue;
-    uint32_t rpc_incoming_message_queue;
-    uint32_t rpc_fn_group_queue;
+    uint32_t rpc;
     uint32_t heap;
 } UVISOR_PACKED UvisorBssSections;
 
@@ -218,10 +215,6 @@ typedef struct {
      * This is set to `NULL` by uVisor, signalling to the user lib that the
      * box heap needs to be initialized before use! */
     void * active_heap;
-
-    /* Counter that helps to avoid waiting on the same RPC message result twice
-     * by accident. */
-    uint32_t rpc_result_counter;
 
     /* Box ID */
     int box_id_self;

--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -212,8 +212,6 @@ typedef struct {
         UvisorBssSections address_of;
     } bss;
 
-    /* Pointer to the box heap */
-    void * box_heap;
     /* Size of the box heap */
     uint32_t box_heap_size;
     /* Pointer to the currently active heap.

--- a/api/rtx/src/box_init.c
+++ b/api/rtx/src/box_init.c
@@ -39,9 +39,12 @@ void __uvisor_initialize_rpc_queues(void)
 
     uvisor_pool_slot_t i;
 
-    uvisor_rpc_outgoing_message_queue_t * rpc_outgoing_msg_queue = index->rpc_outgoing_message_queue;
-    uvisor_rpc_incoming_message_queue_t * rpc_incoming_msg_queue = index->rpc_incoming_message_queue;
-    uvisor_rpc_fn_group_queue_t * rpc_fn_group_queue = index->rpc_fn_group_queue;
+    uvisor_rpc_outgoing_message_queue_t * rpc_outgoing_msg_queue =
+        (uvisor_rpc_outgoing_message_queue_t *) index->bss.address_of.rpc_outgoing_message_queue;
+    uvisor_rpc_incoming_message_queue_t * rpc_incoming_msg_queue =
+        (uvisor_rpc_incoming_message_queue_t *) index->bss.address_of.rpc_incoming_message_queue;
+    uvisor_rpc_fn_group_queue_t * rpc_fn_group_queue =
+        (uvisor_rpc_fn_group_queue_t *) index->bss.address_of.rpc_fn_group_queue;
 
     /* Initialize the outgoing RPC message queue. */
     if (uvisor_pool_queue_init(&rpc_outgoing_msg_queue->queue,

--- a/api/rtx/src/box_init.c
+++ b/api/rtx/src/box_init.c
@@ -39,12 +39,9 @@ void __uvisor_initialize_rpc_queues(void)
 
     uvisor_pool_slot_t i;
 
-    uvisor_rpc_outgoing_message_queue_t * rpc_outgoing_msg_queue =
-        (uvisor_rpc_outgoing_message_queue_t *) index->bss.address_of.rpc_outgoing_message_queue;
-    uvisor_rpc_incoming_message_queue_t * rpc_incoming_msg_queue =
-        (uvisor_rpc_incoming_message_queue_t *) index->bss.address_of.rpc_incoming_message_queue;
-    uvisor_rpc_fn_group_queue_t * rpc_fn_group_queue =
-        (uvisor_rpc_fn_group_queue_t *) index->bss.address_of.rpc_fn_group_queue;
+    uvisor_rpc_outgoing_message_queue_t * rpc_outgoing_msg_queue = &(uvisor_rpc(index)->outgoing_message_queue);
+    uvisor_rpc_incoming_message_queue_t * rpc_incoming_msg_queue = &(uvisor_rpc(index)->incoming_message_queue);
+    uvisor_rpc_fn_group_queue_t * rpc_fn_group_queue = &(uvisor_rpc(index)->fn_group_queue);
 
     /* Initialize the outgoing RPC message queue. */
     if (uvisor_pool_queue_init(&rpc_outgoing_msg_queue->queue,

--- a/api/rtx/src/rtx_malloc_wrapper.c
+++ b/api/rtx/src/rtx_malloc_wrapper.c
@@ -76,7 +76,7 @@ static int init_allocator()
 
     if (__uvisor_ps->index.active_heap == NULL) {
         /* We need to initialize the process heap. */
-        if (__uvisor_ps->index.box_heap != NULL) {
+        if ((void *) __uvisor_ps->index.bss.address_of.heap != NULL) {
             /* Lock the mutex during initialization. */
             int kernel_initialized = is_kernel_initialized();
             if (kernel_initialized) {
@@ -84,7 +84,7 @@ static int init_allocator()
             }
             /* Initialize the process heap. */
             SecureAllocator allocator = secure_allocator_create_with_pool(
-                __uvisor_ps->index.box_heap,
+                (void *) __uvisor_ps->index.bss.address_of.heap,
                 __uvisor_ps->index.box_heap_size);
             /* Set the allocator. */
             ret = allocator ? 0 : -1;
@@ -112,9 +112,10 @@ static void * memory(void * ptr, size_t size, int heap, int operation)
     }
     /* Check if we need to aquire the mutex. */
     int mutexed = is_kernel_initialized() &&
-                  ((heap == HEAP_PROCESS) || __uvisor_ps->index.box_heap == __uvisor_ps->index.active_heap);
+                  ((heap == HEAP_PROCESS) ||
+                   (void *) __uvisor_ps->index.bss.address_of.heap == __uvisor_ps->index.active_heap);
     void * allocator = (heap == HEAP_PROCESS) ?
-                       (__uvisor_ps->index.box_heap) :
+                       ((void *) __uvisor_ps->index.bss.address_of.heap) :
                        (__uvisor_ps->index.active_heap);
 
     /* Aquire the mutex if required.

--- a/api/src/rpc.c
+++ b/api/src/rpc.c
@@ -23,61 +23,46 @@
 #include "api/inc/uvisor_semaphore.h"
 #include <string.h>
 
-extern UvisorBoxIndex * __uvisor_ps;
-
+extern UvisorBoxIndex * const __uvisor_ps;
 
 static uvisor_pool_queue_t * outgoing_message_queue(void)
 {
-    uvisor_rpc_outgoing_message_queue_t * ptr =
-        (uvisor_rpc_outgoing_message_queue_t *) __uvisor_ps->bss.address_of.rpc_outgoing_message_queue;
-    return &(ptr->queue);
+    return &(uvisor_rpc(__uvisor_ps)->outgoing_message_queue.queue);
 }
 
 static uvisor_rpc_message_t * outgoing_message_array(void)
 {
-    uvisor_rpc_outgoing_message_queue_t * ptr =
-        (uvisor_rpc_outgoing_message_queue_t *) __uvisor_ps->bss.address_of.rpc_outgoing_message_queue;
-    return ptr->messages;
+    return uvisor_rpc(__uvisor_ps)->outgoing_message_queue.messages;
 }
 
 static uint32_t * result_counter(void)
 {
-    return &(__uvisor_ps->rpc_result_counter);
+    return &(uvisor_rpc(__uvisor_ps)->result_counter);
 }
 
 static uvisor_pool_queue_t * incoming_message_todo_queue(void)
 {
-    uvisor_rpc_incoming_message_queue_t * ptr =
-        (uvisor_rpc_incoming_message_queue_t *) __uvisor_ps->bss.address_of.rpc_incoming_message_queue;
-    return &(ptr->todo_queue);
+    return &(uvisor_rpc(__uvisor_ps)->incoming_message_queue.todo_queue);
 }
 
 static uvisor_pool_queue_t * incoming_message_done_queue(void)
 {
-    uvisor_rpc_incoming_message_queue_t * ptr =
-        (uvisor_rpc_incoming_message_queue_t *) __uvisor_ps->bss.address_of.rpc_incoming_message_queue;
-    return &(ptr->done_queue);
+    return &(uvisor_rpc(__uvisor_ps)->incoming_message_queue.done_queue);
 }
 
 static uvisor_rpc_message_t * incoming_message_array(void)
 {
-    uvisor_rpc_incoming_message_queue_t * ptr =
-        (uvisor_rpc_incoming_message_queue_t *) __uvisor_ps->bss.address_of.rpc_incoming_message_queue;
-    return ptr->messages;
+    return uvisor_rpc(__uvisor_ps)->incoming_message_queue.messages;
 }
 
 static uvisor_pool_queue_t * fn_group_queue(void)
 {
-    uvisor_rpc_fn_group_queue_t * ptr =
-        (uvisor_rpc_fn_group_queue_t *) __uvisor_ps->bss.address_of.rpc_fn_group_queue;
-    return &(ptr->queue);
+    return &(uvisor_rpc(__uvisor_ps)->fn_group_queue.queue);
 }
 
 static uvisor_rpc_fn_group_t * fn_group_array(void)
 {
-    uvisor_rpc_fn_group_queue_t * ptr =
-        (uvisor_rpc_fn_group_queue_t *) __uvisor_ps->bss.address_of.rpc_fn_group_queue;
-    return ptr->fn_groups;
+    return uvisor_rpc(__uvisor_ps)->fn_group_queue.fn_groups;
 }
 
 /* Place a message into the outgoing queue. `timeout_ms` is how long to wait

--- a/api/src/rpc.c
+++ b/api/src/rpc.c
@@ -28,42 +28,56 @@ extern UvisorBoxIndex * __uvisor_ps;
 
 static uvisor_pool_queue_t * outgoing_message_queue(void)
 {
-    return &__uvisor_ps->rpc_outgoing_message_queue->queue;
+    uvisor_rpc_outgoing_message_queue_t * ptr =
+        (uvisor_rpc_outgoing_message_queue_t *) __uvisor_ps->bss.address_of.rpc_outgoing_message_queue;
+    return &(ptr->queue);
 }
 
 static uvisor_rpc_message_t * outgoing_message_array(void)
 {
-    return __uvisor_ps->rpc_outgoing_message_queue->messages;
+    uvisor_rpc_outgoing_message_queue_t * ptr =
+        (uvisor_rpc_outgoing_message_queue_t *) __uvisor_ps->bss.address_of.rpc_outgoing_message_queue;
+    return ptr->messages;
 }
 
 static uint32_t * result_counter(void)
 {
-    return &__uvisor_ps->rpc_result_counter;
+    return &(__uvisor_ps->rpc_result_counter);
 }
 
 static uvisor_pool_queue_t * incoming_message_todo_queue(void)
 {
-    return &__uvisor_ps->rpc_incoming_message_queue->todo_queue;
+    uvisor_rpc_incoming_message_queue_t * ptr =
+        (uvisor_rpc_incoming_message_queue_t *) __uvisor_ps->bss.address_of.rpc_incoming_message_queue;
+    return &(ptr->todo_queue);
 }
 
 static uvisor_pool_queue_t * incoming_message_done_queue(void)
 {
-    return &__uvisor_ps->rpc_incoming_message_queue->done_queue;
+    uvisor_rpc_incoming_message_queue_t * ptr =
+        (uvisor_rpc_incoming_message_queue_t *) __uvisor_ps->bss.address_of.rpc_incoming_message_queue;
+    return &(ptr->done_queue);
 }
 
 static uvisor_rpc_message_t * incoming_message_array(void)
 {
-    return __uvisor_ps->rpc_incoming_message_queue->messages;
+    uvisor_rpc_incoming_message_queue_t * ptr =
+        (uvisor_rpc_incoming_message_queue_t *) __uvisor_ps->bss.address_of.rpc_incoming_message_queue;
+    return ptr->messages;
 }
 
 static uvisor_pool_queue_t * fn_group_queue(void)
 {
-    return &__uvisor_ps->rpc_fn_group_queue->queue;
+    uvisor_rpc_fn_group_queue_t * ptr =
+        (uvisor_rpc_fn_group_queue_t *) __uvisor_ps->bss.address_of.rpc_fn_group_queue;
+    return &(ptr->queue);
 }
 
 static uvisor_rpc_fn_group_t * fn_group_array(void)
 {
-    return __uvisor_ps->rpc_fn_group_queue->fn_groups;
+    uvisor_rpc_fn_group_queue_t * ptr =
+        (uvisor_rpc_fn_group_queue_t *) __uvisor_ps->bss.address_of.rpc_fn_group_queue;
+    return ptr->fn_groups;
 }
 
 /* Place a message into the outgoing queue. `timeout_ms` is how long to wait

--- a/core/system/src/rpc.c
+++ b/core/system/src/rpc.c
@@ -32,8 +32,10 @@ static int wake_up_handlers_for_target(const TFN_Ptr function, int box_id)
     int num_posted = 0;
 
     UvisorBoxIndex * index = (UvisorBoxIndex *) g_context_current_states[box_id].bss;
-    uvisor_pool_queue_t * fn_group_queue = &index->rpc_fn_group_queue->queue;
-    uvisor_rpc_fn_group_t * fn_group_array = index->rpc_fn_group_queue->fn_groups;
+    uvisor_rpc_fn_group_queue_t * fn_group_queue_ptr =
+        (uvisor_rpc_fn_group_queue_t *) index->bss.address_of.rpc_fn_group_queue;
+    uvisor_pool_queue_t * fn_group_queue = &(fn_group_queue_ptr->queue);
+    uvisor_rpc_fn_group_t * fn_group_array = fn_group_queue_ptr->fn_groups;
 
     /* Wake up all known waiters for this function. Search for the function in
      * all known function groups. We have to search through all function groups
@@ -194,7 +196,9 @@ static int is_valid_queue(uvisor_pool_queue_t * queue, int box_id)
 void drain_message_queue(void)
 {
     UvisorBoxIndex * caller_index = (UvisorBoxIndex *) *__uvisor_config.uvisor_box_context;
-    uvisor_pool_queue_t * caller_queue = &caller_index->rpc_outgoing_message_queue->queue;
+    uvisor_rpc_outgoing_message_queue_t * outgoing_message_queue_ptr =
+        (uvisor_rpc_outgoing_message_queue_t *) caller_index->bss.address_of.rpc_outgoing_message_queue;
+    uvisor_pool_queue_t * caller_queue = &(outgoing_message_queue_ptr->queue);
     uvisor_rpc_message_t * caller_array = (uvisor_rpc_message_t *) caller_queue->pool->array;
     int caller_box = g_active_box;
     int first_slot = -1;
@@ -262,7 +266,9 @@ void drain_message_queue(void)
         }
 
         UvisorBoxIndex * callee_index = (UvisorBoxIndex *) g_context_current_states[callee_box].bss;
-        uvisor_pool_queue_t * callee_queue = &callee_index->rpc_incoming_message_queue->todo_queue;
+        uvisor_rpc_incoming_message_queue_t * incoming_message_queue_ptr =
+            (uvisor_rpc_incoming_message_queue_t *) callee_index->bss.address_of.rpc_incoming_message_queue;
+        uvisor_pool_queue_t * callee_queue = &(incoming_message_queue_ptr->todo_queue);
         uvisor_rpc_message_t * callee_array = (uvisor_rpc_message_t *) callee_queue->pool->array;
 
         /* Verify that the callee queue is entirely in callee box BSS. We check the
@@ -348,7 +354,9 @@ void drain_message_queue(void)
 void drain_result_queue(void)
 {
     UvisorBoxIndex * callee_index = (UvisorBoxIndex *) *__uvisor_config.uvisor_box_context;
-    uvisor_pool_queue_t * callee_queue = &callee_index->rpc_incoming_message_queue->done_queue;
+    uvisor_rpc_incoming_message_queue_t * incoming_message_queue_ptr =
+        (uvisor_rpc_incoming_message_queue_t *) callee_index->bss.address_of.rpc_incoming_message_queue;
+    uvisor_pool_queue_t * callee_queue = &(incoming_message_queue_ptr->done_queue);
     uvisor_rpc_message_t * callee_array = (uvisor_rpc_message_t *) callee_queue->pool->array;
 
     int callee_box = g_active_box;
@@ -388,7 +396,9 @@ void drain_result_queue(void)
         const int caller_box = callee_msg->other_box_id;
 
         UvisorBoxIndex * caller_index = (UvisorBoxIndex *) g_context_current_states[caller_box].bss;
-        uvisor_pool_queue_t * caller_queue = &caller_index->rpc_outgoing_message_queue->queue;
+        uvisor_rpc_outgoing_message_queue_t * outgoing_message_queue_ptr =
+            (uvisor_rpc_outgoing_message_queue_t *) caller_index->bss.address_of.rpc_outgoing_message_queue;
+        uvisor_pool_queue_t * caller_queue = &(outgoing_message_queue_ptr->queue);
         uvisor_rpc_message_t * caller_array = (uvisor_rpc_message_t *) caller_queue->pool->array;
 
         /* Verify that the caller queue is entirely in caller box BSS. We check the

--- a/core/system/src/rpc.c
+++ b/core/system/src/rpc.c
@@ -32,10 +32,8 @@ static int wake_up_handlers_for_target(const TFN_Ptr function, int box_id)
     int num_posted = 0;
 
     UvisorBoxIndex * index = (UvisorBoxIndex *) g_context_current_states[box_id].bss;
-    uvisor_rpc_fn_group_queue_t * fn_group_queue_ptr =
-        (uvisor_rpc_fn_group_queue_t *) index->bss.address_of.rpc_fn_group_queue;
-    uvisor_pool_queue_t * fn_group_queue = &(fn_group_queue_ptr->queue);
-    uvisor_rpc_fn_group_t * fn_group_array = fn_group_queue_ptr->fn_groups;
+    uvisor_pool_queue_t * fn_group_queue = &(uvisor_rpc(index)->fn_group_queue.queue);
+    uvisor_rpc_fn_group_t * fn_group_array = uvisor_rpc(index)->fn_group_queue.fn_groups;
 
     /* Wake up all known waiters for this function. Search for the function in
      * all known function groups. We have to search through all function groups
@@ -196,9 +194,7 @@ static int is_valid_queue(uvisor_pool_queue_t * queue, int box_id)
 void drain_message_queue(void)
 {
     UvisorBoxIndex * caller_index = (UvisorBoxIndex *) *__uvisor_config.uvisor_box_context;
-    uvisor_rpc_outgoing_message_queue_t * outgoing_message_queue_ptr =
-        (uvisor_rpc_outgoing_message_queue_t *) caller_index->bss.address_of.rpc_outgoing_message_queue;
-    uvisor_pool_queue_t * caller_queue = &(outgoing_message_queue_ptr->queue);
+    uvisor_pool_queue_t * caller_queue = &(uvisor_rpc(caller_index)->outgoing_message_queue.queue);
     uvisor_rpc_message_t * caller_array = (uvisor_rpc_message_t *) caller_queue->pool->array;
     int caller_box = g_active_box;
     int first_slot = -1;
@@ -266,9 +262,7 @@ void drain_message_queue(void)
         }
 
         UvisorBoxIndex * callee_index = (UvisorBoxIndex *) g_context_current_states[callee_box].bss;
-        uvisor_rpc_incoming_message_queue_t * incoming_message_queue_ptr =
-            (uvisor_rpc_incoming_message_queue_t *) callee_index->bss.address_of.rpc_incoming_message_queue;
-        uvisor_pool_queue_t * callee_queue = &(incoming_message_queue_ptr->todo_queue);
+        uvisor_pool_queue_t * callee_queue = &(uvisor_rpc(callee_index)->incoming_message_queue.todo_queue);
         uvisor_rpc_message_t * callee_array = (uvisor_rpc_message_t *) callee_queue->pool->array;
 
         /* Verify that the callee queue is entirely in callee box BSS. We check the
@@ -354,9 +348,7 @@ void drain_message_queue(void)
 void drain_result_queue(void)
 {
     UvisorBoxIndex * callee_index = (UvisorBoxIndex *) *__uvisor_config.uvisor_box_context;
-    uvisor_rpc_incoming_message_queue_t * incoming_message_queue_ptr =
-        (uvisor_rpc_incoming_message_queue_t *) callee_index->bss.address_of.rpc_incoming_message_queue;
-    uvisor_pool_queue_t * callee_queue = &(incoming_message_queue_ptr->done_queue);
+    uvisor_pool_queue_t * callee_queue = &(uvisor_rpc(callee_index)->incoming_message_queue.done_queue);
     uvisor_rpc_message_t * callee_array = (uvisor_rpc_message_t *) callee_queue->pool->array;
 
     int callee_box = g_active_box;
@@ -396,9 +388,7 @@ void drain_result_queue(void)
         const int caller_box = callee_msg->other_box_id;
 
         UvisorBoxIndex * caller_index = (UvisorBoxIndex *) g_context_current_states[caller_box].bss;
-        uvisor_rpc_outgoing_message_queue_t * outgoing_message_queue_ptr =
-            (uvisor_rpc_outgoing_message_queue_t *) caller_index->bss.address_of.rpc_outgoing_message_queue;
-        uvisor_pool_queue_t * caller_queue = &(outgoing_message_queue_ptr->queue);
+        uvisor_pool_queue_t * caller_queue = &(uvisor_rpc(caller_index)->outgoing_message_queue.queue);
         uvisor_rpc_message_t * caller_array = (uvisor_rpc_message_t *) caller_queue->pool->array;
 
         /* Verify that the caller queue is entirely in caller box BSS. We check the

--- a/core/system/src/thread.c
+++ b/core/system/src/thread.c
@@ -75,7 +75,7 @@ void * thread_create(int id, void * c)
         /* Remember the process id for this thread. */
         thread[ii].process_id = g_active_box;
         /* Fall back to the process heap if ctx is NULL. */
-        thread[ii].allocator = context ? context : index->box_heap;
+        thread[ii].allocator = context ? context : (void *) index->bss.address_of.heap;
         return &thread[ii];
     }
     return context;

--- a/core/vmpu/inc/vmpu.h
+++ b/core/vmpu/inc/vmpu.h
@@ -206,6 +206,8 @@ extern int vmpu_is_region_size_valid(uint32_t size);
  */
 extern uint32_t vmpu_round_up_region(uint32_t addr, uint32_t size);
 
+extern void vmpu_order_boxes(int * const best_order, int box_count);
+
 static UVISOR_FORCEINLINE bool vmpu_is_box_id_valid(int box_id)
 {
     /* Return true if the box_id is valid.

--- a/core/vmpu/inc/vmpu.h
+++ b/core/vmpu/inc/vmpu.h
@@ -161,8 +161,8 @@ extern int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr
 
 uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size);
 
-extern void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
-                           uint32_t * stack_pointer);
+extern void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
+                          uint32_t * stack_pointer);
 extern uint32_t vmpu_acl_static_region(uint8_t region, void* base, uint32_t size, UvisorBoxAcl acl);
 
 extern void vmpu_arch_init(void);

--- a/core/vmpu/inc/vmpu.h
+++ b/core/vmpu/inc/vmpu.h
@@ -161,7 +161,8 @@ extern int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr
 
 uint32_t vmpu_fault_find_acl(uint32_t fault_addr, uint32_t size);
 
-extern void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size);
+extern void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
+                           uint32_t * stack_pointer);
 extern uint32_t vmpu_acl_static_region(uint8_t region, void* base, uint32_t size, UvisorBoxAcl acl);
 
 extern void vmpu_arch_init(void);

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -369,11 +369,6 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint
      * alignment requirements). */
     *stack_pointer = (box_mem_pos + region_size) - 8;
 
-    /* Reset uninitialized secured box context. */
-    if (slots_for_bss) {
-        memset((void *) box_mem_pos, 0, bss_size);
-    }
-
     /* Create stack protection region. */
     region_size = vmpu_region_add_static_acl(
         box_id,

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -304,7 +304,7 @@ extern int vmpu_region_bits(uint32_t size);
 /* Compute the MPU region size for the given BSS sections and stack sizes.
  * The function also updates the region_start parameter to meet the alignment
  * requirements of the MPU. */
-static uint32_t vmpu_acl_stack_region_size(uint32_t * region_start, uint32_t const bss_size, uint32_t const stack_size)
+static uint32_t vmpu_acl_sram_region_size(uint32_t * region_start, uint32_t const bss_size, uint32_t const stack_size)
 {
     /* Ensure that 2/8th are available for protecting the stack from the BSS
      * sections. One subregion will separate the 2 areas, another one is needed
@@ -326,8 +326,8 @@ static uint32_t vmpu_acl_stack_region_size(uint32_t * region_start, uint32_t con
     return region_size;
 }
 
-void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
-                    uint32_t * stack_pointer)
+void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
+                   uint32_t * stack_pointer)
 {
     /* Offset at which the SRAM region is configured for a secure box. This
      * offset is incremented at every function call. The actual MPU region start
@@ -343,7 +343,7 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint
     /* Compute the MPU region size. */
     /* Note: This function also updates the memory offset to meet the alignment
      *       requirements. */
-    uint32_t region_size = vmpu_acl_stack_region_size(&box_mem_pos, bss_size, stack_size);
+    uint32_t region_size = vmpu_acl_sram_region_size(&box_mem_pos, bss_size, stack_size);
 
     DPRINTF("\tbox[%i] stack=%i bss=%i rounded=%i\n\r", box_id, stack_size, bss_size, region_size);
 
@@ -532,7 +532,7 @@ static uint32_t __vmpu_order_boxes(int * const box_order, int * const best_order
             uint32_t stack_size = box_cfgtbl->stack_size;
             /* This function automatically updates the sram_offset parameter to
              * meet the MPU alignment requirements. */
-            uint32_t region_size = vmpu_acl_stack_region_size(&sram_offset, bss_size, stack_size);
+            uint32_t region_size = vmpu_acl_sram_region_size(&sram_offset, bss_size, stack_size);
             sram_offset += region_size;
         }
         /* Update the best box configuration. */

--- a/core/vmpu/src/armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/armv7m/vmpu_armv7m.c
@@ -345,8 +345,6 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
      *       requirements. */
     uint32_t region_size = vmpu_acl_sram_region_size(&box_mem_pos, bss_size, stack_size);
 
-    DPRINTF("\tbox[%i] stack=%i bss=%i rounded=%i\n\r", box_id, stack_size, bss_size, region_size);
-
     /* Allocate the subregions slots for the BSS sections and for the stack.
      * One subregion is used to allow for rounding errors (BSS), and another one
      * is used to separate the BSS sections from the stack. */
@@ -377,9 +375,16 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
         UVISOR_TACLDEF_STACK,
         slots_for_bss ? 1UL << slots_for_bss : 0
     );
+    DPRINTF("  - SRAM:       0x%08X - 0x%08X (permissions: 0x%04X, subregions: 0x%02X)\r\n",
+            box_mem_pos, box_mem_pos + region_size, UVISOR_TACLDEF_STACK, slots_for_bss ? 1UL << slots_for_bss : 0);
 
     /* Move on to the next memory block. */
     box_mem_pos += region_size;
+
+    DPRINTF("    - BSS:      0x%08X - 0x%08X (original size: %uB, rounded size: %uB)\r\n",
+            *bss_start, *bss_start + bss_size, bss_size, slots_for_bss * subregion_size);
+    DPRINTF("    - Stack:    0x%08X - 0x%08X (original size: %uB, rounded size: %uB)\r\n",
+            *bss_start + (slots_for_bss + 1) * subregion_size, box_mem_pos, stack_size, slots_for_stack * subregion_size);
 }
 
 void vmpu_arch_init(void)

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -200,6 +200,8 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
         UVISOR_TACLDEF_STACK,
         0
     );
+    DPRINTF("  - Stack:      0x%08X - 0x%08X (permissions: 0x%04X)\r\n",
+            g_box_mem_pos, g_box_mem_pos + stack_size, UVISOR_TACLDEF_STACK);
 
     /* Set stack pointer to box stack size minus guard band. */
     g_box_mem_pos += stack_size;
@@ -220,6 +222,8 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
         UVISOR_TACLDEF_DATA,
         0
     );
+    DPRINTF("  - BSS:        0x%08X - 0x%08X (permissions: 0x%04X)\r\n",
+            g_box_mem_pos, g_box_mem_pos + bss_size, UVISOR_TACLDEF_DATA);
 
     g_box_mem_pos += bss_size + UVISOR_STACK_BAND_SIZE;
 }

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -212,18 +212,6 @@ void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint
     bss_size = UVISOR_REGION_ROUND_UP(bss_size);
     *bss_start = g_box_mem_pos;
 
-    DPRINTF("erasing box context at 0x%08X (%u bytes)\n",
-        g_box_mem_pos,
-        bss_size
-    );
-
-    /* Reset uninitialized secured box context. */
-    memset(
-        (void *) g_box_mem_pos,
-        0,
-        bss_size
-    );
-
     /* Add context ACL. */
     vmpu_region_add_static_acl(
         box_id,

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -294,3 +294,10 @@ void vmpu_arch_init(void)
 
     vmpu_mpu_lock();
 }
+
+void vmpu_order_boxes(int * const best_order, int box_count)
+{
+    for (int i = 0; i < box_count; ++i) {
+        best_order[i] = i;
+    }
+}

--- a/core/vmpu/src/kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis.c
@@ -177,8 +177,8 @@ uint32_t vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
     return lr;
 }
 
-void vmpu_acl_stack(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
-                    uint32_t * stack_pointer)
+void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint32_t * bss_start,
+                   uint32_t * stack_pointer)
 {
     static uint32_t g_box_mem_pos = 0;
 

--- a/core/vmpu/src/kinetis/vmpu_kinetis_aips.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis_aips.c
@@ -52,8 +52,6 @@ int vmpu_aips_add(uint8_t box_id, void* start, uint32_t size, UvisorBoxAcl acl)
 
     /* calculate resulting AIPS slot and base */
     base = AIPS0_BASE | (((uint32_t)(aips_slot)) << 12);
-    DPRINTF("\t\tAIPS slot[%02i] for base 0x%08X\n",
-        aips_slot, base);
 
     /* check if ACL base is equal to slot base */
     if(base != (uint32_t)start)

--- a/core/vmpu/src/kinetis/vmpu_kinetis_mpu.c
+++ b/core/vmpu/src/kinetis/vmpu_kinetis_mpu.c
@@ -161,9 +161,6 @@ static uint32_t vmpu_region_add_static_acl_internal(uint8_t box_id, uint32_t sta
     MpuRegionSlice * box;
     uint32_t rounded_size, end, t;
 
-    DPRINTF(" mem_acl[%i]: 0x%08X-0x%08X (size=%i, acl=0x%04X)\n",
-            g_mpu_region_count, start, ((uint32_t)start)+size, size, acl);
-
     /* handle empty or fully protected regions */
     if(!size || !(acl & (UVISOR_TACL_UACL|UVISOR_TACL_SACL)))
         return 1;
@@ -217,10 +214,6 @@ uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t siz
 {
     int res;
 
-#ifndef NDEBUG
-    const MemMap *map;
-#endif/*NDEBUG*/
-
     /* check for maximum box ID */
     if (!vmpu_is_box_id_valid(box_id)) {
         HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box ID is out of range (%u).\r\n", box_id);
@@ -230,9 +223,6 @@ uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t siz
     if(start & 0x1F) {
         HALT_ERROR(SANITY_CHECK_FAILED, "ACL start address is not aligned [0x%08X]\n", start);
     }
-
-    DPRINTF("\t@0x%08X size=%06i acl=0x%04X [%s]\n", start, size, acl,
-        (map = memory_map_name(start)) ? map->name : "unknown");
 
     /* check for peripheral memory, proceed with general memory */
     if(acl & UVISOR_TACL_PERIPHERAL) {

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -23,14 +23,6 @@
 #include "vmpu.h"
 #include "vmpu_mpu.h"
 
-#ifndef MPU_MAX_PRIVATE_FUNCTIONS
-#define MPU_MAX_PRIVATE_FUNCTIONS 16
-#endif /* MPU_MAX_PRIVATE_FUNCTIONS */
-
-#if (MPU_MAX_PRIVATE_FUNCTIONS > 0x100UL)
-#error "MPU_MAX_PRIVATE_FUNCTIONS needs to be lower/equal to 0x100"
-#endif
-
 uint32_t  g_vmpu_box_count;
 bool g_vmpu_boxes_counted;
 

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -365,7 +365,7 @@ static void vmpu_configure_box_sram(uint8_t box_id, UvisorBoxConfig const * box_
         stack_pointer = __get_PSP();
     } else {
         uint32_t stack_size = box_cfgtbl->stack_size;
-        vmpu_acl_stack(box_id, bss_size, stack_size, &bss_start, &stack_pointer);
+        vmpu_acl_sram(box_id, bss_size, stack_size, &bss_start, &stack_pointer);
     }
 
     /* Set the box state for the SRAM sections. */

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -270,10 +270,10 @@ static void vmpu_check_sanity_box_cfgtbl(uint8_t box_id, UvisorBoxConfig const *
     vmpu_check_sanity_box_namespace(box_id, box_cfgtbl->box_namespace);
 }
 
-static void vmpu_box_index_init(uint8_t box_id, UvisorBoxConfig const * const box_cfgtbl)
+static void vmpu_box_index_init(uint8_t box_id, UvisorBoxConfig const * const box_cfgtbl, void * const bss_start)
 {
     /* The box index is at the beginning of the BSS section. */
-    void * box_bss = (void *) g_context_current_states[box_id].bss;
+    void * box_bss = bss_start;
     UvisorBoxIndex * index = (UvisorBoxIndex *) box_bss;
 
     /* Zero the _entire_ index, so that user data inside the box index is in a
@@ -379,7 +379,7 @@ static void vmpu_configure_box_sram(uint8_t box_id, UvisorBoxConfig const * box_
     g_context_current_states[box_id].sp = stack_pointer;
 
     /* Initialize the box index. */
-    vmpu_box_index_init(box_id, box_cfgtbl);
+    vmpu_box_index_init(box_id, box_cfgtbl, (void *) bss_start);
 }
 
 static void vmpu_enumerate_boxes(void)

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -162,6 +162,20 @@ static int vmpu_sanity_checks(void)
         }
     }
 
+    /* Check the public heap start and end addresses. */
+    uint32_t const heap_end = (uint32_t) __uvisor_config.heap_end;
+    uint32_t const heap_start = (uint32_t) __uvisor_config.heap_start;
+    if (!heap_start || !vmpu_public_sram_addr(heap_start)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "Heap start pointer (0x%08x) is not in SRAM memory.\r\n", heap_start);
+    }
+    if (!heap_end || !vmpu_public_sram_addr(heap_end)) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is not in SRAM memory.\r\n", heap_end);
+    }
+    if (heap_end < heap_start) {
+        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is smaller than heap start pointer (0x%08x).\r\n",
+                   heap_end, heap_start);
+    }
+
     /* Return an error if uVisor is disabled. */
     if (!__uvisor_config.mode || (*__uvisor_config.mode == 0)) {
         return -1;
@@ -260,20 +274,6 @@ static void vmpu_enumerate_boxes(void)
     const UvisorBoxConfig **box_cfgtbl;
     uint32_t bss_size;
     uint8_t box_id;
-
-    /* Check heap start and end addresses. */
-    if (!__uvisor_config.heap_start || !vmpu_public_sram_addr((uint32_t) __uvisor_config.heap_start)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Heap start pointer (0x%08x) is not in SRAM memory.\n",
-            (uint32_t) __uvisor_config.heap_start);
-    }
-    if (!__uvisor_config.heap_end || !vmpu_public_sram_addr((uint32_t) __uvisor_config.heap_end)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is not in SRAM memory.\n",
-            (uint32_t) __uvisor_config.heap_end);
-    }
-    if (__uvisor_config.heap_end < __uvisor_config.heap_start) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is smaller than heap start pointer (0x%08x).\n",
-            (uint32_t) __uvisor_config.heap_end, (uint32_t) __uvisor_config.heap_start);
-    }
 
     /* Enumerate boxes. */
     g_vmpu_box_count = (uint32_t) (__uvisor_config.cfgtbl_ptr_end - __uvisor_config.cfgtbl_ptr_start);

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -26,7 +26,7 @@
 uint32_t  g_vmpu_box_count;
 bool g_vmpu_boxes_counted;
 
-static int vmpu_sanity_checks(void)
+static int vmpu_check_sanity(void)
 {
     /* Verify the uVisor configuration structure. */
     if (__uvisor_config.magic != UVISOR_MAGIC) {
@@ -176,7 +176,7 @@ static int vmpu_sanity_checks(void)
     }
 }
 
-static void vmpu_sanity_check_box_namespace(int box_id, const char *const box_namespace)
+static void vmpu_check_sanity_box_namespace(int box_id, const char *const box_namespace)
 {
     /* Verify that all characters of the box_namespace (including the trailing
      * NUL) are within flash and that the box_namespace is not too long. It is
@@ -305,7 +305,7 @@ static void vmpu_enumerate_boxes(void)
         }
 
         /* Check that the box namespace is not too long. */
-        vmpu_sanity_check_box_namespace(box_id, (*box_cfgtbl)->box_namespace);
+        vmpu_check_sanity_box_namespace(box_id, (*box_cfgtbl)->box_namespace);
 
         /* Load the box ACLs. */
         DPRINTF("box[%i] ACL list:\n", box_id);
@@ -501,7 +501,7 @@ int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr, uint3
 
 int vmpu_init_pre(void)
 {
-    return vmpu_sanity_checks();
+    return vmpu_check_sanity();
 }
 
 void vmpu_init_post(void)

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -253,7 +253,7 @@ static void vmpu_box_index_init(uint8_t box_id, const UvisorBoxConfig * const co
     index->config = config;
 }
 
-static void vmpu_load_boxes(void)
+static void vmpu_enumerate_boxes(void)
 {
     int i, count;
     const UvisorBoxAclItem *region;
@@ -375,7 +375,7 @@ static void vmpu_load_boxes(void)
     vmpu_load_box(0);
     *(__uvisor_config.uvisor_box_context) = (uint32_t *) g_context_current_states[0].bss;
 
-    DPRINTF("vmpu_load_boxes [DONE]\n");
+    DPRINTF("vmpu_enumerate_boxes [DONE]\n");
 }
 
 int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr, uint32_t fault_status)
@@ -523,7 +523,7 @@ void vmpu_init_post(void)
     vmpu_arch_init();
 
     /* load boxes */
-    vmpu_load_boxes();
+    vmpu_enumerate_boxes();
 }
 
 static int copy_box_namespace(const char *src, char *dst)

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -315,7 +315,6 @@ static void vmpu_box_index_init(uint8_t box_id, UvisorBoxConfig const * const bo
 static void vmpu_configure_box_peripherals(uint8_t box_id, UvisorBoxConfig const * const box_cfgtbl)
 {
     /* Enumerate the box ACLs. */
-    DPRINTF("box[%i] ACL list:\r\n", box_id);
     const UvisorBoxAclItem * region = box_cfgtbl->acl_list;
     if (region != NULL) {
         int count = box_cfgtbl->acl_count;
@@ -337,6 +336,9 @@ static void vmpu_configure_box_peripherals(uint8_t box_id, UvisorBoxConfig const
                     region->acl | UVISOR_TACL_USER,
                     0
                 );
+                DPRINTF("  - Peripheral: 0x%08X - 0x%08X (permissions: 0x%04X)\r\n",
+                        (uint32_t) region->param1, (uint32_t) region->param1 + region->param2,
+                        region->acl | UVISOR_TACL_USER);
             }
 
             /* Proceed to the next ACL. */
@@ -401,8 +403,7 @@ static void vmpu_enumerate_boxes(void)
         /* Note: This function halts if a sanity check fails. */
         vmpu_check_sanity_box_cfgtbl(box_id, box_cfgtbl);
 
-        /* Load the box ACLs. */
-        DPRINTF("box[%i] ACL list:\n", box_id);
+        DPRINTF("Box %i ACLs:\r\n", box_id);
 
         /* Add the box ACL for the static SRAM memories. */
         vmpu_configure_box_sram(box_id, box_cfgtbl);

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -391,9 +391,15 @@ static void vmpu_enumerate_boxes(void)
     }
     g_vmpu_boxes_counted = TRUE;
 
+    /* Get the boxes order. This is MPU-specific. */
+    int box_order[UVISOR_MAX_BOXES];
+    vmpu_order_boxes(box_order, g_vmpu_box_count);
+
     /* Initialize the boxes. */
     for (uint8_t box_id = 0; box_id < g_vmpu_box_count; ++box_id) {
-        UvisorBoxConfig const * box_cfgtbl = ((UvisorBoxConfig const * *) __uvisor_config.cfgtbl_ptr_start)[box_id];
+        /* Select the pointer to the (permuted) box configuration table. */
+        int index = box_order[box_id];
+        UvisorBoxConfig const * box_cfgtbl = ((UvisorBoxConfig const * *) __uvisor_config.cfgtbl_ptr_start)[index];
 
         /* Verify the box configuration table. */
         /* Note: This function halts if a sanity check fails. */


### PR DESCRIPTION
This PR refactors the vMPU code that enumerates boxes.

The refactoring brings the following changes:

* Parts of `vmpu_enumerate_boxes` have been moved to other functions, which makes it easier to read the code.
* The code has been updated to reflect the migration from simple "per-box context + stack" model to "per-box BSS sections + stack", where the BSS sections contain multiple items (index, context, heap, RPC queues).
    * There is now a unified way to read and reason about the BSS sections, by using the `UvisorBssSections` struct.
* Added an optimization for ARMv7-M:
    * Boxes are enumerated based on the order that minimizes the SRAM usage.
    * If the total SRAM usage exceeds the available allocated space, then the error message which is printed before halting suggests the space to allocate to remove the memory overflow.

**Note**: This refactoring breaks backwards compatibility, in that it removes the magic pointer `uvisor_ctx`.

A `__uvisor_ctx` pointer is now introduced, which still points to the user context for each box — but it's now a `void *` pointer. This means that box developers will have to cast it to their own context structure.

Although this is a UX change, I believe it makes it more explicit (from a semantics perspective it's a bit confusing that `uvisor_ctx`, never explicitly declared, means something different in each box). This point is open to discussion, but keep in mind that in the future we will likely expose the whole `UvisorBoxIndex` instead of just the context pointer. Developers will need to be aware that the index is a box-agnostic structure of pointers that uVisor switches in and out when switching processes.

@Patater @niklas-arm 