### PR TITLE
Coverity work

### DIFF
--- a/api/inc/uvisor_exports.h
+++ b/api/inc/uvisor_exports.h
@@ -133,6 +133,12 @@
 #define UVISOR_MACRO_REGS_RETVAL(type, name) \
     register type name asm("r0");
 
+UVISOR_FORCEINLINE void uvisor_noreturn(void)
+{
+    volatile int var = 1;
+    while(var);
+}
+
 /* declare callee-saved input/output operands for gcc-style inline asm */
 /* note: this macro requires that a C variable having the same name of the
  *       corresponding callee-saved register is declared; these operands follow

--- a/api/src/disabled.c
+++ b/api/src/disabled.c
@@ -80,7 +80,7 @@ TUserIrq g_uvisor_disabled_vectors[NVIC_VECTORS];
 
 static void __not_implemented(void)
 {
-    while(1);
+    uvisor_noreturn();
 }
 
 static void uvisor_disabled_init_context(void)

--- a/api/src/uvisor-lib.c
+++ b/api/src/uvisor-lib.c
@@ -37,7 +37,7 @@ static void uvisor_sanity_check_api_load(void)
          * uVisor API working. */
 
         /* We can't call uvisor_error either, because the API is messed up. */
-        for (;;);
+        uvisor_noreturn();
     }
 }
 
@@ -47,7 +47,7 @@ static void uvisor_sanity_check_api_version()
     if (uvisor_api.get_version(UVISOR_API_VERSION) != UVISOR_API_VERSION) {
         /* We can't call any uVisor APIs other than get_version (which is a
          * backwards and forwards compatible API), so we must halt. */
-        for (;;);
+        uvisor_noreturn();
     }
 }
 

--- a/core/debug/src/core_armv8m/debug_box_armv8m.c
+++ b/core/debug/src/core_armv8m/debug_box_armv8m.c
@@ -22,7 +22,7 @@
 
 void debug_die(void)
 {
-    while (1);
+    uvisor_noreturn();
 }
 
 /* Note: On ARMv8-M the return_handler is executed in S mode. */

--- a/core/debug/src/debug_box.c
+++ b/core/debug/src/debug_box.c
@@ -47,7 +47,7 @@ void debug_halt_error(THaltError reason, const THaltInfo *halt_info)
     /* If the debug box does not exist (or it has not been initialized yet), or
      * the debug box was already called once, just loop forever. */
     if (!g_debug_box.initialized || debugged_once_before) {
-        while (1);
+        uvisor_noreturn();
     } else {
         /* Remember that debug_deprivilege_and_return() has been called once. */
         debugged_once_before = 1;

--- a/core/system/src/halt.c
+++ b/core/system/src/halt.c
@@ -77,5 +77,5 @@ void halt_line(const char *file, uint32_t line, THaltError reason,
 void halt_user_error(THaltUserError reason)
 {
     /* Die. */
-    while(1);
+    uvisor_noreturn();
 }

--- a/core/uvisor.h
+++ b/core/uvisor.h
@@ -57,8 +57,11 @@ typedef void (*UnprivilegedBoxEntry)(void);
 #define assert(...)
 #else /*NDEBUG*/
 #define DPRINTF dprintf
-#define assert(x) if(!(x)){dprintf("HALTED(%s:%i): assert(%s)\n",\
-                                   __FILE__, __LINE__, #x);while(1);}
+#define assert(x) \
+    if (!(x)) { \
+        dprintf("HALTED(%s:%i): assert(%s)\n", __FILE__, __LINE__, #x); \
+        uvisor_noreturn(); \
+    }
 #endif/*NDEBUG*/
 
 #ifdef  CHANNEL_DEBUG

--- a/tools/coverity/models.c
+++ b/tools/coverity/models.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void uvisor_noreturn(void) {
+    return __coverity_panic__();
+}


### PR DESCRIPTION
* Merge all of the infinite loops like `while (1)` to one function `uvisor_noreturn()`.
* Add a killpath model for the `uvisor_noreturn()` - Coverity will stop analyzing after this function.
  * This significantly reduces number of false positives in the analysis.

@Patater @alzix @danny4478 @orenc17A 