### PR TITLE
Remove memory map references from uvisor core

### DIFF
--- a/core/debug/inc/debug.h
+++ b/core/debug/inc/debug.h
@@ -37,7 +37,6 @@ void debug_mpu_config(void);
 void debug_sau_config(void);
 #endif /* defined(ARCH_MPU_ARMv8M) */
 void debug_fault(THaltError reason, uint32_t lr, uint32_t sp);
-void debug_map_addr_to_periph(uint32_t address);
 
 /* Debug box */
 void debug_register_driver(const TUvisorDebugDriver * const driver);

--- a/core/debug/src/core_armv7m/mpu_armv7m/debug_armv7m.c
+++ b/core/debug/src/core_armv7m/mpu_armv7m/debug_armv7m.c
@@ -31,50 +31,6 @@ static void debug_fault_mpu(void)
     dprintf("\n\r");
 }
 
-void debug_map_addr_to_periph(uint32_t address)
-{
-    uint32_t physical_addr, physical_bit;
-    int is_bitbanded;
-    const MemMap *map;
-
-    dprintf("* MEMORY MAP\n\r");
-    is_bitbanded = 0;
-    if ((map = memory_map_name(address)) != NULL) {
-        dprintf("  Address:           0x%08X\n\r", address);
-        dprintf("  Region/Peripheral: %s\n\r", map->name);
-        dprintf("    Base address:    0x%08X\n\r", map->base);
-        dprintf("    End address:     0x%08X\n\r", map->end);
-
-        if (address >= VMPU_PERIPH_BITBAND_START && address <= VMPU_PERIPH_BITBAND_END) {
-            physical_addr = VMPU_PERIPH_BITBAND_ALIAS_TO_ADDR(address);
-            physical_bit = VMPU_PERIPH_BITBAND_ALIAS_TO_BIT(address);
-            is_bitbanded = 1;
-            map = memory_map_name(physical_addr);
-        }
-        else if (address >= VMPU_SRAM_BITBAND_START && address <= VMPU_SRAM_BITBAND_END) {
-            physical_addr = VMPU_SRAM_BITBAND_ALIAS_TO_ADDR(address);
-            physical_bit = VMPU_SRAM_BITBAND_ALIAS_TO_BIT(address);
-            is_bitbanded = 1;
-            map = memory_map_name(physical_addr);
-        }
-
-        if (map != NULL && is_bitbanded) {
-            dprintf("    Before bitband:  0x%08X\n\r", physical_addr);
-            dprintf("    Alias:           %s\n\r", map->name);
-            dprintf("      Base address:  0x%08X\n\r", map->base);
-            dprintf("      End address:   0x%08X\n\r", map->end);
-            dprintf("    Accessed bit:    %d\n\r", physical_bit);
-        }
-        else {
-            dprintf("    Before bitband:  [invalid]\n\r");
-        }
-    }
-    else {
-        dprintf("  Address:           [invalid]\n\r");
-    }
-    dprintf("\n\r");
-}
-
 void debug_mpu_config(void)
 {
     uint32_t dregion, ctrl, size, rasr, ap, tex, srd;
@@ -138,5 +94,4 @@ void debug_mpu_config(void)
 void debug_fault_memmanage_hw(void)
 {
     debug_fault_mpu();
-    debug_map_addr_to_periph(SCB->MMFAR);
 }

--- a/core/debug/src/core_armv7m/mpu_kinetis/debug_kinetis.c
+++ b/core/debug/src/core_armv7m/mpu_kinetis/debug_kinetis.c
@@ -95,7 +95,9 @@ static void debug_fault_mpu(void)
         }
     }
     else
+    {
         dprintf("* No MPU violation found\n\r");
+    }
     dprintf("\n\r");
 }
 

--- a/core/debug/src/core_armv8m/mpu_armv8m/debug_armv8m.c
+++ b/core/debug/src/core_armv8m/mpu_armv8m/debug_armv8m.c
@@ -26,11 +26,6 @@ static void debug_fault_sau(void)
     /* FIXME: This function must be implemented for the vMPU port to be complete. */
 }
 
-void debug_map_addr_to_periph(uint32_t address)
-{
-    /* FIXME: This function must be implemented for the vMPU port to be complete. */
-}
-
 void debug_mpu_config(void)
 {
     /* On ARMv8-M we have 2 MPUs (S, NS). */
@@ -145,11 +140,9 @@ void debug_sau_config(void)
 void debug_fault_memmanage_hw(void)
 {
     debug_fault_mpu();
-    debug_map_addr_to_periph(0);
 }
 
 void debug_fault_secure_hw(void)
 {
     debug_fault_sau();
-    debug_map_addr_to_periph(0);
 }


### PR DESCRIPTION
Fix #398 

Remove any platform-specific memory-map references from uvisor core.