### PR TITLE
Fix typo in file docs/lib/QUICKSTART.md

### DIFF
--- a/docs/lib/QUICKSTART.md
+++ b/docs/lib/QUICKSTART.md
@@ -396,7 +396,7 @@ To call the public secure entry point from any other box, you can use the `secur
 ```cpp
 /* ~/code/uvisor-example/source/main.cpp */
 
-#include "secure-box.h"
+#include "secure_box.h"
 ```
 
 Then replace the `main` function with:


### PR DESCRIPTION
fix #434 
Typo in file name: #include "secure-box.h"