### PR TITLE
pool_queue: Add static assert for management_array offset

### DIFF
--- a/core/system/src/pool_queue.c
+++ b/core/system/src/pool_queue.c
@@ -17,6 +17,7 @@
 #include "api/inc/linker_exports.h"
 #include "api/inc/pool_queue_exports.h"
 #include "api/inc/uvisor_spinlock_exports.h"
+#include <stddef.h>
 #include <string.h>
 
 int uvisor_pool_init(uvisor_pool_t * pool, void * array, size_t stride, size_t num)
@@ -45,6 +46,10 @@ int uvisor_pool_init(uvisor_pool_t * pool, void * array, size_t stride, size_t n
     pool->management_array[num - 1].dequeued.next = UVISOR_POOL_SLOT_INVALID;
 
     uvisor_spin_init(&pool->spinlock);
+
+    UVISOR_STATIC_ASSERT(
+            sizeof(uvisor_pool_t) == offsetof(uvisor_pool_t, management_array),
+            management_array_offset_must_be_aligned_to_pool_structure_size);
 
     return 0;
 }


### PR DESCRIPTION
In order for the GNU extension of static initialisation of flexible
array member to work. Care must be taken to check whether the offset of
`management_array` is the size of the structure, so that accessing the
`management_array` will be to the allocated static memory following the
pool struct. If this assertion fails, accessing management_array might
end of accessing the struct padding inserted by the compiler.

Additional explanation:

Current struct layout

|  byte	| byte        	|  byte   	| byte 	|
|--------	|---------------	|------------	|----------	|
| magic  	|    magic      	| magic 	|  magic |
| array  	|     array 	|  array |    array	|
| stride 	|    stride	|  stride	|  stride	|
| num    	| num_allocated 	| first_free 	| spinlock 	|
| -> | | |

`->` = location `management_array` points to (outside the struct)

If future modifications are to be added to this data structure, say adding/removing an u8 field. A possible layout will be 

|  byte	| byte        	|  byte   	| byte 	|
|--------	|---------------	|------------	|----------	|
| magic  	|    magic      	| magic 	|  magic |
| array  	|     array 	|  array |    array	|
| stride 	|    stride	|  stride	|  stride	|
| num    	| num_allocated 	| first_free 	| spinlock 	|
| new_field | ->padding | padding | padding |

`->` = location `management_array` points to (inside the struct)

In this case, `management_array` points to the struct padding due to the layout of `uvisor_pool_entry_t` being u8. However, the actual management array is located after the paddings (due to struct alignments).

The C standard does not make clear requirements on struct paddings, but it would be nice to avoid the grey area and be certain.

See also: http://www.cl.cam.ac.uk/~pes20/cerberus/notes30.pdf Section 3.3