### PR TITLE
box_init: Re-enable interrupts for 1 box apps

### DIFF
--- a/core/system/src/core_armv7m/box_init_v7m.c
+++ b/core/system/src/core_armv7m/box_init_v7m.c
@@ -162,6 +162,7 @@ bool box_init_context_switch_next(uint32_t src_svc_sp)
      * not allowed to have a box initialization function. */
     if (g_vmpu_box_count == 1) {
         g_box_init_happened = true;
+        box_init_post();
         return g_box_init_happened;
     }
 


### PR DESCRIPTION
When only 1 box is used, interrupts aren't re-enabled when we finish box
initialization. Call box_init_post() even when there is only 1 box.

@gilles-peskine-arm @niklas-arm 