### PR TITLE
Add deprivilege/print/reprivilege flow

### DIFF
--- a/api/inc/box_config.h
+++ b/api/inc/box_config.h
@@ -173,19 +173,20 @@ UVISOR_EXTERN void const * const public_box_cfg_ptr;
 
 /* Use this macro after calling the box configuration macro, in order to register your box as a debug box.
  * It will create a valid debug driver struct with the halt_error_func parameter as its halt_error() function */
-#define UVISOR_DEBUG_DRIVER(box_name, halt_error_func) \
+#define UVISOR_DEBUG_DRIVER(box_name, halt_error_func, debug_print_func) \
         UVISOR_EXTERN TUvisorDebugDriver const __uvisor_debug_driver; \
         TUvisorDebugDriver const __uvisor_debug_driver = { \
             UVISOR_DEBUG_BOX_MAGIC, \
             UVISOR_DEBUG_BOX_VERSION, \
             &box_name ## _cfg, \
-            halt_error_func \
+            halt_error_func, \
+            debug_print_func \
         };
 
 /* Use this macro after calling the box configuration macro, in order to
  * register the public box as a debug box. */
-#define UVISOR_PUBLIC_BOX_DEBUG_DRIVER(halt_error_func) \
-        UVISOR_DEBUG_DRIVER(public_box, halt_error_func)
+#define UVISOR_PUBLIC_BOX_DEBUG_DRIVER(halt_error_func, debug_print_func) \
+        UVISOR_DEBUG_DRIVER(public_box, halt_error_func, debug_print_func)
 
 
 #endif /* __UVISOR_API_BOX_CONFIG_H__ */

--- a/api/inc/debug_exports.h
+++ b/api/inc/debug_exports.h
@@ -33,6 +33,7 @@ typedef struct TUvisorDebugDriver {
     const uint32_t version;
     const UvisorBoxConfig * const box_cfg_ptr;
     void (*halt_error)(THaltError, const THaltInfo *);
+    void (*debug_print)(const char *);
 } TUvisorDebugDriver;
 
 /* Number of handlers in the debug box driver */

--- a/api/inc/svc_exports.h
+++ b/api/inc/svc_exports.h
@@ -91,7 +91,7 @@
 
 /* SVC immediate values for hardcoded table (call from unprivileged) */
 #define UVISOR_SVC_ID_UNVIC_OUT           UVISOR_SVC_FIXED_TABLE(0, 0)
-/* Deprecated: UVISOR_SVC_ID_CX_IN(nargs) UVISOR_SVC_FIXED_TABLE(1, nargs) */
+#define UVISOR_SVC_ID_RETURN              UVISOR_SVC_FIXED_TABLE(1, 0)
 /* Deprecated: UVISOR_SVC_ID_CX_OUT       UVISOR_SVC_FIXED_TABLE(2, 0) */
 #define UVISOR_SVC_ID_REGISTER_GATEWAY    UVISOR_SVC_FIXED_TABLE(3, 0)
 #define UVISOR_SVC_ID_BOX_INIT_FIRST      UVISOR_SVC_FIXED_TABLE(4, 0)
@@ -99,5 +99,6 @@
 
 /* SVC immediate values for hardcoded table (call from privileged) */
 #define UVISOR_SVC_ID_UNVIC_IN         UVISOR_SVC_FIXED_TABLE(0, 0)
+#define UVISOR_SVC_ID_DEPRIVILEGE      UVISOR_SVC_FIXED_TABLE(1, 0)
 
 #endif /* __UVISOR_API_SVC_EXPORTS_H__ */

--- a/core/debug/inc/debug.h
+++ b/core/debug/inc/debug.h
@@ -50,8 +50,8 @@ void debug_reboot(TResetReason reason);
 uint32_t debug_box_enter_from_priv(uint32_t lr);
 
 void debug_die(void);
-void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
-                                  uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
+void debug_deprivilege_and_die(void * debug_handler, void * return_handler,
+                               uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
 bool debug_collect_halt_info(uint32_t lr, uint32_t sp, THaltInfo *halt_info);
 
 #ifdef  NDEBUG

--- a/core/debug/inc/debug.h
+++ b/core/debug/inc/debug.h
@@ -39,6 +39,7 @@ void debug_sau_config(void);
 void debug_fault(THaltError reason, uint32_t lr, uint32_t sp);
 
 /* Debug box */
+void debug_print(const uint8_t * message_buffer, uint32_t size);
 void debug_halt_error(THaltError reason, const THaltInfo *halt_info);
 void debug_reboot(TResetReason reason);
 
@@ -52,7 +53,15 @@ uint32_t debug_box_enter_from_priv(uint32_t lr);
 void debug_die(void);
 void debug_deprivilege_and_die(void * debug_handler, void * return_handler,
                                uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
+void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
+                                  uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
+void debug_return(void);
 bool debug_collect_halt_info(uint32_t lr, uint32_t sp, THaltInfo *halt_info);
+
+/* Two SVC handlers that are used to deprivilege from uVisor and return to it
+ * respectively. */
+void UVISOR_NAKED debug_uvisor_deprivilege(uint32_t svc_sp, uint32_t svc_pc);
+void UVISOR_NAKED debug_uvisor_return(uint32_t svc_sp, uint32_t svc_pc);
 
 #ifdef  NDEBUG
 

--- a/core/debug/src/core_armv7m/debug_box_armv7m.c
+++ b/core/debug/src/core_armv7m/debug_box_armv7m.c
@@ -41,20 +41,13 @@ void debug_deprivilege_and_die(void * debug_handler, void * return_handler,
     /* Destination box: The debug box. */
     uint8_t dst_id = g_debug_box.box_id;
 
-    /* Copy the xPSR from the source exception stack frame. */
-    uint32_t * xpsr_p = &((uint32_t *) src_sp)[7];
-    uint32_t xpsr = xPSR_T_Msk;
-    if (vmpu_buffer_access_is_ok(g_active_box, xpsr_p, sizeof(*xpsr_p))) {
-        xpsr = vmpu_unpriv_uint32_read((uint32_t) xpsr_p);
-    }
-
     /* FIXME: This makes the debug box overwrite the top of the interrupt stack! */
     g_context_current_states[dst_id].sp = g_debug_interrupt_sp[dst_id];
 
     /* Destination box: Forge the destination stack frame. */
     /* Note: We manually have to set the 4 parameters on the destination stack,
      *       so we will set the API to have nargs=0. */
-    uint32_t dst_sp = context_forge_exc_sf(src_sp, dst_id, (uint32_t) debug_handler, (uint32_t) return_handler, xpsr, 0);
+    uint32_t dst_sp = context_forge_exc_sf(src_sp, dst_id, (uint32_t) debug_handler, (uint32_t) return_handler, xPSR_T_Msk, 0);
     ((uint32_t *) dst_sp)[0] = a0;
     ((uint32_t *) dst_sp)[1] = a1;
     ((uint32_t *) dst_sp)[2] = a2;

--- a/core/debug/src/core_armv7m/debug_box_armv7m.c
+++ b/core/debug/src/core_armv7m/debug_box_armv7m.c
@@ -30,8 +30,8 @@ extern uint32_t g_debug_interrupt_sp[];
 /* FIXME: Currently it is not possible to return to a regular execution flow
  *        after the execution of the debug box handler. */
 /* Note: On ARMv7-M the return_handler is executed in NP mode. */
-void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
-                                  uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
+void debug_deprivilege_and_die(void * debug_handler, void * return_handler,
+                               uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
 {
     /* Source box: Get the current stack pointer. */
     /* Note: The source stack pointer is only used to assess the stack

--- a/core/debug/src/core_armv7m/mpu_armv7m/debug_armv7m.c
+++ b/core/debug/src/core_armv7m/mpu_armv7m/debug_armv7m.c
@@ -22,12 +22,12 @@
 static void debug_fault_mpu(void)
 {
     if (VMPU_SCB_MMFSR & 0x80) {
-        dprintf("* MPU FAULT\n\r");
+        dprintf("* MPU FAULT\n");
     }
     else {
-        dprintf("* No MPU violation found\n\r");
+        dprintf("* No MPU violation found\n");
     }
-    dprintf("\n\r");
+    default_putc('\n');
 }
 
 void debug_mpu_config(void)
@@ -36,22 +36,22 @@ void debug_mpu_config(void)
     char dim[][3] = {"B ", "KB", "MB", "GB"};
     int i;
 
-    dprintf("* MPU CONFIGURATION\n\r");
+    dprintf("* MPU CONFIGURATION\n");
 
     /* CTRL */
     ctrl = MPU->CTRL;
-    dprintf("\n\r");
-    dprintf("  Background region %s\n\r", ctrl & MPU_CTRL_PRIVDEFENA_Msk ?
+    default_putc('\n');
+    dprintf("  Background region %s\n", ctrl & MPU_CTRL_PRIVDEFENA_Msk ?
                                           "enabled" : "disabled");
-    dprintf("  MPU %s @NMI, @HardFault\n\r", ctrl & MPU_CTRL_HFNMIENA_Msk ?
+    dprintf("  MPU %s @NMI, @HardFault\n", ctrl & MPU_CTRL_HFNMIENA_Msk ?
                                              "enabled" : "bypassed");
-    dprintf("  MPU %s\n\r", ctrl & MPU_CTRL_PRIVDEFENA_Msk ?
+    dprintf("  MPU %s\n", ctrl & MPU_CTRL_PRIVDEFENA_Msk ?
                                   "enabled" : "disabled");
-    dprintf("\n\r");
+    default_putc('\n');
 
     /* information for each region (RBAR, RASR) */
     dregion = (MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
-    dprintf("  Region Start      Size  XN AP  TEX S C B SRD      Valid\n\r");
+    dprintf("  Region Start      Size  XN AP  TEX S C B SRD      Valid\n");
     for(i = 0; i < dregion; ++i)
     {
         /* select region */
@@ -80,14 +80,14 @@ void debug_mpu_config(void)
                 (rasr & MPU_RASR_C_Msk)   >> MPU_RASR_C_Pos,
                 (rasr & MPU_RASR_B_Msk)   >> MPU_RASR_B_Pos,
                 (rasr & MPU_RASR_SRD_Msk) >> MPU_RASR_B_Pos);
-        dprintf("%d%d%d%d%d%d%d%d %d\n\r",
+        dprintf("%d%d%d%d%d%d%d%d %d\n",
                 (srd & 0x80) >> 0x7, (srd & 0x40) >> 0x6,
                 (srd & 0x20) >> 0x5, (srd & 0x10) >> 0x4,
                 (srd & 0x08) >> 0x3, (srd & 0x04) >> 0x2,
                 (srd & 0x02) >> 0x1, (srd & 0x01) >> 0x0,
                 rasr & MPU_RASR_ENABLE_Msk ? 1 : 0);
     }
-    dprintf("\n\r");
+    default_putc('\n');
 }
 
 void debug_fault_memmanage_hw(void)

--- a/core/debug/src/core_armv7m/mpu_kinetis/debug_kinetis.c
+++ b/core/debug/src/core_armv7m/mpu_kinetis/debug_kinetis.c
@@ -36,9 +36,9 @@ static void debug_fault_mpu(void)
                 ear = MPU->SP[4 - s].EAR;
                 eacd = edr >> 20;
 
-                dprintf("* MPU FAULT:\n\r");
-                dprintf("  Slave port:       %d\n\r", 4 - s);
-                dprintf("  Address:          0x%08X\n\r", ear);
+                dprintf("* MPU FAULT:\n");
+                dprintf("  Slave port:       %d\n", 4 - s);
+                dprintf("  Address:          0x%08X\n", ear);
                 dprintf("  Faulting regions: ");
                 found = 0;
                 for(r = 11; r >= 0; r--)
@@ -47,20 +47,20 @@ static void debug_fault_mpu(void)
                     {
                         if(!found)
                         {
-                            dprintf("\n\r");
+                            default_putc('\n');
                             found = 1;
                         }
                         dprintf("    R%02d:", 11 - r);
                         for (i = 0; i < 4; i++) {
                             dprintf(" 0x%08X", MPU->WORD[11 - r][i]);
                         }
-                        dprintf("\n\r");
+                        default_putc('\n');
                     }
                 }
                 if(!found)
-                    dprintf("[none]\n\r");
-                dprintf("  Master port:      %d\n\r", (edr >> 4) & 0xF);
-                dprintf("  Error attribute:  %s %s (%s mode)\n\r",
+                    dprintf("[none]\n");
+                dprintf("  Master port:      %d\n", (edr >> 4) & 0xF);
+                dprintf("  Error attribute:  %s %s (%s mode)\n",
                         edr & 0x2 ? "Data" : "Instruction",
                         edr & 0x1 ? "WRITE" : "READ",
                         edr & 0x4 ? "supervisor" : "user");
@@ -70,9 +70,9 @@ static void debug_fault_mpu(void)
     }
     else
     {
-        dprintf("* No MPU violation found\n\r");
+        dprintf("* No MPU violation found\n");
     }
-    dprintf("\n\r");
+    default_putc('\n');
 }
 
 void debug_mpu_config(void)
@@ -93,7 +93,7 @@ void debug_mpu_config(void)
     for (i = 0; i < 5; i++) {
         dprintf(" 0x%08X", MPU->SP[i].EDR);
     }
-    dprintf("\n");
+    default_putc('\n');
     /* region descriptors */
     dprintf("       Start      End        Perm.      Valid\n");
     for (i = 0; i < 12; i++) {
@@ -101,9 +101,9 @@ void debug_mpu_config(void)
         for (j = 0; j < 4; j++) {
             dprintf(" 0x%08X", MPU->WORD[i][j]);
         }
-        dprintf("\n");
+        default_putc('\n');
     }
-    dprintf("\n");
+    default_putc('\n');
     /* the alternate view is not printed */
 }
 

--- a/core/debug/src/core_armv8m/debug_box_armv8m.c
+++ b/core/debug/src/core_armv8m/debug_box_armv8m.c
@@ -26,8 +26,8 @@ void debug_die(void)
 }
 
 /* Note: On ARMv8-M the return_handler is executed in S mode. */
-void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
-                                  uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
+void debug_deprivilege_and_die(void * debug_handler, void * return_handler,
+                               uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
 {
     /* Switch to the debug box.
      * We use a regular process switch, so we don't need a dedicated stack for

--- a/core/debug/src/core_armv8m/debug_box_armv8m.c
+++ b/core/debug/src/core_armv8m/debug_box_armv8m.c
@@ -37,7 +37,21 @@ void debug_deprivilege_and_die(void * debug_handler, void * return_handler,
 
     /* De-privilege, call the debug box handler, re-privilege, call the return
      * handler. */
+    /* FIXME: the below way of deprivileging may be problematic when executed from an exception handler
+     * since we're going to stay in the context of the exception with IPSR reflecting that.
+     * We need to do deprivileging in a way similar to ARMv7 when an exception frame is forged
+     * for that purpose. */
     uint32_t caller = UVISOR_GET_NS_ALIAS(UVISOR_GET_NS_ADDRESS((uint32_t) debug_handler));
     SECURE_TRANSITION_S_TO_NS(caller, a0, a1, a2, a3);
     ((void (*)(void)) return_handler)();
+}
+
+/* FIXME: replace these stubs by the actual implementation. */
+void UVISOR_NAKED UVISOR_NORETURN debug_return(void)
+{
+}
+
+void debug_deprivilege_and_return(void * debug_handler, void * return_handler,
+                                  uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
+{
 }

--- a/core/debug/src/core_armv8m/mpu_armv8m/debug_armv8m.c
+++ b/core/debug/src/core_armv8m/mpu_armv8m/debug_armv8m.c
@@ -32,26 +32,26 @@ void debug_mpu_config(void)
     MPU_Type * mpu_bases[2] = {MPU, MPU_NS};
     int mpu = 0;
     for (; mpu < 2; ++mpu) {
-        dprintf("* MPU CONFIGURATION (%s)\r\n", (mpu == 0) ? "S" : "NS");
-        dprintf("\r\n");
+        dprintf("* MPU CONFIGURATION (%s)\n", (mpu == 0) ? "S" : "NS");
+        default_putc('\n');
 
         /* MPU_TYPE register */
         /* Note: On ARMv8-M the "SEPARATE" bit is always 0, so it's omitted. */
         uint32_t type = mpu_bases[mpu]->TYPE;
         int nregions = (type & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
-        dprintf("  --> %d regions available.\r\n", nregions);
+        dprintf("  --> %d regions available.\n", nregions);
 
         /* MPU_CTRL register */
         uint32_t ctrl = mpu_bases[mpu]->CTRL;
-        dprintf("  --> The MPU is %s.\r\n", (ctrl & MPU_CTRL_ENABLE_Msk) ? "enabled" : "disabled");
-        dprintf("  --> The MPU is %s for HardFault/NMI exceptions.\r\n",
+        dprintf("  --> The MPU is %s.\n", (ctrl & MPU_CTRL_ENABLE_Msk) ? "enabled" : "disabled");
+        dprintf("  --> The MPU is %s for HardFault/NMI exceptions.\n",
                 (ctrl & MPU_CTRL_HFNMIENA_Msk) ? "enabled" : "disabled");
-        dprintf("  --> By default %s code can execute from the system address map.\r\n",
+        dprintf("  --> By default %s code can execute from the system address map.\n",
                 (ctrl & MPU_CTRL_PRIVDEFENA_Msk) ? "only privileged" : "all");
 
         /* Regions dump. */
-        dprintf("\r\n");
-        dprintf("  Region  Base        Limit       Shareable  Permissions      Attr  En\r\n");
+        default_putc('\n');
+        dprintf("  Region  Base        Limit       Shareable  Permissions      Attr  En\n");
         int region = 0;
         for (; region < nregions; ++region) {
             /* Select the region. */
@@ -88,7 +88,7 @@ void debug_mpu_config(void)
             };
             bool xn = rbar & MPU_RBAR_XN_Msk;
 
-            dprintf("  %03d     0x%08X  0x%08X  %s      P: %s%s, NP: %s%s  %02d    %s\r\n",
+            dprintf("  %03d     0x%08X  0x%08X  %s      P: %s%s, NP: %s%s  %02d    %s\n",
                     region,
                     base, limit,
                     sh_strings[sh],
@@ -97,28 +97,28 @@ void debug_mpu_config(void)
                     (rlar & MPU_RLAR_EN_Msk) ? "Y" : "N");
         }
 
-        dprintf("\r\n");
+        default_putc('\n');
     }
 }
 
 void debug_sau_config(void)
 {
-    dprintf("* SAU CONFIGURATION\r\n");
-    dprintf("\r\n");
+    dprintf("* SAU CONFIGURATION\n");
+    default_putc('\n');
 
     /* SAU_CTRL register */
     uint32_t ctrl = SAU->CTRL;
-    dprintf("  --> Memory is marked by default as %s.\r\n", (ctrl & SAU_CTRL_ALLNS_Msk) ? "NS" : "S, not NSC");
-    dprintf("  --> The SAU is %sabled.\r\n", (ctrl & SAU_CTRL_ENABLE_Msk) ? "en" : "dis");
+    dprintf("  --> Memory is marked by default as %s.\n", (ctrl & SAU_CTRL_ALLNS_Msk) ? "NS" : "S, not NSC");
+    dprintf("  --> The SAU is %sabled.\n", (ctrl & SAU_CTRL_ENABLE_Msk) ? "en" : "dis");
 
     /* SAU_TYPE register */
     uint32_t type = SAU->TYPE;
     int nregions = (type & SAU_TYPE_SREGION_Msk) >> SAU_TYPE_SREGION_Pos;
-    dprintf("  --> %d regions available.\r\n", nregions);
+    dprintf("  --> %d regions available.\n", nregions);
 
     /* Regions dump. */
-    dprintf("\r\n");
-    dprintf("  Region  Base        Limit       NSC  En\r\n");
+    default_putc('\n');
+    dprintf("  Region  Base        Limit       NSC  En\n");
     int region = 0;
     for (; region < nregions; ++region) {
         /* Select the region. */
@@ -126,7 +126,7 @@ void debug_sau_config(void)
         uint32_t rbar = SAU->RBAR;
         uint32_t rlar = SAU->RLAR;
 
-        dprintf("  %03d     0x%08X  0x%08X  %s    %s\r\n",
+        dprintf("  %03d     0x%08X  0x%08X  %s    %s\n",
             region,
             rbar & SAU_RBAR_BADDR_Msk,
             (rlar & SAU_RLAR_LADDR_Msk) | 0x1F,
@@ -134,7 +134,7 @@ void debug_sau_config(void)
             (rlar & SAU_RLAR_ENABLE_Msk) ? "Y" : "N");
     }
 
-    dprintf("\r\n");
+    default_putc('\n');
 }
 
 void debug_fault_memmanage_hw(void)

--- a/core/debug/src/debug.c
+++ b/core/debug/src/debug.c
@@ -74,8 +74,8 @@ UVISOR_WEAK void default_putc(uint8_t data)
 
 static void debug_exception_stack_frame(uint32_t lr, uint32_t sp)
 {
-    dprintf("* EXCEPTION STACK FRAME\r\n");
-    dprintf("\r\n");
+    dprintf("* EXCEPTION STACK FRAME\n");
+    default_putc('\n');
 
     /* Determine the exception origin. */
     bool from_np = EXC_FROM_NP(lr);
@@ -86,15 +86,15 @@ static void debug_exception_stack_frame(uint32_t lr, uint32_t sp)
 #endif /* defined(ARCH_MPU_ARMv8M) */
 
     /* Debug the value of EXC_RETURN. */
-    dprintf("  lr: 0x%08X\r\n", lr);
+    dprintf("  lr: 0x%08X\n", lr);
 #if defined(ARCH_MPU_ARMv8M)
-    dprintf("  --> Exception from %s mode, handled in %s mode.\r\n", from_s ? "S" : "NS", to_s ? "S" : "NS");
-    dprintf("  --> R4-R11 %sstacked.\r\n", (lr & EXC_RETURN_DCRS_Msk) ? "" : "not ");
+    dprintf("  --> Exception from %s mode, handled in %s mode.\n", from_s ? "S" : "NS", to_s ? "S" : "NS");
+    dprintf("  --> R4-R11 %sstacked.\n", (lr & EXC_RETURN_DCRS_Msk) ? "" : "not ");
 #endif /* defined(ARCH_MPU_ARMv8M) */
-    dprintf("  --> FP stack frame %ssaved.\r\n", (lr & EXC_RETURN_FType_Msk) ? "not " : "");
-    dprintf("  --> Exception from %s mode.\r\n", from_np ? "NP" : "P");
-    dprintf("  --> Return to %cSP.\r\n", from_psp ? 'P' : 'M');
-    dprintf("\r\n");
+    dprintf("  --> FP stack frame %ssaved.\n", (lr & EXC_RETURN_FType_Msk) ? "not " : "");
+    dprintf("  --> Exception from %s mode.\n", from_np ? "NP" : "P");
+    dprintf("  --> Return to %cSP.\n", from_psp ? 'P' : 'M');
+    default_putc('\n');
 
     /* Debug the exception stack frame. */
 
@@ -103,7 +103,7 @@ static void debug_exception_stack_frame(uint32_t lr, uint32_t sp)
         "r0", "r1", "r2", "r3", "r12",
         "lr", "pc", "xPSR", "align"
     };
-    dprintf("  sp: 0x%08X\r\n", sp);
+    dprintf("  sp: 0x%08X\n", sp);
 
     /* The regular exception stack frame might be preceded by an additional one
      * on ARMv8-M. */
@@ -115,7 +115,7 @@ static void debug_exception_stack_frame(uint32_t lr, uint32_t sp)
 
     /* Print the alignment field, if required. */
     if (((uint32_t *) sp)[offset + CONTEXT_SWITCH_EXC_SF_WORDS - 1] & (1 << 9)) {
-        dprintf("      sp[%02d]: 0x%08X | %s\r\n",
+        dprintf("      sp[%02d]: 0x%08X | %s\n",
                 offset + CONTEXT_SWITCH_EXC_SF_WORDS,
                 ((uint32_t *) sp)[offset + CONTEXT_SWITCH_EXC_SF_WORDS],
                 exc_sf_verbose[CONTEXT_SWITCH_EXC_SF_WORDS]
@@ -125,7 +125,7 @@ static void debug_exception_stack_frame(uint32_t lr, uint32_t sp)
     /* Dump the regular exception stack frame. */
     int i = CONTEXT_SWITCH_EXC_SF_WORDS - 1;
     for (; i >= 0; --i) {
-        dprintf("      sp[%02d]: 0x%08X | %s\r\n",
+        dprintf("      sp[%02d]: 0x%08X | %s\n",
                 offset + i,
                 ((uint32_t *) sp)[offset + i],
                 exc_sf_verbose[i]
@@ -149,9 +149,9 @@ static void debug_exception_stack_frame(uint32_t lr, uint32_t sp)
     }
 #endif /* defined(ARCH_MPU_ARMv8M) */
 
-    dprintf("\r\n");
+    default_putc('\n');
 
-    dprintf("\r\n");
+    default_putc('\n');
 }
 
 /* Specific architectures/ports can provide additional debug handlers. */
@@ -163,37 +163,37 @@ UVISOR_WEAK void debug_fault_secure_hw(void) {}
 
 static void debug_fault_memmanage(void)
 {
-    dprintf("* FAULT SYNDROME REGISTERS\r\n");
-    dprintf("\r\n");
+    dprintf("* FAULT SYNDROME REGISTERS\n");
+    default_putc('\n');
 
     uint32_t mmfsr = SCB->CFSR;
-    dprintf("  CFSR: 0x%08X\r\n", mmfsr);
+    dprintf("  CFSR: 0x%08X\n", mmfsr);
     if (mmfsr & SCB_CFSR_MMARVALID_Msk) {
-        dprintf("  MMFAR: 0x%08X\r\n", SCB->MMFAR);
+        dprintf("  MMFAR: 0x%08X\n", SCB->MMFAR);
     } else {
-        dprintf("  --> MMFAR not valid.\r\n");
+        dprintf("  --> MMFAR not valid.\n");
     }
 #if defined(__FPU_PRESENT) && (__FPU_PRESENT == 1)
     if (mmfsr & SCB_CFSR_MLSPERR_Msk) {
-        dprintf("  --> MLSPERR: lazy FP state preservation.\r\n");
+        dprintf("  --> MLSPERR: lazy FP state preservation.\n");
     }
 #endif /* defined(__FPU_PRESENT) && __FPU_PRESENT == 1 */
     if (mmfsr & SCB_CFSR_MSTKERR_Msk) {
-        dprintf("  --> MSTKERR: exception entry.\r\n");
+        dprintf("  --> MSTKERR: exception entry.\n");
     }
     if (mmfsr & SCB_CFSR_MUNSTKERR_Msk) {
-        dprintf("  --> MUNSTKERR: exception exit.\r\n");
+        dprintf("  --> MUNSTKERR: exception exit.\n");
     }
     if (mmfsr & SCB_CFSR_DACCVIOL_Msk) {
-        dprintf("  --> DACCVIOL: data access violation.\r\n");
+        dprintf("  --> DACCVIOL: data access violation.\n");
     }
     if (mmfsr & SCB_CFSR_IACCVIOL_Msk) {
-        dprintf("  --> IACCVIOL: precise data access.\r\n");
+        dprintf("  --> IACCVIOL: precise data access.\n");
     }
     if (mmfsr & SCB_CFSR_IBUSERR_Msk) {
-        dprintf("  --> IBUSERR: MPU fault/XN default map violation at instruction fetch (instruction has been issued).\r\n");
+        dprintf("  --> IBUSERR: MPU fault/XN default map violation at instruction fetch (instruction has been issued).\n");
     }
-    dprintf("\r\n");
+    default_putc('\n');
 
     /* Call the MPU-specific debug handler. */
     debug_fault_memmanage_hw();
@@ -201,37 +201,37 @@ static void debug_fault_memmanage(void)
 
 static void debug_fault_bus(void)
 {
-    dprintf("* FAULT SYNDROME REGISTERS\r\n");
-    dprintf("\r\n");
+    dprintf("* FAULT SYNDROME REGISTERS\n");
+    default_putc('\n');
 
     uint32_t bfsr = SCB->CFSR;
-    dprintf("  CFSR: 0x%08X\r\n", bfsr);
+    dprintf("  CFSR: 0x%08X\n", bfsr);
     if (bfsr & SCB_CFSR_BFARVALID_Msk) {
-        dprintf("  BFAR: 0x%08X\r\n", SCB->BFAR);
+        dprintf("  BFAR: 0x%08X\n", SCB->BFAR);
     } else {
-        dprintf("  --> BFAR not valid.\r\n");
+        dprintf("  --> BFAR not valid.\n");
     }
 #if defined(__FPU_PRESENT) && (__FPU_PRESENT == 1)
     if (bfsr & SCB_CFSR_LSPERR_Msk) {
-        dprintf("  --> LSPERR: lazy FP state preservation.\r\n");
+        dprintf("  --> LSPERR: lazy FP state preservation.\n");
     }
 #endif /* defined(__FPU_PRESENT) && __FPU_PRESENT == 1 */
     if (bfsr & SCB_CFSR_STKERR_Msk) {
-        dprintf("  --> STKERR: exception entry.\r\n");
+        dprintf("  --> STKERR: exception entry.\n");
     }
     if (bfsr & SCB_CFSR_UNSTKERR_Msk) {
-        dprintf("  --> UNSTKERR: exception exit.\r\n");
+        dprintf("  --> UNSTKERR: exception exit.\n");
     }
     if (bfsr & SCB_CFSR_IMPRECISERR_Msk) {
-        dprintf("  --> IMPRECISERR: imprecise data access.\r\n");
+        dprintf("  --> IMPRECISERR: imprecise data access.\n");
     }
     if (bfsr & SCB_CFSR_PRECISERR_Msk) {
-        dprintf("  --> PRECISERR: precise data access.\r\n");
+        dprintf("  --> PRECISERR: precise data access.\n");
     }
     if (bfsr & SCB_CFSR_IBUSERR_Msk) {
-        dprintf("  --> IBUSERR: instruction prefetch (instruction has been issued).\r\n");
+        dprintf("  --> IBUSERR: instruction prefetch (instruction has been issued).\n");
     }
-    dprintf("\r\n");
+    default_putc('\n');
 
     /* Call the MPU-specific debug handler. */
     debug_fault_bus_hw();
@@ -239,74 +239,74 @@ static void debug_fault_bus(void)
 
 static void debug_fault_usage(void)
 {
-    dprintf("* FAULT SYNDROME REGISTERS\r\n");
-    dprintf("\r\n");
+    dprintf("* FAULT SYNDROME REGISTERS\n");
+    default_putc('\n');
 
     uint32_t ufsr = SCB->CFSR;
-    dprintf("  CFSR: 0x%08X\r\n", ufsr);
+    dprintf("  CFSR: 0x%08X\n", ufsr);
     if (ufsr & SCB_CFSR_DIVBYZERO_Msk) {
-        dprintf("  --> DIVBYZERO: divide by zero.\r\n");
+        dprintf("  --> DIVBYZERO: divide by zero.\n");
     }
     if (ufsr & SCB_CFSR_UNALIGNED_Msk) {
-        dprintf("  --> UNALIGNED: unaligned access.\r\n");
+        dprintf("  --> UNALIGNED: unaligned access.\n");
     }
 #if defined(ARCH_MPU_ARMv8M)
     if (ufsr & SCB_CFSR_STKOF_Msk) {
-        dprintf("  --> STKOF: stack overflow.\r\n");
+        dprintf("  --> STKOF: stack overflow.\n");
     }
 #endif /* defined(ARCH_MPU_ARMv8M) */
     if (ufsr & SCB_CFSR_NOCP_Msk) {
-        dprintf("  --> NOCP: coprocessor access (disabled/absent).\r\n");
+        dprintf("  --> NOCP: coprocessor access (disabled/absent).\n");
     }
     if (ufsr & SCB_CFSR_INVPC_Msk) {
-        dprintf("  --> INVPC: integrity checks on EXC_RETURN.\r\n");
+        dprintf("  --> INVPC: integrity checks on EXC_RETURN.\n");
     }
     if (ufsr & SCB_CFSR_INVSTATE_Msk) {
-        dprintf("  --> INVSTATE: instruction executed with invalid EPSR.T/.IT field.\r\n");
+        dprintf("  --> INVSTATE: instruction executed with invalid EPSR.T/.IT field.\n");
     }
     if (ufsr & SCB_CFSR_UNDEFINSTR_Msk) {
-        dprintf("  --> UNDEFINSTR: undefined instruction.\r\n");
+        dprintf("  --> UNDEFINSTR: undefined instruction.\n");
     }
-    dprintf("\r\n");
+    default_putc('\n');
 }
 
 #if defined(ARCH_MPU_ARMv8M)
 static void debug_fault_secure(void)
 {
-    dprintf("* FAULT SYNDROME REGISTERS\r\n");
-    dprintf("\r\n");
+    dprintf("* FAULT SYNDROME REGISTERS\n");
+    default_putc('\n');
 
     uint32_t sfsr = SAU->SFSR;
-    dprintf("  SFSR: 0x%08X\r\n", sfsr);
+    dprintf("  SFSR: 0x%08X\n", sfsr);
     if (sfsr & SAU_SFSR_SFARVALID_Msk) {
-        dprintf("  SFAR: 0x%08X\r\n", SAU->SFAR);
+        dprintf("  SFAR: 0x%08X\n", SAU->SFAR);
     } else {
-        dprintf("  --> SFAR not valid.\r\n");
+        dprintf("  --> SFAR not valid.\n");
     }
     if (sfsr & SAU_SFSR_LSERR_Msk) {
-        dprintf("  --> LSERR: lazy state preservation.\r\n");
+        dprintf("  --> LSERR: lazy state preservation.\n");
     }
 #if defined(__FPU_PRESENT) && (__FPU_PRESENT == 1)
     if (sfsr & SAU_SFSR_LSPERR_Msk) {
-        dprintf("  --> LSPERR: lazy FP state preservation.\r\n");
+        dprintf("  --> LSPERR: lazy FP state preservation.\n");
     }
 #endif /* defined(__FPU_PRESENT) && __FPU_PRESENT == 1 */
     if (sfsr & SAU_SFSR_INVTRAN_Msk) {
-        dprintf("  --> INVTRAN: invalid transition (branch not flagged for transition).\r\n");
+        dprintf("  --> INVTRAN: invalid transition (branch not flagged for transition).\n");
     }
     if (sfsr & SAU_SFSR_AUVIOL_Msk) {
-        dprintf("  --> AUVIOL: attribution unit violation.\r\n");
+        dprintf("  --> AUVIOL: attribution unit violation.\n");
     }
     if (sfsr & SAU_SFSR_INVER_Msk) {
-        dprintf("  --> INVER: invalid EXC_RETURN (S/NS state bit).\r\n");
+        dprintf("  --> INVER: invalid EXC_RETURN (S/NS state bit).\n");
     }
     if (sfsr & SAU_SFSR_INVIS_Msk) {
-        dprintf("  --> INVIS: invalid integrity signature in exception stack frame.\r\n");
+        dprintf("  --> INVIS: invalid integrity signature in exception stack frame.\n");
     }
     if (sfsr & SAU_SFSR_INVEP_Msk) {
-        dprintf("  --> INVEP: invalid entry point NS->S (no SG or no matching SAU/IDAU region found).\r\n");
+        dprintf("  --> INVEP: invalid entry point NS->S (no SG or no matching SAU/IDAU region found).\n");
     }
-    dprintf("\r\n");
+    default_putc('\n');
 
     /* Call the MPU-specific debug handler. */
     debug_fault_secure_hw();
@@ -315,63 +315,63 @@ static void debug_fault_secure(void)
 
 static void debug_fault_debug(void)
 {
-    dprintf("* FAULT SYNDROME REGISTERS\r\n");
-    dprintf("\r\n");
+    dprintf("* FAULT SYNDROME REGISTERS\n");
+    default_putc('\n');
 
-    dprintf("  DFSR  : 0x%08X\r\n\r\n", SCB->DFSR);
+    dprintf("  DFSR  : 0x%08X\n\n", SCB->DFSR);
 }
 
 static void debug_box_id(void) {
-    dprintf("* Active Box ID: %u\r\n", g_active_box);
+    dprintf("* Active Box ID: %u\n", g_active_box);
 }
 
 static void debug_fault_hard(void)
 {
-    dprintf("* FAULT SYNDROME REGISTERS\r\n");
-    dprintf("\r\n");
+    dprintf("* FAULT SYNDROME REGISTERS\n");
+    default_putc('\n');
 
     uint32_t hfsr = SCB->HFSR;
     bool forced = false;
-    dprintf("  HFSR: 0x%08X\r\n", hfsr);
+    dprintf("  HFSR: 0x%08X\n", hfsr);
     if (hfsr & SCB_HFSR_DEBUGEVT_Msk) {
-        dprintf("  --> DEBUGEVT: debug event occurred.\r\n");
+        dprintf("  --> DEBUGEVT: debug event occurred.\n");
     }
     if (hfsr & SCB_HFSR_FORCED_Msk) {
-        dprintf("  --> FORCED: another priority escalated to hard fault.\r\n");
+        dprintf("  --> FORCED: another priority escalated to hard fault.\n");
         forced = true;
     }
     if (hfsr & SCB_HFSR_VECTTBL_Msk) {
-        dprintf("  --> VECTTBL: vector table read fault on exception processing.\r\n");
+        dprintf("  --> VECTTBL: vector table read fault on exception processing.\n");
     }
 
     if (forced) {
         uint32_t shcsr = SCB->SHCSR;
         if (shcsr & SCB_SHCSR_USGFAULTPENDED_Msk) {
-            dprintf("  --> Escalated from Usage fault.\r\n");
-            dprintf("\r\n");
+            dprintf("  --> Escalated from Usage fault.\n");
+            default_putc('\n');
             debug_fault_usage();
             return;
         }
         if (shcsr & SCB_SHCSR_BUSFAULTPENDED_Msk) {
-            dprintf("  --> Escalated from Bus fault.\r\n");
-            dprintf("\r\n");
+            dprintf("  --> Escalated from Bus fault.\n");
+            default_putc('\n');
             debug_fault_bus();
             return;
         }
         if (shcsr & SCB_SHCSR_MEMFAULTPENDED_Msk) {
-            dprintf("  --> Escalated from MemManage fault.\r\n");
-            dprintf("\r\n");
+            dprintf("  --> Escalated from MemManage fault.\n");
+            default_putc('\n');
             debug_fault_memmanage();
             return;
         }
         if (shcsr & SCB_SHCSR_SVCALLPENDED_Msk) {
-            dprintf("  --> Escalated from SVCall.\r\n");
+            dprintf("  --> Escalated from SVCall.\n");
         }
         if (((SCB->ICSR & SCB_ICSR_VECTPENDING_Msk) >> SCB_ICSR_VECTPENDING_Pos) == (SysTick_IRQn + NVIC_OFFSET)) {
-            dprintf("  --> Escalated from SysTick IRQ.\r\n");
+            dprintf("  --> Escalated from SysTick IRQ.\n");
         }
     }
-    dprintf("\r\n");
+    default_putc('\n');
 }
 
 void debug_init(void)

--- a/core/debug/src/debug_box.c
+++ b/core/debug/src/debug_box.c
@@ -63,7 +63,7 @@ void debug_halt_error(THaltError reason, const THaltInfo *halt_info)
          *   1. reason
          *   2. halt info
          * Upon return from the debug handler, the system will die. */
-        debug_deprivilege_and_return(g_debug_box.driver->halt_error, debug_die, reason, (uint32_t)info, 0, 0);
+        debug_deprivilege_and_die(g_debug_box.driver->halt_error, debug_die, reason, (uint32_t)info, 0, 0);
     }
 }
 

--- a/core/debug/src/debug_box.c
+++ b/core/debug/src/debug_box.c
@@ -39,6 +39,55 @@ void debug_reboot(TResetReason reason)
 
 uint32_t g_debug_interrupt_sp[UVISOR_MAX_BOXES];
 
+void debug_print(const uint8_t * message_buffer, uint32_t size)
+{
+    /* Abort printing if debug box wasn't initialized yet. */
+    if (!g_debug_box.initialized) {
+        return;
+    }
+
+    /* Debug print relies on "deprivilege and return" flow that will currently
+     * only work if:
+     * - executed with exceptions enabled
+     * - executed from within the exception context, i.e. when IPSR isn't 0
+     * - the current exception priority is lower than of Hard Fault
+     * These limitation are dictated by the fact that SVC is used for
+     * deprivileging and in order for it to work SVC must be executed with
+     * exceptions enabled and its priority must be higher than of the current
+     * exception. SVC's priority is set to be higher than of any other
+     * exception with programmable priority but this still can't beat NMI and
+     * Hard Fault.
+     */
+
+    /* Make sure we're within an exception and exceptions are enabled. */
+    int exception = (int)(__get_IPSR() & 0x1FF);
+    if (!exception || __get_PRIMASK() || __get_FAULTMASK())    {
+        return;
+    }
+
+    /* Bring exception number to CMSIS format and check exception's priority. */
+    exception -= NVIC_OFFSET;
+    if (exception == NonMaskableInt_IRQn || exception == HardFault_IRQn) {
+        return;
+    }
+
+    /* Place the message on the interrupt stack allocating the size rounded up
+     * to the next value divisible by 8. This way the stack stays aligned on
+     * double-word boundary.
+     * The stack memory is managed by uVisor itself and is supposed to be
+     * accessible by debug box, so there's no need for the access check. */
+    uint32_t sp = g_debug_interrupt_sp[g_debug_box.box_id];
+    g_debug_interrupt_sp[g_debug_box.box_id] -= ((size + 7) / 8) * 8;
+    void *message = (void *)g_debug_interrupt_sp[g_debug_box.box_id];
+    memmove(message, message_buffer, size);
+
+    /* Call debug driver's print function. */
+    debug_deprivilege_and_return(g_debug_box.driver->debug_print, debug_return, (uint32_t)message, 0, 0, 0);
+
+    /* Pop the message off the stack. */
+    g_debug_interrupt_sp[g_debug_box.box_id] = sp;
+}
+
 void debug_halt_error(THaltError reason, const THaltInfo *halt_info)
 {
     static int debugged_once_before = 0;
@@ -49,7 +98,7 @@ void debug_halt_error(THaltError reason, const THaltInfo *halt_info)
     if (!g_debug_box.initialized || debugged_once_before) {
         while (1);
     } else {
-        /* Remember that debug_deprivilege_and_return() has been called once. */
+        /* Remember that debug_deprivilege_and_die() has been called once. */
         debugged_once_before = 1;
 
         /* Place the halt info on the interrupt stack. */
@@ -94,3 +143,25 @@ uint32_t debug_box_enter_from_priv(uint32_t lr) {
      * have been changed already. */
     return 0xFFFFFFFD;
 }
+
+/* Jump to unprivileged thread mode, the stack frame is already prepared on PSP. */
+void UVISOR_NAKED debug_uvisor_deprivilege(uint32_t svc_sp, uint32_t svc_pc)
+{
+    /* Return to thread mode with PSP using a basic stack frame. */
+    asm volatile(
+        "ldr lr, =0xfffffffd\n"
+        "bx lr\n"
+    );
+}
+
+/* Restore the execution right after the point of deprivilege, the needed stack frame
+ * was created on MSP by SVC used for deprivileging. */
+void UVISOR_NAKED debug_uvisor_return(uint32_t svc_sp, uint32_t svc_pc)
+{
+    /* Return to handler mode with MSP using a basic stack frame. */
+    asm volatile(
+        "ldr lr, =0xfffffff1\n"
+        "bx lr\n"
+    );
+}
+

--- a/core/system/src/context.c
+++ b/core/system/src/context.c
@@ -184,11 +184,11 @@ void context_switch_in(TContextSwitchType context_type, uint8_t dst_id, uint32_t
         if (context_type == CONTEXT_SWITCH_UNBOUND_FIRST) {
             src_id = dst_id;
         } else {
-            HALT_ERROR(SANITY_CHECK_FAILED, "Context switch: The source box ID is out of range (%u).\r\n", src_id);
+            HALT_ERROR(SANITY_CHECK_FAILED, "Context switch: The source box ID is out of range (%u).\n", src_id);
         }
     }
     if (!vmpu_is_box_id_valid(dst_id)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Context switch: The destination box ID is out of range (%u).\r\n", dst_id);
+        HALT_ERROR(SANITY_CHECK_FAILED, "Context switch: The destination box ID is out of range (%u).\n", dst_id);
     }
 
     /* The source/destination box IDs can be the same (for example, in IRQs). */

--- a/core/system/src/core_armv7m/svc.c
+++ b/core/system/src/core_armv7m/svc.c
@@ -34,7 +34,7 @@ UVISOR_EXTERN const uint32_t jump_table_priv_end;
 /* default function for not implemented handlers */
 void __svc_not_implemented(void)
 {
-    HALT_ERROR(NOT_IMPLEMENTED, "function not implemented\n\r");
+    HALT_ERROR(NOT_IMPLEMENTED, "function not implemented\n");
 }
 
 /* SVC handlers */

--- a/core/system/src/core_armv7m/svc.c
+++ b/core/system/src/core_armv7m/svc.c
@@ -135,7 +135,7 @@ void UVISOR_NAKED SVCall_IRQn_Handler(void)
         ".align 4\n"                                // the jump table must be aligned
     "jump_table_unpriv:\n"
         ".word  virq_gateway_out\n"
-        ".word  __svc_not_implemented\n" // Deprecated: secure_gateway_in
+        ".word  debug_uvisor_return\n"
         ".word  __svc_not_implemented\n" // Deprecated: secure_gateway_out
         ".word  register_gateway_perform_operation\n"
         ".word  box_init_first\n"
@@ -208,7 +208,7 @@ void UVISOR_NAKED SVCall_IRQn_Handler(void)
         ".align 4\n"                                // the jump table must be aligned
     "jump_table_priv:\n"
         ".word  virq_gateway_in\n"
-        ".word  __svc_not_implemented\n"
+        ".word  debug_uvisor_deprivilege\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"
         ".word  __svc_not_implemented\n"

--- a/core/system/src/core_armv8m/unused.c
+++ b/core/system/src/core_armv8m/unused.c
@@ -24,7 +24,7 @@ void unused_v8m_ignore(void)
 
 void unused_v8m_halt(void)
 {
-    HALT_ERROR(NOT_IMPLEMENTED, "You called a function that is not implemented for ARMv8-M targets.\r\n");
+    HALT_ERROR(NOT_IMPLEMENTED, "You called a function that is not implemented for ARMv8-M targets.\n");
 }
 
 void     UVISOR_ALIAS(unused_v8m_ignore) boxes_init(void);

--- a/core/system/src/core_armv8m/virq.c
+++ b/core/system/src/core_armv8m/virq.c
@@ -62,13 +62,13 @@ static void virq_check_acls(uint32_t irqn, uint8_t box_id)
 {
     /* IRQn goes from 0 to (NVIC_VECTORS - 1) */
     if (irqn >= NVIC_VECTORS) {
-        HALT_ERROR(NOT_ALLOWED, "Not allowed: IRQ %d is out of range\n\r", irqn);
+        HALT_ERROR(NOT_ALLOWED, "Not allowed: IRQ %d is out of range\n", irqn);
     }
 
     /* Note: IRQs ownership is determined on a first come first served basis. */
     if (g_virq_states[irqn].box_id != UVISOR_BOX_ID_INVALID &&
         g_virq_states[irqn].box_id != box_id) {
-        HALT_ERROR(PERMISSION_DENIED, "IRQ %d is owned by box %d.\r\n",
+        HALT_ERROR(PERMISSION_DENIED, "IRQ %d is owned by box %d.\n",
                    irqn, box_id);
     }
 }

--- a/core/system/src/ipc.c
+++ b/core/system/src/ipc.c
@@ -333,7 +333,7 @@ void ipc_drain_queue(void)
 #ifndef NDEBUG
         uvisor_ipc_desc_t * recv_desc = recv_io->desc;
 #endif
-        DPRINTF("Delivered [b%d:s%d].t0x%08x to [b%d:s%d].t0x%08x\r\n", send_box_id, send_slot, send_desc->token, recv_box_id, recv_slot, recv_desc->token);
+        DPRINTF("Delivered [b%d:s%d].t0x%08x to [b%d:s%d].t0x%08x\n", send_box_id, send_slot, send_desc->token, recv_box_id, recv_slot, recv_desc->token);
 
         /* Free the slots, as we have consumed the IOs. */
         send_slot = uvisor_pool_queue_try_free(send_queue, send_slot);

--- a/core/system/src/page_allocator.c
+++ b/core/system/src/page_allocator.c
@@ -138,7 +138,7 @@ void page_allocator_init(void * const heap_start, void * const heap_end, const u
     g_page_map_shift -= (g_page_head_end_rounded - (uint32_t) g_page_heap_end) / g_page_size;
 
     DPRINTF(
-        "page heap: [0x%08x, 0x%08x] %ukB -> %u %ukB pages\r\n",
+        "page heap: [0x%08x, 0x%08x] %ukB -> %u %ukB pages\n",
             (unsigned int) g_page_heap_start,
             (unsigned int) g_page_heap_end,
             (unsigned int) (g_page_count_free * g_page_size / 1024),

--- a/core/system/src/register_gateway.c
+++ b/core/system/src/register_gateway.c
@@ -44,13 +44,13 @@ static int register_gateway_check(TRegisterGateway const * const register_gatewa
      * that all of it is in public flash. */
     if (!vmpu_public_flash_addr((uint32_t) register_gateway) ||
         !vmpu_public_flash_addr((uint32_t) ((void *) register_gateway + sizeof(TRegisterGateway) - 1))) {
-        DPRINTF("Register gateway 0x%08X is not in public flash.\r\n", (uint32_t) register_gateway);
+        DPRINTF("Register gateway 0x%08X is not in public flash.\n", (uint32_t) register_gateway);
         return REGISTER_GATEWAY_STATUS_ERROR_FLASH;
     }
 
     /* Verify that the register gateway magic is present. */
     if (register_gateway->magic != UVISOR_REGISTER_GATEWAY_MAGIC) {
-        DPRINTF("Register gateway 0x%08X does not contain a valid magic (0x%08X).\r\n",
+        DPRINTF("Register gateway 0x%08X does not contain a valid magic (0x%08X).\n",
                 (uint32_t) register_gateway, register_gateway->magic);
         return REGISTER_GATEWAY_STATUS_ERROR_MAGIC;
     }
@@ -61,7 +61,7 @@ static int register_gateway_check(TRegisterGateway const * const register_gatewa
      * pointer region. The subsequent substraction that we do to calculate the
      * box ID is then guaranteed to be sane. */
     if (register_gateway->box_ptr < (uint32_t) __uvisor_config.cfgtbl_ptr_start) {
-        DPRINTF("The pointer (0x%08X) in the register gateway 0x%08X is not a valid box configuration pointer.\r\n",
+        DPRINTF("The pointer (0x%08X) in the register gateway 0x%08X is not a valid box configuration pointer.\n",
                 register_gateway->box_ptr, (uint32_t) register_gateway);
         return REGISTER_GATEWAY_STATUS_ERROR_BOX_PTR;
     }
@@ -71,7 +71,7 @@ static int register_gateway_check(TRegisterGateway const * const register_gatewa
      * shared. */
     uint8_t box_id = (uint8_t) ((uint32_t *) register_gateway->box_ptr - __uvisor_config.cfgtbl_ptr_start);
     if (!(register_gateway->operation & __UVISOR_RGW_OP_SHARED_MASK) && (box_id != g_active_box)) {
-        DPRINTF("Register gateway is owned by box %d, while the active box is %d.\r\n", box_id, g_active_box);
+        DPRINTF("Register gateway is owned by box %d, while the active box is %d.\n", box_id, g_active_box);
         return REGISTER_GATEWAY_STATUS_ERROR_BOX_ID;
     }
 
@@ -82,7 +82,7 @@ static int register_gateway_check(TRegisterGateway const * const register_gatewa
     if (((address & VMPU_PERIPH_FULL_MASK) != VMPU_PERIPH_START) &&
         ((address & VMPU_ROMTABLE_MASK) != VMPU_ROMTABLE_START)) {
         DPRINTF("Register gateways can only target the peripheral or ROM Table memory regions. "
-                "Address 0x%08X not allowed.\r\n", address);
+                "Address 0x%08X not allowed.\n", address);
         return REGISTER_GATEWAY_STATUS_ERROR_ADDRESS;
     }
 

--- a/core/vmpu/src/mpu_armv7m/vmpu_armv7m.c
+++ b/core/vmpu/src/mpu_armv7m/vmpu_armv7m.c
@@ -273,7 +273,7 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
     uint32_t dst_count;
     const MpuRegion * region;
 
-    /* DPRINTF("switching from %i to %i\n\r", src_box, dst_box); */
+    /* DPRINTF("switching from %i to %i\n", src_box, dst_box); */
 
     vmpu_mpu_invalidate();
 
@@ -358,10 +358,10 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
 
     /* Final sanity checks */
     if ((slots_for_bss * subregion_size) < bss_size) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "slots_ctx underrun\n\r");
+        HALT_ERROR(SANITY_CHECK_FAILED, "slots_ctx underrun\n");
     }
     if ((slots_for_stack * subregion_size) < stack_size) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "slots_stack underrun\n\r");
+        HALT_ERROR(SANITY_CHECK_FAILED, "slots_stack underrun\n");
     }
 
     /* Set the pointers to the BSS sections and to the stack. */
@@ -379,22 +379,22 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
         UVISOR_TACLDEF_STACK,
         slots_for_bss ? 1UL << slots_for_bss : 0
     );
-    DPRINTF("  - SRAM:       0x%08X - 0x%08X (permissions: 0x%04X, subregions: 0x%02X)\r\n",
+    DPRINTF("  - SRAM:       0x%08X - 0x%08X (permissions: 0x%04X, subregions: 0x%02X)\n",
             box_mem_pos, box_mem_pos + region_size, UVISOR_TACLDEF_STACK, slots_for_bss ? 1UL << slots_for_bss : 0);
 
     /* Move on to the next memory block. */
     box_mem_pos += region_size;
 
-    DPRINTF("    - BSS:      0x%08X - 0x%08X (original size: %uB, rounded size: %uB)\r\n",
+    DPRINTF("    - BSS:      0x%08X - 0x%08X (original size: %uB, rounded size: %uB)\n",
             *bss_start, *bss_start + bss_size, bss_size, slots_for_bss * subregion_size);
-    DPRINTF("    - Stack:    0x%08X - 0x%08X (original size: %uB, rounded size: %uB)\r\n",
+    DPRINTF("    - Stack:    0x%08X - 0x%08X (original size: %uB, rounded size: %uB)\n",
             *bss_start + (slots_for_bss + 1) * subregion_size, box_mem_pos, stack_size, slots_for_stack * subregion_size);
 }
 
 void vmpu_arch_init(void)
 {
     /* Init protected box memory enumeration pointer. */
-    DPRINTF("\n\rbox stack segment start=0x%08X end=0x%08X (length=%i)\n\r",
+    DPRINTF("\nbox stack segment start=0x%08X end=0x%08X (length=%i)\n",
         __uvisor_config.bss_boxes_start, __uvisor_config.bss_boxes_end,
         ((uint32_t) __uvisor_config.bss_boxes_end) - ((uint32_t) __uvisor_config.bss_boxes_start));
 
@@ -584,10 +584,10 @@ void vmpu_order_boxes(int * const best_order, int box_count)
      * at link time. */
     uint32_t available_sram_size = (uint32_t) __uvisor_config.bss_boxes_end - (uint32_t) __uvisor_config.bss_boxes_start;
     if (available_sram_size < total_sram_size) {
-        DPRINTF("Not enough memory allocated for the secure boxes. This is a known limitation of the ARMv7-M MPU.\r\n");
-        DPRINTF("Please insert the following snippet in your public box file (usually main.cpp):\r\n");
-        DPRINTF("uint8_t __attribute__((section(\".keep.uvisor.bss.boxes\"), aligned(32))) __boxes_overhead[%d];\r\n",
+        DPRINTF("Not enough memory allocated for the secure boxes. This is a known limitation of the ARMv7-M MPU.\n");
+        DPRINTF("Please insert the following snippet in your public box file (usually main.cpp):\n");
+        DPRINTF("uint8_t __attribute__((section(\".keep.uvisor.bss.boxes\"), aligned(32))) __boxes_overhead[%d];\n",
                 total_sram_size - available_sram_size);
-        HALT_ERROR(SANITY_CHECK_FAILED, "Secure boxes memory overflow. See message above to fix it.\r\n");
+        HALT_ERROR(SANITY_CHECK_FAILED, "Secure boxes memory overflow. See message above to fix it.\n");
     }
 }

--- a/core/vmpu/src/mpu_armv7m/vmpu_armv7m_mpu.c
+++ b/core/vmpu/src/mpu_armv7m/vmpu_armv7m_mpu.c
@@ -299,7 +299,7 @@ uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t siz
 bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, uint32_t * const count)
 {
     if (!g_mpu_region_count) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions.\r\n");
+        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions.\n");
     }
 
     if (box_id < UVISOR_MAX_BOXES) {
@@ -438,16 +438,16 @@ void vmpu_mpu_init(void)
     SCB->SHCSR |= 0x70000;
 
     /* show basic mpu settings */
-    DPRINTF("MPU.REGIONS=%i\r\n", (uint8_t)(MPU->TYPE >> MPU_TYPE_DREGION_Pos));
-    DPRINTF("MPU.ALIGNMENT=0x%08X\r\n", aligment_mask);
-    DPRINTF("MPU.ALIGNMENT_BITS=%i\r\n", vmpu_bits(aligment_mask));
+    DPRINTF("MPU.REGIONS=%i\n", (uint8_t)(MPU->TYPE >> MPU_TYPE_DREGION_Pos));
+    DPRINTF("MPU.ALIGNMENT=0x%08X\n", aligment_mask);
+    DPRINTF("MPU.ALIGNMENT_BITS=%i\n", vmpu_bits(aligment_mask));
 
     /* Perform sanity checks. */
     if (ARMv7M_MPU_REGIONS != ((MPU->TYPE >> MPU_TYPE_DREGION_Pos) & 0xFF)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_REGIONS is inconsistent with actual region count.\n\r");
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_REGIONS is inconsistent with actual region count.\n");
     }
     if (ARMv7M_MPU_ALIGNMENT_BITS != vmpu_bits(aligment_mask)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_ALIGNMENT_BITS are inconsistent with actual MPU alignment\n\r");
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv7M_MPU_ALIGNMENT_BITS are inconsistent with actual MPU alignment\n");
     }
 }
 

--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m.c
@@ -199,7 +199,7 @@ void vmpu_switch(uint8_t src_box, uint8_t dst_box)
     uint32_t dst_count = 0;
     const MpuRegion * region;
 
-    /* DPRINTF("switching from %i to %i\n\r", src_box, dst_box); */
+    /* DPRINTF("switching from %i to %i\n", src_box, dst_box); */
 
     vmpu_mpu_invalidate();
 

--- a/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
+++ b/core/vmpu/src/mpu_armv8m/vmpu_armv8m_mpu.c
@@ -188,7 +188,7 @@ bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, u
     if (!g_mpu_region_count) {
         *count = 0;
         return false;
-        // HALT_ERROR(SANITY_CHECK_FAILED, "No available SAU regions.\r\n");
+        // HALT_ERROR(SANITY_CHECK_FAILED, "No available SAU regions.\n");
     }
 
     if (box_id < UVISOR_MAX_BOXES) {
@@ -305,7 +305,7 @@ void vmpu_mpu_init(void)
     SAU->CTRL = 0;
 
     if (ARMv8M_SAU_REGIONS != ((SAU->TYPE >> SAU_TYPE_SREGION_Pos) & 0xFF)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv8M_SAU_REGIONS is inconsistent with actual region count.\n\r");
+        HALT_ERROR(SANITY_CHECK_FAILED, "ARMv8M_SAU_REGIONS is inconsistent with actual region count.\n");
     }
 }
 

--- a/core/vmpu/src/mpu_kinetis/vmpu_kinetis.c
+++ b/core/vmpu/src/mpu_kinetis/vmpu_kinetis.c
@@ -148,7 +148,7 @@ uint32_t vmpu_sys_mux_handler(uint32_t lr, uint32_t msp)
                     return lr;
                 }
             } else if (slave_port == VMPU_FAULT_MULTIPLE) {
-                DPRINTF("Multiple MPU violations found.\r\n");
+                DPRINTF("Multiple MPU violations found.\n");
             }
 
             /* Check if the fault is the special register corner case. uVisor
@@ -220,7 +220,7 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
         UVISOR_TACLDEF_STACK,
         0
     );
-    DPRINTF("  - Stack:      0x%08X - 0x%08X (permissions: 0x%04X)\r\n",
+    DPRINTF("  - Stack:      0x%08X - 0x%08X (permissions: 0x%04X)\n",
             g_box_mem_pos, g_box_mem_pos + stack_size, UVISOR_TACLDEF_STACK);
 
     /* Set stack pointer to box stack size minus guard band. */
@@ -242,7 +242,7 @@ void vmpu_acl_sram(uint8_t box_id, uint32_t bss_size, uint32_t stack_size, uint3
         UVISOR_TACLDEF_DATA,
         0
     );
-    DPRINTF("  - BSS:        0x%08X - 0x%08X (permissions: 0x%04X)\r\n",
+    DPRINTF("  - BSS:        0x%08X - 0x%08X (permissions: 0x%04X)\n",
             g_box_mem_pos, g_box_mem_pos + bss_size, UVISOR_TACLDEF_DATA);
 
     g_box_mem_pos += bss_size + UVISOR_STACK_BAND_SIZE;

--- a/core/vmpu/src/mpu_kinetis/vmpu_kinetis_mpu.c
+++ b/core/vmpu/src/mpu_kinetis/vmpu_kinetis_mpu.c
@@ -244,7 +244,7 @@ uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t siz
 
     /* check for maximum box ID */
     if (!vmpu_is_box_id_valid(box_id)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box ID is out of range (%u).\r\n", box_id);
+        HALT_ERROR(SANITY_CHECK_FAILED, "ACL add: The box ID is out of range (%u).\n", box_id);
     }
 
     /* check for alignment to 32 bytes */
@@ -276,7 +276,7 @@ uint32_t vmpu_region_add_static_acl(uint8_t box_id, uint32_t start, uint32_t siz
 bool vmpu_region_get_for_box(uint8_t box_id, const MpuRegion * * const region, uint32_t * const count)
 {
     if (!g_mpu_region_count) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions.\r\n");
+        HALT_ERROR(SANITY_CHECK_FAILED, "No available MPU regions.\n");
     }
 
     if (box_id < UVISOR_MAX_BOXES) {

--- a/core/vmpu/src/vmpu.c
+++ b/core/vmpu/src/vmpu.c
@@ -57,7 +57,7 @@ static int vmpu_check_sanity(void)
     /* Verify that the core version is the same as expected. */
     if (!CORE_VERSION_CHECK() || !CORE_REVISION_CHECK()) {
         HALT_ERROR(SANITY_CHECK_FAILED, "This core is unsupported or there is a mismatch between the uVisor "
-                                        "configuration you are using and the core this configuration supports.\n\r");
+                                        "configuration you are using and the core this configuration supports.\n");
     }
 
     /* Verify that the known hard-coded symbols are equal to the ones taken from
@@ -161,13 +161,13 @@ static int vmpu_check_sanity(void)
     uint32_t const heap_end = (uint32_t) __uvisor_config.heap_end;
     uint32_t const heap_start = (uint32_t) __uvisor_config.heap_start;
     if (!heap_start || !vmpu_public_sram_addr(heap_start)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Heap start pointer (0x%08x) is not in SRAM memory.\r\n", heap_start);
+        HALT_ERROR(SANITY_CHECK_FAILED, "Heap start pointer (0x%08x) is not in SRAM memory.\n", heap_start);
     }
     if (!heap_end || !vmpu_public_sram_addr(heap_end)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is not in SRAM memory.\r\n", heap_end);
+        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is not in SRAM memory.\n", heap_end);
     }
     if (heap_end < heap_start) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is smaller than heap start pointer (0x%08x).\r\n",
+        HALT_ERROR(SANITY_CHECK_FAILED, "Heap end pointer (0x%08x) is smaller than heap start pointer (0x%08x).\n",
                    heap_end, heap_start);
     }
 
@@ -223,31 +223,31 @@ static void vmpu_check_sanity_box_cfgtbl(uint8_t box_id, UvisorBoxConfig const *
     /* Ensure that the configuration table resides in flash. */
     if (!(vmpu_flash_addr((uint32_t) box_cfgtbl) &&
         vmpu_flash_addr((uint32_t) ((uint8_t *) box_cfgtbl + (sizeof(*box_cfgtbl) - 1))))) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: The box configuration table is not in flash.\r\n",
+        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: The box configuration table is not in flash.\n",
                    box_id, (uint32_t) box_cfgtbl);
     }
 
     /* Check the magic value in the box configuration table. */
     if (box_cfgtbl->magic != UVISOR_BOX_MAGIC) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Invalid magic number (found: 0x%08X, exepcted 0x%08X).\r\n",
+        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Invalid magic number (found: 0x%08X, exepcted 0x%08X).\n",
                    box_id, (uint32_t) box_cfgtbl, box_cfgtbl->magic, UVISOR_BOX_MAGIC);
     }
 
     /* Check the box configuration table version. */
     if (box_cfgtbl->version != UVISOR_BOX_VERSION) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Invalid version number (found: 0x%04X, expected: 0x%04X).\r\n",
+        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Invalid version number (found: 0x%04X, expected: 0x%04X).\n",
                    box_id, (uint32_t) box_cfgtbl, box_cfgtbl->version, UVISOR_BOX_VERSION);
     }
 
     /* Check the minimal size of the box index size. */
     if (box_cfgtbl->bss.size_of.index < sizeof(UvisorBoxIndex)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Index size (%uB) < sizeof(UvisorBoxIndex) (%uB).\r\n",
+        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Index size (%uB) < sizeof(UvisorBoxIndex) (%uB).\n",
                    box_id, (uint32_t) box_cfgtbl, box_cfgtbl->bss.size_of.index, sizeof(UvisorBoxIndex));
     }
 
     /* Check the minimal size of the box stack. */
     if (box_id != 0 && (box_cfgtbl->stack_size < UVISOR_MIN_STACK_SIZE)) {
-        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Stack size (%uB) < UVISOR_MIN_STACK_SIZE (%uB).\r\n",
+        HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Stack size (%uB) < UVISOR_MIN_STACK_SIZE (%uB).\n",
                    box_id, (uint32_t) box_cfgtbl, box_cfgtbl->stack_size, UVISOR_MIN_STACK_SIZE);
     }
 
@@ -260,11 +260,11 @@ static void vmpu_check_sanity_box_cfgtbl(uint8_t box_id, UvisorBoxConfig const *
          *        to zero and then determine them at runtime (see code in box
          *        index initialization). We should remove this dependency. */
         if (box_cfgtbl->stack_size != 0) {
-            HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: The public box stack size must be set to 0 (found %uB).\r\n",
+            HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: The public box stack size must be set to 0 (found %uB).\n",
                        box_id, (uint32_t) box_cfgtbl, box_cfgtbl->stack_size);
         }
         if (box_cfgtbl->bss.size_of.heap != 0) {
-            HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: The public box heap size must be set to 0 (found %uB).\r\n",
+            HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: The public box heap size must be set to 0 (found %uB).\n",
                        box_id, (uint32_t) box_cfgtbl, box_cfgtbl->bss.size_of.heap);
         }
     }
@@ -336,7 +336,7 @@ static void vmpu_configure_box_peripherals(uint8_t box_id, UvisorBoxConfig const
         for (int i = 0; i < count; i++) {
             /* Ensure that the ACL resides in public flash. */
             if (!vmpu_public_flash_addr((uint32_t) region)) {
-                HALT_ERROR(SANITY_CHECK_FAILED, "box[%i]:acl[%i] must be in code section (@0x%08X)i\r\n",
+                HALT_ERROR(SANITY_CHECK_FAILED, "box[%i]:acl[%i] must be in code section (@0x%08X)i\n",
                            box_id, i, box_cfgtbl);
             }
 
@@ -351,7 +351,7 @@ static void vmpu_configure_box_peripherals(uint8_t box_id, UvisorBoxConfig const
                     region->acl | UVISOR_TACL_USER,
                     0
                 );
-                DPRINTF("  - Peripheral: 0x%08X - 0x%08X (permissions: 0x%04X)\r\n",
+                DPRINTF("  - Peripheral: 0x%08X - 0x%08X (permissions: 0x%04X)\n",
                         (uint32_t) region->param1, (uint32_t) region->param1 + region->param2,
                         region->acl | UVISOR_TACL_USER);
             }
@@ -435,11 +435,11 @@ static void vmpu_enumerate_boxes(void)
 
             /* Before g_debug_box initialization, verify magic and version of the debug box. */
             if (debug_driver->magic != UVISOR_DEBUG_BOX_MAGIC) {
-                HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Wrong debug box magic.\r\n",
+                HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Wrong debug box magic.\n",
                         box_id, (uint32_t) box_cfgtbl);
             }
             if (debug_driver->version != UVISOR_DEBUG_BOX_VERSION) {
-                HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Wrong debug box version.\r\n",
+                HALT_ERROR(SANITY_CHECK_FAILED, "Box %i @0x%08X: Wrong debug box version.\n",
                         box_id, (uint32_t) box_cfgtbl);
             }
 
@@ -454,7 +454,7 @@ static void vmpu_enumerate_boxes(void)
         /* Note: This function halts if a sanity check fails. */
         vmpu_check_sanity_box_cfgtbl(index, box_cfgtbl);
 
-        DPRINTF("Box %i ACLs:\r\n", index);
+        DPRINTF("Box %i ACLs:\n", index);
 
         /* Add the box ACL for the static SRAM memories. */
         vmpu_configure_box_sram(index, box_cfgtbl);
@@ -551,7 +551,7 @@ int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr, uint3
                         break;
                 }
                 if (found) {
-                    /* DPRINTF("Executed privileged access: 0x%08X written to 0x%08X\n\r", r1, r0); */
+                    /* DPRINTF("Executed privileged access: 0x%08X written to 0x%08X\n", r1, r0); */
                 }
                 break;
 
@@ -583,7 +583,7 @@ int vmpu_fault_recovery_bus(uint32_t pc, uint32_t sp, uint32_t fault_addr, uint3
                 if (found) {
                     /* The result is stored back to the stack (r0). */
                     vmpu_unpriv_uint32_write(sp, r1);
-                    /* DPRINTF("Executed privileged access: read 0x%08X from 0x%08X\n\r", r1, r0); */
+                    /* DPRINTF("Executed privileged access: read 0x%08X from 0x%08X\n", r1, r0); */
                 }
                 break;
 
@@ -647,7 +647,7 @@ static int copy_box_namespace(const char *src, char *dst)
      * in vmpu_box_namespace_from_id as being in the box config table. It is a
      * programmer error if the namespace in the box config table is not
      * null-terminated, so we halt. */
-    HALT_ERROR(SANITY_CHECK_FAILED, "vmpu: Box namespace missing terminating-null\r\n");
+    HALT_ERROR(SANITY_CHECK_FAILED, "vmpu: Box namespace missing terminating-null\n");
 
 done:
     return bytes_copied;

--- a/tools/uvisor-tests.txt
+++ b/tools/uvisor-tests.txt
@@ -1,1 +1,1 @@
-f8890583ac72f83ac3f9b2ad80ad230fbc5257ef
+origin-pull/pull/150/merge


### PR DESCRIPTION
Major changes:
- Rename old debug_deprivilege_and_return() to debug_deprivilege_and_die()
  which better reflects its nature
- Add a new debug_deprivilege_and_return() which indeed
  performs deprivilege and return within the function itself
- Add a new API function uvisor_debug_print_enable() which should
  be used from the user's application to enable
  deprivilege/print/reprivilege flow
- Make SVC's priority higher than of the other exceptions with programmable priority
- Normalize line endings used in printing in a few places to "\r\n" (still need to fix in some other places)

Note:
  Ideally it would be better to break this commit into a few smaller ones

Usage example in the user's application:
...
static void halt_error(THaltError reason, const THaltInfo * halt_info)
{
...
}

static void debug_print(const char * message)
{
	printf("%s", message);
}

UVISOR_PUBLIC_BOX_DEBUG_DRIVER(halt_error, debug_print);

#define BAD_BAD_ADDR (*((volatile unsigned long *) (0xFFFFFFFF)))

int main(void)
{
	uvisor_debug_print_enable(true);
 
   	/* About to get a fault now: */
        BAD_BAD_ADDR = 13;
}