### PR TITLE
pool_queue: Remove extra unlock in find_first

### DIFF
--- a/core/system/src/pool_queue.c
+++ b/core/system/src/pool_queue.c
@@ -379,7 +379,6 @@ static uvisor_pool_slot_t find_first(uvisor_pool_queue_t * pool_queue,
         int query_result = query_fn(slot, context);
 
         if (query_result) {
-            uvisor_spin_unlock(&pool->spinlock);
             return slot;
         }
 


### PR DESCRIPTION
This unlock is extraneous as the lock will be released at Line 403/416.
This extra unlock will cause synchronisation issues.
Consider 3 threads trying to operate on the same queue.
Thread 0 obtains the lock to and is running find_first.
Thread 1 and Thread 2 is spinning on the lock.
When Thread 0 has found the entry, there is an unlock action. This
allows Thread 1 to operate on the queue. However, the unlock at Line
403/416 executed by Thread 0 will release the lock again. This will
allow Thread 2 to operate on the queue, causing synchronisation problem