### PR TITLE
ARMv8-M: Fix scheduler when there is only 1 box

### DIFF
--- a/core/system/src/core_armv8m/scheduler.c
+++ b/core/system/src/core_armv8m/scheduler.c
@@ -23,7 +23,7 @@
 #include "vmpu.h"
 
 /* The box to switch to when the current one runs out of time. */
-static int g_next_box_id = 1;
+static int g_next_box_id;
 
 /* Set the desired time slice. */
 static const int32_t time_slice_ms = 100;
@@ -186,10 +186,8 @@ static void scheduler_delta_add(uint32_t delta_ms, saved_reg_t * reg)
 
     g_context_current_states[src_box_id].remaining_ms -= delta_ms;
     if (g_context_current_states[src_box_id].remaining_ms <= 0) {
-        int dst_box_id = g_next_box_id;
         g_next_box_id = (g_next_box_id + 1) % g_vmpu_box_count; /* Cycle through the boxes. */
-
-        dispatch(dst_box_id, src_box_id, reg);
+        dispatch(g_next_box_id, src_box_id, reg);
         g_context_current_states[src_box_id].remaining_ms = time_slice_ms;
     }
 }


### PR DESCRIPTION
In the previous implementation the context switch function takes the
next box ID before applying modular arithmetic to it. This means that
the very first time a context switch is required, we take the bare
next box ID. Since the next box ID is initialized to 1, if there is only
one box the context switch will fail with an out-of-range box ID error.

This commit makes sure that we modularize the next box ID right from the
first use.

@Patater @niklas-arm 