### PR TITLE
pool_queue: Force termination of find_first

### DIFF
--- a/core/system/src/pool_queue.c
+++ b/core/system/src/pool_queue.c
@@ -361,10 +361,11 @@ static uvisor_pool_slot_t find_first(uvisor_pool_queue_t * pool_queue,
 {
     uvisor_pool_slot_t slot;
     uvisor_pool_t * pool = UVISOR_AUTO_NS_ALIAS(pool_queue->pool);
+    uvisor_pool_slot_t iterated = 0;
 
     /* Walk the queue, looking for the first slot that matches the query. */
     slot = pool_queue->head;
-    while (slot != UVISOR_POOL_SLOT_INVALID)
+    while (slot != UVISOR_POOL_SLOT_INVALID && iterated <= UVISOR_POOL_MAX_VALID)
     {
         uvisor_pool_queue_entry_t * entry = &pool->management_array[slot];
 
@@ -378,6 +379,7 @@ static uvisor_pool_slot_t find_first(uvisor_pool_queue_t * pool_queue,
         }
 
         slot = entry->queued.next;
+        iterated++;
     }
 
     /* We didn't find a match. */


### PR DESCRIPTION
When the pool is corrupted to contain a cycle, it would be bad to keep
the loop infinite because this creates a denial of service. The counter
will force termination of look_first to a finite number of iterations.