### PR TITLE
vmpu_buffer_is_ok for v7-M

### DIFF
--- a/core/debug/src/core_armv7m/debug_box_armv7m.c
+++ b/core/debug/src/core_armv7m/debug_box_armv7m.c
@@ -18,6 +18,7 @@
 #include "context.h"
 #include "debug.h"
 #include "vmpu.h"
+#include "vmpu_mpu.h"
 
 void debug_die(void)
 {
@@ -41,7 +42,11 @@ void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
     uint8_t dst_id = g_debug_box.box_id;
 
     /* Copy the xPSR from the source exception stack frame. */
-    uint32_t xpsr = vmpu_unpriv_uint32_read((uint32_t) &((uint32_t *) src_sp)[7]);
+    uint32_t * xpsr_p = &((uint32_t *) src_sp)[7];
+    uint32_t xpsr = xPSR_T_Msk;
+    if (vmpu_buffer_access_is_ok(g_active_box, xpsr_p, sizeof(*xpsr_p))) {
+        xpsr = vmpu_unpriv_uint32_read((uint32_t) xpsr_p);
+    }
 
     /* FIXME: This makes the debug box overwrite the top of the interrupt stack! */
     g_context_current_states[dst_id].sp = g_debug_interrupt_sp[dst_id];

--- a/core/system/inc/page_allocator_faults.h
+++ b/core/system/inc/page_allocator_faults.h
@@ -28,6 +28,19 @@ void page_allocator_register_fault(uint8_t page);
 /** @returns the number of faults on this page. */
 uint32_t page_allocator_get_faults(uint8_t page);
 
+/** Check if a box is allowed to access a address range.
+ * Note that the address range must be contained inside one page.
+ *
+ * @param box_id       the id of the box to query for
+ * @param start_addr   the start address of the range
+ * @param end_addr     the end address of the range
+ * @retval
+ *  - `UVISOR_ERROR_PAGE_OK`  range is contained in one page owned by the box id
+ *  - `UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER` range is spread over multiple pages or owners
+ *  - `UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN` range is not outside of in page heap
+ */
+int page_allocator_check_range_for_box(int box_id, uint32_t start_addr, uint32_t end_addr);
+
 /** Map an address to the start and end addresses of a page.
  * If the address is not part of any page, or the page does not belong to the
  * active box or box 0 an error is returned and `start`, `end` and `page` are invalid.

--- a/core/system/src/page_allocator_faults.c
+++ b/core/system/src/page_allocator_faults.c
@@ -48,6 +48,23 @@ uint32_t page_allocator_get_faults(uint8_t page)
     return 0;
 }
 
+
+int page_allocator_check_range_for_box(int box_id, uint32_t start_addr, uint32_t end_addr)
+{
+    uint8_t pa = page_allocator_get_page_from_address(start_addr);
+    uint8_t pe = page_allocator_get_page_from_address(end_addr);
+    if (pa != pe) {
+        /* Range is spread of two or more pages, we're not testing that! */
+        return UVISOR_ERROR_PAGE_INVALID_PAGE_OWNER;
+    }
+    else if (pa != UVISOR_PAGE_UNUSED && page_allocator_map_get(g_page_owner_map[box_id], pa)) {
+        /* Range is in page and accessible by box. */
+        return UVISOR_ERROR_PAGE_OK;
+    }
+    /* Range is not in page heap */
+    return UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN;
+}
+
 int page_allocator_get_active_region_for_address(uint32_t address, uint32_t * start_addr, uint32_t * end_addr, uint8_t * page)
 {
     const page_owner_t box_id = g_active_box;

--- a/core/vmpu/inc/vmpu.h
+++ b/core/vmpu/inc/vmpu.h
@@ -206,6 +206,11 @@ extern uint32_t vmpu_round_up_region(uint32_t addr, uint32_t size);
 
 extern void vmpu_order_boxes(int * const best_order, int box_count);
 
+static UVISOR_FORCEINLINE bool vmpu_value_in_range(size_t start, size_t end, size_t value)
+{
+    return start <= value && value < end;
+}
+
 static UVISOR_FORCEINLINE bool vmpu_is_box_id_valid(uint8_t box_id)
 {
     /* Return true if the box_id is valid.

--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
@@ -19,6 +19,7 @@
 #include "context.h"
 #include "halt.h"
 #include "memory_map.h"
+#include "page_allocator_faults.h"
 #include "vmpu.h"
 #include "vmpu_mpu.h"
 
@@ -280,6 +281,14 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
     assert(start_addr <= end_addr);
     if (start_addr > end_addr) {
         /* We couldn't determine the end of the buffer. */
+        return false;
+    }
+
+    /* Check if addr range lies in page heap. */
+    int error = page_allocator_check_range_for_box(box_id, start_addr, end_addr);
+    if (error == UVISOR_ERROR_PAGE_OK) {
+        return true;
+    } else if (error != UVISOR_ERROR_PAGE_INVALID_PAGE_ORIGIN) {
         return false;
     }
 

--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
@@ -200,11 +200,6 @@ bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, u
     return false;
 }
 
-static bool value_in_range(size_t start, size_t end, size_t value)
-{
-    return start <= value && value < end;
-}
-
 MpuRegion * vmpu_region_find_for_address(uint8_t box_id, uint32_t address)
 {
     int count;
@@ -213,7 +208,7 @@ MpuRegion * vmpu_region_find_for_address(uint8_t box_id, uint32_t address)
     count = g_mpu_box_region[box_id].count;
     region = g_mpu_box_region[box_id].regions;
     for (; count-- > 0; region++) {
-        if (value_in_range(region->start, region->end, address)) {
+        if (vmpu_value_in_range(region->start, region->end, address)) {
             return region;
         }
     }
@@ -249,7 +244,7 @@ static bool vmpu_buffer_access_is_ok_static(uint32_t start_addr, uint32_t end_ad
         uint32_t end = rlar | 0x1F; /* The bottom 5 bits are not part of the limit. */
 
         /* Test that the buffer is fully contained in the region. */
-        if (value_in_range(start, end, start_addr) && value_in_range(start, end, end_addr)) {
+        if (vmpu_value_in_range(start, end, start_addr) && vmpu_value_in_range(start, end, end_addr)) {
             return true;
         }
     }
@@ -300,7 +295,7 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
 
     /* If the end address is also within the region, and the region is NS
      * accessible, then access to the buffer is OK. */
-    return value_in_range(region->start, region->end, end_addr) &&
+    return vmpu_value_in_range(region->start, region->end, end_addr) &&
            vmpu_region_is_ns(region->config);
 }
 


### PR DESCRIPTION
- add `vmpu_buffer_is_ok` for v7-M
- fix `vmpu_buffer_is_ok` for v8-M (also check page heap)
- fix reading xpsr from invalid memory on v7-M

cc @Patater 