### PR TITLE
vmpu: Check start_addr is no greater than end_addr first

### DIFF
--- a/core/vmpu/src/mpu_armv7m/vmpu_armv7m_mpu.c
+++ b/core/vmpu/src/mpu_armv7m/vmpu_armv7m_mpu.c
@@ -380,6 +380,12 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
     uint32_t start_addr = (uint32_t) addr;
     uint32_t end_addr = start_addr + size - 1;
 
+    assert(start_addr <= end_addr);
+    if (start_addr > end_addr) {
+        /* We couldn't determine the end of the buffer. */
+        return false;
+    }
+
     /* NOTE: Buffers are not allowed to span more than 1 region. If they do
      * span more than one region, access will be denied. */
 
@@ -394,12 +400,6 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
         if (vmpu_buffer_access_is_ok_static(start_addr, end_addr)) {
             return true;
         }
-    }
-
-    assert(start_addr <= end_addr);
-    if (start_addr > end_addr) {
-        /* We couldn't determine the end of the buffer. */
-        return false;
     }
 
     /* Check if addr range lies in page heap. */

--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
@@ -257,6 +257,12 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
     uint32_t start_addr = (uint32_t) UVISOR_GET_NS_ALIAS(addr);
     uint32_t end_addr = start_addr + size - 1;
 
+    assert(start_addr <= end_addr);
+    if (start_addr > end_addr) {
+        /* We couldn't determine the end of the buffer. */
+        return false;
+    }
+
     /* NOTE: Buffers are not allowed to span more than 1 region. If they do
      * span more than one region, access will be denied. */
 
@@ -271,12 +277,6 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
         if (vmpu_buffer_access_is_ok_static(start_addr, end_addr)) {
             return true;
         }
-    }
-
-    assert(start_addr <= end_addr);
-    if (start_addr > end_addr) {
-        /* We couldn't determine the end of the buffer. */
-        return false;
     }
 
     /* Check if addr range lies in page heap. */

--- a/core/vmpu/src/mpu_kinetis/vmpu_kinetis_mpu.c
+++ b/core/vmpu/src/mpu_kinetis/vmpu_kinetis_mpu.c
@@ -332,6 +332,12 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
     uint32_t start_addr = (uint32_t) addr;
     uint32_t end_addr = start_addr + size - 1;
 
+    assert(start_addr <= end_addr);
+    if (start_addr > end_addr) {
+        /* We couldn't determine the end of the buffer. */
+        return false;
+    }
+
     /* NOTE: Buffers are not allowed to span more than 1 region. If they do
      * span more than one region, access will be denied. */
 
@@ -346,12 +352,6 @@ bool vmpu_buffer_access_is_ok(int box_id, const void * addr, size_t size)
         if (vmpu_buffer_access_is_ok_static(start_addr, end_addr)) {
             return true;
         }
-    }
-
-    assert(start_addr <= end_addr);
-    if (start_addr > end_addr) {
-        /* We couldn't determine the end of the buffer. */
-        return false;
     }
 
     /* Check if addr range lies in AIPS */


### PR DESCRIPTION
If the check is not done first, it can be avoided at
`vmpu_buffer_access_is_ok_static` where there is not check for start is
smaller than end. Line 247 only checks range.