### PR TITLE
priv_sys_hooks: Fix build warning

### DIFF
--- a/api/inc/priv_sys_hooks_exports.h
+++ b/api/inc/priv_sys_hooks_exports.h
@@ -33,7 +33,7 @@ typedef struct {
     void (*priv_svc_0)(void);
     void (*priv_pendsv)(void);
     void (*priv_systick)(void);
-    uint32_t (*priv_os_suspend)(void);
+    int32_t (*priv_os_suspend)(void);
     int (*priv_uvisor_semaphore_post)(UvisorSemaphore * semaphore);
 } UvisorPrivSystemHooks;
 


### PR DESCRIPTION
Change the internal priv_os_suspend function pointer type to match RTX's svcRtxKernelLock type.

    [Warning] box_init.c@34,73: initialization from incompatible pointer type [-Wincompatible-pointer-types]

Fixes 49d882c0b46d ("Fix declaration of svcRtxKernelLock")