### PR TITLE
Fix declaration of svcRtxKernelLock

### DIFF
--- a/api/rtx/src/box_init.c
+++ b/api/rtx/src/box_init.c
@@ -29,7 +29,7 @@
 extern void SVC_Handler(void);
 extern void PendSV_Handler(void);
 extern void SysTick_Handler(void);
-extern uint32_t svcRtxKernelLock(void);
+extern int32_t svcRtxKernelLock(void);
 
 UVISOR_SET_PRIV_SYS_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler, svcRtxKernelLock, __uvisor_semaphore_post);
 


### PR DESCRIPTION
Change the return type of svcRtxKernelLock from uint32_t to int32_t so it matches RTX - https://github.com/ARMmbed/mbed-os/blob/master/rtos/rtx5/TARGET_CORTEX_M/rtx_lib.h#L122. 