### PR TITLE
Remove __builtin_clz(0) calls

### DIFF
--- a/api/inc/vmpu_exports.h
+++ b/api/inc/vmpu_exports.h
@@ -243,7 +243,8 @@ typedef struct {
 #if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
 static UVISOR_FORCEINLINE int vmpu_bits(uint32_t size)
 {
-    return 32 - __builtin_clz(size);
+    /* If size is 0, the result of __builtin_clz is undefined */
+    return (0 == size) ? 0: 32 - __builtin_clz(size);
 }
 #endif /* defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1 */
 

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -44,7 +44,6 @@ static int vmpu_check_sanity(void)
     assert(!vmpu_is_box_id_valid(UVISOR_BOX_ID_INVALID));
 
     /* Verify basic assumptions about vmpu_bits/__builtin_clz. */
-    assert(__builtin_clz(0) == 32);
     assert(__builtin_clz(1UL << 31) == 0);
     assert(vmpu_bits(0) == 0);
     assert(vmpu_bits(1UL << 31) == 32);


### PR DESCRIPTION
According to GCC documentation __builtin_clz(0) result is undefined.
- Removed sanity checks with explicit 0 value calls.
- Hard-coded expected result for __builtin_clz(0) to 0.

