### PR TITLE
Disable interrupts before debugging and avoid special register handling on priv faults

### DIFF
--- a/core/debug/src/core_armv7m/debug_box_armv7m.c
+++ b/core/debug/src/core_armv7m/debug_box_armv7m.c
@@ -53,6 +53,12 @@ void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
     /* Suspend the OS. */
     g_priv_sys_hooks.priv_os_suspend();
 
+    /* Stop all lower-than-SVC-priority interrupts. FIXME Enable debug box to
+     * do things that require interrupts. One idea would be to provide an SVC
+     * to re-enable interrupts that can only be called by the debug box during
+     * debug handling. */
+    __set_BASEPRI(__UVISOR_NVIC_MIN_PRIORITY << (8U - __NVIC_PRIO_BITS));
+
     context_switch_in(CONTEXT_SWITCH_FUNCTION_DEBUG, dst_id, src_sp, dst_sp);
 
     /* Upon execution return debug_handler will be executed. Upon return from

--- a/core/vmpu/src/mpu_kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/mpu_kinetis/vmpu_kinetis.c
@@ -146,8 +146,11 @@ uint32_t vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
                 DPRINTF("Multiple MPU violations found.\r\n");
             }
 
-            /* Check if the fault is the special register corner case. */
-            if (!vmpu_fault_recovery_bus(pc, sp, fault_addr, fault_status)) {
+            /* Check if the fault is the special register corner case. uVisor
+             * won't fault if it tries to access the special registers, so we
+             * must not handle the special register case when we are from
+             * privileged mode. */
+            if (from_psp && !vmpu_fault_recovery_bus(pc, sp, fault_addr, fault_status)) {
                 VMPU_SCB_BFSR = fault_status;
                 return lr;
             }


### PR DESCRIPTION
This PR fixes two unrelated bugs.
- debug: Disable interrupts before handling debug box
- kinetis: Don't recover special registers from priv

@niklas-arm @AlessandroA 