### PR TITLE
Add memory barriers

### DIFF
--- a/core/system/src/core_armv7m/virq.c
+++ b/core/system/src/core_armv7m/virq.c
@@ -422,6 +422,9 @@ uint32_t virq_gateway_context_switch_in(uint32_t svc_sp, uint32_t svc_pc)
     /* De-privilege execution. */
     __set_CONTROL(__get_CONTROL() | 3);
 
+    /* ISB to ensure subsequent instructions are fetched with the correct privilege level */
+    __ISB();
+
     /* Return whether the destination box requires privacy or not. */
     /* TODO: Context privacy is currently unsupported. */
     return 0;
@@ -487,6 +490,9 @@ void virq_gateway_context_switch_out(uint32_t svc_sp, uint32_t msp)
 
     /* Re-privilege execution. */
     __set_CONTROL(__get_CONTROL() & ~2);
+
+    /* ISB to ensure subsequent instructions are fetched with the correct privilege level */
+    __ISB();
 }
 
 void virq_init(uint32_t const * const user_vtor)

--- a/core/system/src/main.c
+++ b/core/system/src/main.c
@@ -100,6 +100,9 @@ UVISOR_NAKED void main_entry(uint32_t caller)
         "mrs   r1, CONTROL\n"
         "orr   r1, r1, #3\n"
         "msr   CONTROL, r1\n"
+
+        /* ISB to ensure subsequent instructions are fetched with the correct privilege level */
+        "isb\n"
 #endif /* defined(ARCH_CORE_ARMv7M) */
 
         /* Return to the caller. */

--- a/core/vmpu/src/mpu_armv7m/vmpu_armv7m_mpu.c
+++ b/core/vmpu/src/mpu_armv7m/vmpu_armv7m_mpu.c
@@ -454,8 +454,15 @@ void vmpu_mpu_init(void)
 
 void vmpu_mpu_lock(void)
 {
+    /* DMB to ensure MPU update after all transfer to memory completed */
+    __DMB();
+
     /* Finally enable the MPU. */
     MPU->CTRL = MPU_CTRL_ENABLE_Msk | MPU_CTRL_PRIVDEFENA_Msk;
+
+    /* DSB & ISB to ensure subsequent data & instruction transfers are using updated MPU settings */
+    __DSB();
+    __ISB();
 }
 
 uint32_t vmpu_mpu_set_static_acl(uint8_t index, uint32_t start, uint32_t size,

--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
@@ -312,7 +312,14 @@ void vmpu_mpu_init(void)
 
 void vmpu_mpu_lock(void)
 {
+    /* DMB to ensure MPU update after all transfer to memory completed */
+    __DMB();
+
     SAU->CTRL = SAU_CTRL_ENABLE_Msk;
+
+    /* DSB & ISB to ensure subsequent data & instruction transfers are using updated MPU settings */
+    __DSB();
+    __ISB();
 }
 
 uint32_t vmpu_mpu_set_static_acl(uint8_t index, uint32_t start, uint32_t size, UvisorBoxAcl acl, uint32_t acl_hw_spec)

--- a/core/vmpu/src/mpu_kinetis/vmpu_kinetis_mpu.c
+++ b/core/vmpu/src/mpu_kinetis/vmpu_kinetis_mpu.c
@@ -388,10 +388,17 @@ void vmpu_mpu_init(void)
 
 void vmpu_mpu_lock(void)
 {
+    /* DMB to ensure MPU update after all transfer to memory completed */
+    __DMB();
+
     /* MPU background region permission mask
      *   this mask must be set as last one, since the background region gives no
      *   executable privileges to neither user nor supervisor modes */
     MPU->RGDAAC[0] = UVISOR_TACL_BACKGROUND;
+
+    /* DSB & ISB to ensure subsequent data & instruction transfers are using updated MPU settings */
+    __DSB();
+    __ISB();
 }
 
 uint32_t vmpu_mpu_set_static_acl(uint8_t index, uint32_t start, uint32_t size,


### PR DESCRIPTION
Add memory barriers in places where it is advised by the architecture:
- ISB after updating CONTROL register to ensure subsequent instructions are fetched with the correct privilege level.
- DMB before updating MPU to ensure all transfers to memory are completed before update.
- DSB & ISB after updating MPU to ensure subsequence data & instruction transfers are using updated MPU settings.

References:
1. The Definitive Guide to Cortex-M3 and Cortex-M4 Processors (5.6.13 Memory barrier instructions).
1. [ARM Cortex-M Programming Guide to Memory Barrier Instructions](http://arminfo.emea.arm.com/help/topic/com.arm.doc.dai0321a/DAI0321A_programming_guide_memory_barriers_for_m_profile.pdf).

Feel free to suggest more places which are needed.. :-)