### PR TITLE
vmpu: armv8m: disable SAU region before any modification

### DIFF
--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
@@ -352,8 +352,8 @@ void vmpu_mpu_invalidate(void)
          * other modification, hence we cannot select the SAU region using the
          * region number field in the RBAR register. */
         SAU->RNR = slot;
-        SAU->RBAR = 0;
         SAU->RLAR = 0;
+        SAU->RBAR = 0;
         g_mpu_priority[slot] = 0;
         slot++;
     }


### PR DESCRIPTION
If a SAU region is not disabled, setting RBAR to zero will
extend SAU region and cause a Secure Fault if
vmpu_mpu_invalidate() is covered.

Signed-off-by: Jethro Hsu <jethro@realtek.com>