### PR TITLE
	ipc: Return success immediately if waiting on empty token

### DIFF
--- a/api/src/ipc.c
+++ b/api/src/ipc.c
@@ -144,7 +144,7 @@ static int ipc_waitfor(int (*cond)(uint32_t have, uint32_t expect), uint32_t wai
 /* We have at least one of what we expect. */
 static int any(uint32_t have, uint32_t expect)
 {
-    return have & expect;
+    return (expect == 0) || have & expect;
 }
 
 /* We have at least all of what we expect (and maybe more). */


### PR DESCRIPTION
Waiting on an empty token will bypass the allocated check because
bitwise and won't fail. It will then cause an infinite loop because the
condition will never fulfil.

Instead, waiting on nothing should return success immediately

Fixes 60048c4d3740350bd3254351a00dad0f367a580d