### PR TITLE
Add return statement in halt flow of register_gateway

### DIFF
--- a/core/system/src/register_gateway.c
+++ b/core/system/src/register_gateway.c
@@ -99,6 +99,7 @@ void register_gateway_perform_operation(uint32_t svc_sp, uint32_t svc_pc)
     if (status != REGISTER_GATEWAY_STATUS_OK) {
         HALT_ERROR(PERMISSION_DENIED, "Register gateway 0x%08X not allowed. Error: %d.",
                    (uint32_t) register_gateway, status);
+        return;
     }
 
     /* From now on we can assume the register_gateway structure and the address


### PR DESCRIPTION
- In case there is a debug box HALT_ERROR doesn't halt but forges the
  debug_box stack, deprivileges and set the thread mode return address
  to the debug-driver's halt callback function.
- So after HALT_ERROR need to return in order to exit handler mode so
  the debug-driver's halt callback gets called.