### PR TITLE
Remove definition of g_debug_box from core/debug/inc/debug.h

### DIFF
--- a/core/debug/inc/debug.h
+++ b/core/debug/inc/debug.h
@@ -29,7 +29,7 @@ typedef struct TDebugBox {
     int initialized;
     uint8_t box_id;
 } TDebugBox;
-TDebugBox g_debug_box;
+extern TDebugBox g_debug_box;
 
 void debug_init(void);
 void debug_mpu_config(void);

--- a/core/debug/src/debug_box.c
+++ b/core/debug/src/debug_box.c
@@ -23,6 +23,8 @@
 #include "svc.h"
 #include "vmpu.h"
 
+TDebugBox g_debug_box;
+
 void debug_reboot(TResetReason reason)
 {
     if (!g_debug_box.initialized || g_active_box != g_debug_box.box_id || reason >= __TRESETREASON_MAX) {


### PR DESCRIPTION
`g_debug_box` will now be declared in _core/debug/inc/debug.h_ and defined in _core/debug/src/debug_box.c_.
@Patater @alzix 